### PR TITLE
feat(gates,deliver): judge seat, restored-tree denial, lift outcome and run base from the #431 wire (api-types 0.33.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,12 @@ npm publish dates. Every version listed here exists on
   - *Denial card — the restored tree* (`evaluatorMutatedWorktree.restored` + `worktreeRestored`):
     a worktree-guard denial the engine already remedied says "the evaluator's edit was discarded and
     the creator's verified tree restored", lists the discarded paths from the restore record, and
-    gives `git show refs/wicked/suggestions/<run>/<ord>/<attempt>` as copyable code when the edit was
-    pinned (an honest "not pinned" otherwise). **Approve is relabelled "Retry against the restored
-    tree"** (and "Retry + steer") on exactly that gate — keyed on the evidence frames, not on the
-    prompt, which the engine also changed ("confirm to retry the phase" → "Approve to retry the phase
+    gives `git show refs/wicked/suggestions/<run>/<ord>/<attempt>` as copyable code — with a real,
+    keyboard-reachable **copy** button beside it — when the edit was pinned (an honest "not pinned"
+    otherwise). **Approve is relabelled "Retry against the restored tree"** (and "Retry + steer") on
+    exactly that gate, on the run page's gate card AND the landing inbox's card, from one predicate
+    that mirrors the engine's own guard (`denial.source === 'worktree_guard'` and `restored`) — keyed
+    on the evidence frames, not on the prompt, which the engine also changed ("confirm to retry the phase" → "Approve to retry the phase
     against the restored tree"; the card's NOT PASS match holds for both spellings). A failed
     restore (`restored: false`) is said, with the engine's error, and the manual remedy stands.
   - *Delivery card / deliver gate — the lift* (`deliverLiftEvaluated`, the deliver ord's
@@ -34,7 +36,12 @@ npm publish dates. Every version listed here exists on
     (base and tree before → after, the re-verify per check with the forced-install source
     `package-lock.json (forced: lockfile drift)`) / `conflict` (the files, "nothing was rebased and
     nothing was pushed", the LIFT-CONFLICT remedy) / `skipped` / `failed` — and the engine's
-    refusal verbatim, once. A deliver unit refused BEFORE the lift (a `HEAD` off the run branch)
+    refusal as the wire carries it (`stepFailed.detail` is a head+tail excerpt; the elision marker
+    renders dimmed between the kept words), once: the gate card omits its copy when the engine's
+    triage-escalate prompt already quotes it, the rail when the rejected unit's framed
+    `denial_reason` does. A red check exposes its recorded `stderr` / `stdout` tail (`RepoCheckRun`,
+    declared since 0.31.0) as a collapsed, monospace, phone-width-wrapping block — on the deliver
+    lift and on the gate card's floor. A deliver unit refused BEFORE the lift (a `HEAD` off the run branch)
     has no lift frame and renders its `deliver:` text on its own; a `passed: false` re-verify over
     all-green rows is explained as the checks having CHANGED the worktree.
   - *Run head / timeline — the base* (`runBaseResolved`): a `base` row on the run's context card and
@@ -47,8 +54,10 @@ npm publish dates. Every version listed here exists on
   - Tests: unit suites over synthetic frames in the wire's exact spelling (`tests/fixtures/wire433.ts`,
     mirroring wicked-crew's wire-contract literals) for each surface — every frame declared `satisfies`
     its 0.33.0 named type, and `tests/wire433.shapes.test.ts` re-derives the key-set and union diff
-    against the installed `index.d.ts` at run time; the loopback rig `e2e/wire433_test.py` (fixture
-    switch `wire433`) drives the three surfaces in a real browser.
+    against the installed `index.d.ts` at run time; the deliver fixtures carry what the WIRE carries
+    (`stepFailed.detail` as the engine's 150/250 head+tail excerpt, the triage-escalate prompt quoting
+    the 450/750 excerpt, `denial_reason` framed as `Worker FAILED on unit N …`); the loopback rig
+    `e2e/wire433_test.py` (fixture switch `wire433`) drives the three surfaces in a real browser.
 
 
 ## [0.5.5] — 2026-09-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,10 @@ npm publish dates. Every version listed here exists on
     (`acpFallback.fallbackKind: 'read_only_requires_wrapped'` — routing, not a failure); every other
     `acpFallback` kind stays silent as before.
   - Tests: unit suites over synthetic frames in the wire's exact spelling (`tests/fixtures/wire433.ts`,
-    mirroring wicked-crew's wire-contract literals) for each surface; the loopback rig
-    `e2e/wire433_test.py` (fixture switch `wire433`) drives the three surfaces in a real browser.
+    mirroring wicked-crew's wire-contract literals) for each surface — every frame declared `satisfies`
+    its 0.33.0 named type, and `tests/wire433.shapes.test.ts` re-derives the key-set and union diff
+    against the installed `index.d.ts` at run time; the loopback rig `e2e/wire433_test.py` (fixture
+    switch `wire433`) drives the three surfaces in a real browser.
 
 
 ## [0.5.5] — 2026-09-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,43 @@ npm publish dates. Every version listed here exists on
 [npm](https://www.npmjs.com/package/wicked-studio?activeTab=versions).
 
 ## [Unreleased]
+### Added
+- **The wicked-core#431 wire on the gate, the delivery card, the run head and the feed** (#250/#431
+  consumer follow-through — pins `wicked-crew-api-types` 0.33.0, the wire wicked-crew#527 publishes).
+  Every field is read off the frames the daemon sends and rendered only when present, so an older
+  daemon changes nothing.
+  - *Gate card — the judge seat* (`gateEvaluated.judgeCli` / `judgeDistinct`): the verdict header
+    names WHO judged (`· judge: codex`); `judgeDistinct: false` adds a same-seat warning — the judge
+    fell back to the single default runner, so evaluator ≠ creator is not held on that verdict.
+  - *Denial card — the restored tree* (`evaluatorMutatedWorktree.restored` + `worktreeRestored`):
+    a worktree-guard denial the engine already remedied says "the evaluator's edit was discarded and
+    the creator's verified tree restored", lists the discarded paths from the restore record, and
+    gives `git show refs/wicked/suggestions/<run>/<ord>/<attempt>` as copyable code when the edit was
+    pinned (an honest "not pinned" otherwise). **Approve is relabelled "Retry against the restored
+    tree"** (and "Retry + steer") on exactly that gate — keyed on the evidence frames, not on the
+    prompt, which the engine also changed ("confirm to retry the phase" → "Approve to retry the phase
+    against the restored tree"; the card's NOT PASS match holds for both spellings). A failed
+    restore (`restored: false`) is said, with the engine's error, and the manual remedy stands.
+  - *Delivery card / deliver gate — the lift* (`deliverLiftEvaluated`, the deliver ord's
+    `repoChecksEvaluated`, the deliver unit's `deliver:` refusal): the rail's Delivery body and a
+    gate opened on the deliver unit render what the pre-push lift did — `unchanged` / `lifted`
+    (base and tree before → after, the re-verify per check with the forced-install source
+    `package-lock.json (forced: lockfile drift)`) / `conflict` (the files, "nothing was rebased and
+    nothing was pushed", the LIFT-CONFLICT remedy) / `skipped` / `failed` — and the engine's
+    refusal verbatim, once. A deliver unit refused BEFORE the lift (a `HEAD` off the run branch)
+    has no lift frame and renders its `deliver:` text on its own; a `passed: false` re-verify over
+    all-green rows is explained as the checks having CHANGED the worktree.
+  - *Run head / timeline — the base* (`runBaseResolved`): a `base` row on the run's context card and
+    a `based on` head row on the evidence timeline — "origin/main @ f57069d · 5 behind · lifted to
+    the tip" — plus timeline rows and detail panels for the restore, the lift and a refused write.
+  - *Feed*: narration lines for the run base, the creator-tree restore, each lift outcome, a refused
+    write-class tool call (`evaluatorToolCallDenied`) and the one deliberate ACP reroute
+    (`acpFallback.fallbackKind: 'read_only_requires_wrapped'` — routing, not a failure); every other
+    `acpFallback` kind stays silent as before.
+  - Tests: unit suites over synthetic frames in the wire's exact spelling (`tests/fixtures/wire433.ts`,
+    mirroring wicked-crew's wire-contract literals) for each surface; the loopback rig
+    `e2e/wire433_test.py` (fixture switch `wire433`) drives the three surfaces in a real browser.
+
 
 ## [0.5.5] — 2026-09-11
 ### Added

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -137,8 +137,8 @@ Mutable switches (flipped over POST /__fixture between page loads):
                     edit was discarded and the creator's verified tree restored.
                     Approve to retry the phase against the restored tree …").
                     r-auth (failed) gains a REJECTED `deliver` unit whose
-                    denial_reason is the engine's `deliver: LIFT-CONFLICT — …`
-                    refusal, and its tail becomes the full chronology with
+                    denial_reason is the engine's framed `Worker FAILED on unit 2
+                    (triage: …): deliver: LIFT-CONFLICT — …` refusal, and its tail becomes the full chronology with
                     `runBaseResolved` (origin/main, 5 behind, lifted) at the head
                     and `deliverLiftEvaluated {outcome: "conflict"}` + the
                     `stepFailed` before sessionFailed. Every frame is the wire's
@@ -1199,6 +1199,10 @@ WIRE433_LIFT_REFUSAL = (
     f"(base {WIRE433_BASE_BEFORE[:7]}); nothing was rebased and nothing was pushed. Resolve on "
     "the branch (rebase onto origin/main, regenerate any generated files, re-run the "
     "repository's checks) and approve to retry the deliver phase.")
+WIRE433_TRIAGE_ANALYSIS = "the engine refused the deliver: a git state, not a worker error"
+# A rejected unit's denial_reason as the ENGINE frames it (actor.rs, the triage-Fail path) — the
+# refusal is 370 chars, under the 150/250 excerpt cap, so it rides whole inside the framing.
+WIRE433_LIFT_DENIAL = f"Worker FAILED on unit 2 (triage: {WIRE433_TRIAGE_ANALYSIS}): {WIRE433_LIFT_REFUSAL}"
 WIRE433_INTENT = "migrate the auth tables"
 
 
@@ -1289,7 +1293,7 @@ WIRE433_AUTH_UNITS = [
     _wire433_unit("r-auth", "survey", 0, "survey the auth middleware surface", "recon", "done"),
     _wire433_unit("r-auth", "review", 1, "review the middleware refactor", "review", "done"),
     _wire433_unit("r-auth", "deliver", 2, "deliver — refactor the auth middleware", "build",
-                  "rejected", denial=WIRE433_LIFT_REFUSAL,
+                  "rejected", denial=WIRE433_LIFT_DENIAL,
                   tool_cmd=["bash", "-lc", "gh pr create --fill"]),
 ]
 WIRE433_AUTH_WORKDIR = "/w2/trees/r-auth"
@@ -1336,8 +1340,8 @@ WIRE433_AUTH_EVENTS = [
      "ts": WIRE433_A0 + 5 * MIN + 4 * SEC, "seq": 15},
     {"type": "stepFailed", "session": "r-auth", "ord": 2, "attempt": 0, "detail": WIRE433_LIFT_REFUSAL,
      "failureKind": "workerError", "ts": WIRE433_A0 + 5 * MIN + 4 * SEC, "seq": 16},
-    {"type": "failureTriaged", "session": "r-auth", "ord": 2, "decision": "escalate",
-     "analysis": "the engine refused the deliver: a git state, not a worker error",
+    {"type": "failureTriaged", "session": "r-auth", "ord": 2, "decision": "fail",
+     "analysis": WIRE433_TRIAGE_ANALYSIS,
      "ts": WIRE433_A0 + 5 * MIN + 5 * SEC, "seq": 17},
     {"type": "sessionFailed", "session": "r-auth", "ord": 2, "ts": NOW0 - 12 * MIN, "seq": 18},
 ]
@@ -1885,8 +1889,9 @@ def assemble_runs() -> list:
                 r["session"]["extra_write_roots"] = [FORENSICS_EVIDENCE_ROOT]
             # wicked-core#431 (api-types 0.33.0): r-api on the bug workflow's five
             # units, genuinely ON the denied verify (unit_ix 3); r-auth with its
-            # REJECTED deliver unit (the engine's LIFT-CONFLICT refusal verbatim as
-            # denial_reason) and a workdir, so the Delivery card names the worktree.
+            # REJECTED deliver unit (the engine's LIFT-CONFLICT refusal, framed as the
+            # engine frames a rejected unit's denial_reason) and a workdir, so the
+            # Delivery card names the worktree.
             if wire433_on and r["session"]["id"] == "r-api":
                 r["units"] = json.loads(json.dumps(WIRE433_API_UNITS))
                 r["session"]["unit_ix"] = 3

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -127,6 +127,23 @@ Mutable switches (flipped over POST /__fixture between page loads):
                     unitReworkAmended → re-dispatch → gateEvaluated deny arc,
                     ending sessionFailed. Ride it WITH `forensics` (units +
                     output wires). Default False.
+  wire433         — the wicked-core#431 wire (api-types 0.33.0; wicked-crew#527):
+                    r-api's complex gate becomes the ord-4 RESTORED-TREE denial —
+                    its units grow to the recorded bug workflow's five, its events
+                    tail carries `evaluatorMutatedWorktree {restored: true}` +
+                    `worktreeRestored {suggestionRef}` + a `gateEvaluated` deny
+                    naming the judge (`judgeCli: "codex", judgeDistinct: true`),
+                    and its cached gate carries the engine's NEW prompt ("… its
+                    edit was discarded and the creator's verified tree restored.
+                    Approve to retry the phase against the restored tree …").
+                    r-auth (failed) gains a REJECTED `deliver` unit whose
+                    denial_reason is the engine's `deliver: LIFT-CONFLICT — …`
+                    refusal, and its tail becomes the full chronology with
+                    `runBaseResolved` (origin/main, 5 behind, lifted) at the head
+                    and `deliverLiftEvaluated {outcome: "conflict"}` + the
+                    `stepFailed` before sessionFailed. Every frame is the wire's
+                    exact camelCase spelling (crew's wire-contract literals).
+                    Default False — no standing rig's gate or tail changes.
   project_dto     — the slice-S CREW-UX-2 corpus (DES-UX-001 §2.3): every run
                     DTO carries `project_id` (api-types 0.8.0 — a string echoed
                     from the membership record, or null = GENUINELY unfiled),
@@ -320,6 +337,9 @@ state = {"orphan": True, "q3_gate_age_ms": 30 * SEC,
          # (the units + output wires). Default False: sliceR's tail keeps its
          # historical 4-event shape.
          "timeline": False,
+         # wicked-core#431 (api-types 0.33.0): the restored-tree gate on r-api,
+         # the lift conflict + run base on r-auth — see the module docstring.
+         "wire433": False,
          # C6 fix (BRIEF-UX-002 final gate): the stale-clock reproduction —
          # EVERY clock the board could read for upload-endpoint goes 15h stale
          # (project.updated_at, the r-upload attach clock) AND the /ws
@@ -1136,6 +1156,192 @@ TIMELINE_AUTH_EVENTS = [
 # real fetch (the zero-request-hang regression trap, §1.3-4b).
 FORENSICS_DIFF_HANG_SECONDS = 30
 
+# ── wicked-core#431 (api-types 0.33.0): the wire433 corpus, behind `wire433` ──
+#
+# Two runs, the two stories the studio renders off the new frames — every frame
+# the wire's exact `event_to_json` spelling (camelCase, every key present, `null`
+# never absent), the same literals wicked-crew#527's wire-contract test pins.
+#
+#  - r-api (awaiting_human, project api-migration): the bug workflow's five units;
+#    the `verify` phase (ord 4, `executes_code: false`) changed the worktree, the
+#    engine RESTORED the creator's tree (`restored: true`, a `worktreeRestored`
+#    with the pinned suggestion ref), the judge is named (`codex`, distinct), and
+#    the gate carries the engine's NEW mutation-gate prompt.
+#  - r-auth (failed, project auth-refactor): based on origin/main 5 commits ahead
+#    of the clone (`runBaseResolved`, lifted); survey + review done, then the
+#    deliver phase's pre-push lift hit a CONFLICT in a generated file — the unit
+#    failed with the engine's `deliver: LIFT-CONFLICT — …` refusal, nothing
+#    rebased or pushed, and the run failed.
+
+WIRE433_TREE_BEFORE = "a1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6a7b8c9d0"
+WIRE433_TREE_AFTER = "f0e1d2c3b4a5f0e1d2c3b4a5f0e1d2c3b4a5f0e1"
+WIRE433_BASE_BEFORE = "1432c96e0f1a2b3c4d5e6f708192a3b4c5d6e7f8"
+WIRE433_BASE_AFTER = "f57069d1e2f3a4b5c6d7e8f90a1b2c3d4e5f6a7b"
+WIRE433_SUGGESTION_REF = "refs/wicked/suggestions/r-api/4/0"
+WIRE433_CRITERION = ("the run left a change in its worktree (done is re-derived "
+                     "from the diff, never asserted)")
+WIRE433_RESTORED_REASON = (
+    "evaluator≠creator: phase `verify` declares `executes_code: false` but changed the "
+    "worktree it was reviewing — 1 path(s): M src/App.tsx "
+    f"(tree {WIRE433_TREE_BEFORE[:10]} → {WIRE433_TREE_AFTER[:10]}). "
+    "The change under review is no longer the creator's, so this phase's verdict cannot "
+    "certify it. The evaluator's edit was DISCARDED: the engine restored the creator's tree "
+    f"({WIRE433_TREE_BEFORE[:10]}) in the worktree, so approving this gate retries the phase "
+    "against the verified tree. A phase that must change code declares `executes_code: true` "
+    "in the workflow def.")
+WIRE433_RESTORED_PROMPT = (
+    "Unit 4 verdict is NOT PASS — the evaluator changed the tree under review; its edit was "
+    "discarded and the creator's verified tree restored. Approve to retry the phase against "
+    "the restored tree, or reject to cancel the run")
+WIRE433_LIFT_REFUSAL = (
+    f"deliver: LIFT-CONFLICT — lifting the run's work onto origin/main ({WIRE433_BASE_AFTER[:7]}) "
+    "would conflict in: testid-inventory.json. The worktree was left exactly as verified "
+    f"(base {WIRE433_BASE_BEFORE[:7]}); nothing was rebased and nothing was pushed. Resolve on "
+    "the branch (rebase onto origin/main, regenerate any generated files, re-run the "
+    "repository's checks) and approve to retry the deliver phase.")
+WIRE433_INTENT = "migrate the auth tables"
+
+
+def _wire433_unit(rid: str, key: str, ord_: int, desc: str, stage: str, status: str,
+                  denial: str | None = None, tool_cmd: list | None = None) -> dict:
+    u = {"id": f"{rid}:{key}", "session_id": rid, "ord": ord_, "description": desc,
+         "stage": stage, "assigned_cli": "claude" if status != "pending" else None,
+         "assigned_invocation": None, "council_task_ref": None, "routing": None,
+         "denial_reason": denial, "phase_ref": None, "conformance_ref": None,
+         "phase_status": None, "collection_scope": None, "status": status}
+    if tool_cmd is not None:
+        u["tool_cmd"] = tool_cmd
+    return u
+
+
+WIRE433_API_UNITS = [
+    _wire433_unit("r-api", "triage", 1, f"triage — {WIRE433_INTENT}", "recon", "done"),
+    _wire433_unit("r-api", "reproduce", 2, f"reproduce — {WIRE433_INTENT}", "recon", "done"),
+    _wire433_unit("r-api", "fix", 3, f"fix — {WIRE433_INTENT}", "build", "done"),
+    _wire433_unit("r-api", "verify", 4, f"verify — {WIRE433_INTENT}", "test", "pending"),
+    _wire433_unit("r-api", "deliver", 5, f"deliver — {WIRE433_INTENT}", "build", "pending",
+                  tool_cmd=["bash", "-lc", "gh pr create --fill"]),
+]
+
+WIRE433_T0 = NOW0 - 40 * MIN
+
+
+def _w433_gate_pass(ord_: int, seq: int, ts: int, judge: str | None, distinct: bool | None,
+                    floor: bool) -> dict:
+    return {"type": "gateEvaluated", "session": "r-api", "ord": ord_, "seq": seq, "ts": ts,
+            "criterion": WIRE433_CRITERION if floor else None,
+            "hasDeterministicFloor": floor, "deterministicPass": True,
+            "agentVerdict": "pass" if judge else None,
+            "agentReasoning": ("PASS — the worktree evidence shows modified tracked files, "
+                               "satisfying the criterion. PASS") if judge else None,
+            "evaluatorPass": True, "evaluatorPolicies": [],
+            "denialReason": None, "denial": None, "combined": True,
+            "judgeCli": judge, "judgeDistinct": distinct}
+
+
+WIRE433_API_EVENTS = [
+    {"type": "sessionStarted", "session": "r-api", "problem": WIRE433_INTENT,
+     "workflowId": "bug", "cliCount": 1, "governed": True, "entityMode": "shared",
+     "ts": WIRE433_T0, "seq": 1},
+    {"type": "workflowSelected", "session": "r-api", "workflowId": "bug", "unitCount": 5,
+     "ts": WIRE433_T0 + SEC, "seq": 2},
+    {"type": "awaitingHuman", "session": "r-api", "ord": 1, "seq": 33, "ts": WIRE433_T0 + 2 * SEC,
+     "prompt": f"Approve unit 1 before it runs: triage — {WIRE433_INTENT}", "reviewingOrd": None},
+    _w433_gate_pass(1, 43, WIRE433_T0 + 3 * MIN, None, None, False),
+    {"type": "gateDecided", "session": "r-api", "ord": 1, "seq": 44, "ts": WIRE433_T0 + 3 * MIN, "allow": True},
+    _w433_gate_pass(2, 102, WIRE433_T0 + 6 * MIN, None, None, False),
+    {"type": "gateDecided", "session": "r-api", "ord": 2, "seq": 103, "ts": WIRE433_T0 + 6 * MIN, "allow": True},
+    _w433_gate_pass(3, 197, WIRE433_T0 + 20 * MIN, "codex", True, True),
+    {"type": "gateDecided", "session": "r-api", "ord": 3, "seq": 198, "ts": WIRE433_T0 + 20 * MIN, "allow": True},
+    {"type": "unitDone", "session": "r-api", "ord": 3, "seq": 199, "ts": WIRE433_T0 + 20 * MIN},
+    {"type": "awaitingHuman", "session": "r-api", "ord": 4, "seq": 200, "ts": WIRE433_T0 + 20 * MIN + SEC,
+     "prompt": f"Approve unit 4 before it runs: verify — {WIRE433_INTENT}", "reviewingOrd": None},
+    {"type": "resumed", "session": "r-api", "ord": 4, "seq": 201, "ts": WIRE433_T0 + 22 * MIN},
+    {"type": "unitDispatched", "session": "r-api", "ord": 4, "seq": 202, "ts": WIRE433_T0 + 22 * MIN, "attempt": 0},
+    {"type": "unitExecuting", "session": "r-api", "ord": 4, "seq": 203, "ts": WIRE433_T0 + 22 * MIN},
+    {"type": "evaluatorMutatedWorktree", "session": "r-api", "ord": 4, "seq": 245,
+     "ts": WIRE433_T0 + 28 * MIN, "attempt": 0, "cli": "pi", "phase": "verify",
+     "beforeTree": WIRE433_TREE_BEFORE, "afterTree": WIRE433_TREE_AFTER, "headMoved": False,
+     "changed": [{"path": "src/App.tsx", "status": "M"}], "restored": True, "restoreError": None},
+    {"type": "worktreeRestored", "session": "r-api", "ord": 4, "seq": 246,
+     "ts": WIRE433_T0 + 28 * MIN, "attempt": 0, "cli": "pi", "phase": "verify",
+     "tree": WIRE433_TREE_BEFORE, "head": None,
+     "discarded": [{"path": "src/App.tsx", "status": "M"}],
+     "suggestionRef": WIRE433_SUGGESTION_REF},
+    {"type": "gateEvaluated", "session": "r-api", "ord": 4, "seq": 247, "ts": WIRE433_T0 + 28 * MIN,
+     "criterion": WIRE433_CRITERION, "hasDeterministicFloor": True, "deterministicPass": True,
+     "agentVerdict": "pass",
+     "agentReasoning": "PASS — the worktree evidence shows modified tracked files, satisfying the criterion. PASS",
+     "evaluatorPass": True, "evaluatorPolicies": [],
+     "denialReason": WIRE433_RESTORED_REASON,
+     "denial": {"source": "worktree_guard", "reason": WIRE433_RESTORED_REASON, "claimId": None,
+                "ruleIds": [], "deniedTool": None, "phase": "unit-4"},
+     "combined": False, "judgeCli": "codex", "judgeDistinct": True},
+    {"type": "gateDecided", "session": "r-api", "ord": 4, "seq": 248, "ts": WIRE433_T0 + 28 * MIN, "allow": False},
+    {"type": "unitDenied", "session": "r-api", "ord": 4, "seq": 249, "ts": WIRE433_T0 + 28 * MIN},
+    {"type": "gateEscalated", "session": "r-api", "ord": 4, "seq": 250, "ts": WIRE433_T0 + 28 * MIN,
+     "condition": "verdict_not_pass", "verdictSummary": WIRE433_RESTORED_REASON},
+    {"type": "awaitingHuman", "session": "r-api", "ord": 4, "seq": 251, "ts": WIRE433_T0 + 28 * MIN + SEC,
+     "prompt": WIRE433_RESTORED_PROMPT, "reviewingOrd": 4},
+]
+
+WIRE433_AUTH_UNITS = [
+    _wire433_unit("r-auth", "survey", 0, "survey the auth middleware surface", "recon", "done"),
+    _wire433_unit("r-auth", "review", 1, "review the middleware refactor", "review", "done"),
+    _wire433_unit("r-auth", "deliver", 2, "deliver — refactor the auth middleware", "build",
+                  "rejected", denial=WIRE433_LIFT_REFUSAL,
+                  tool_cmd=["bash", "-lc", "gh pr create --fill"]),
+]
+WIRE433_AUTH_WORKDIR = "/w2/trees/r-auth"
+WIRE433_A0 = NOW0 - 13 * MIN
+
+
+def _w433_auth_planned(ord_: int, desc: str, stage: str, seq: int, ts: int) -> dict:
+    return {"type": "unitPlanned", "session": "r-auth", "ord": ord_, "description": desc,
+            "stage": stage, "role": None, "gate": None, "skillRef": None,
+            "hasValidatorPin": True, "executorType": "cli" if ord_ < 2 else "tool",
+            "ts": ts, "seq": seq}
+
+
+WIRE433_AUTH_EVENTS = [
+    {"type": "sessionStarted", "session": "r-auth", "problem": "refactor the auth middleware",
+     "workflowId": "wf-w2", "cliCount": 1, "governed": True, "entityMode": "shared",
+     "ts": WIRE433_A0, "seq": 1},
+    {"type": "runBaseResolved", "session": "r-auth", "baseRef": "origin/main",
+     "baseCommit": WIRE433_BASE_AFTER, "localHead": WIRE433_BASE_BEFORE, "behind": 5,
+     "fetched": True, "lifted": True, "note": None, "ts": WIRE433_A0 + SEC, "seq": 2},
+    {"type": "workflowSelected", "session": "r-auth", "workflowId": "wf-w2", "unitCount": 3,
+     "ts": WIRE433_A0 + 2 * SEC, "seq": 3},
+    _w433_auth_planned(0, "survey the auth middleware surface", "recon", 4, WIRE433_A0 + 3 * SEC),
+    _w433_auth_planned(1, "review the middleware refactor", "review", 5, WIRE433_A0 + 3 * SEC),
+    _w433_auth_planned(2, "deliver — refactor the auth middleware", "build", 6, WIRE433_A0 + 3 * SEC),
+    {"type": "unitDispatched", "session": "r-auth", "ord": 0, "attempt": 0, "ts": WIRE433_A0 + 4 * SEC, "seq": 7},
+    {"type": "unitOutputCaptured", "session": "r-auth", "ord": 0, "attempt": 0, "outputBytes": 2048,
+     "stepStatus": "ok", "governed": True, "ts": WIRE433_A0 + 40 * SEC, "seq": 8},
+    {"type": "unitDone", "session": "r-auth", "ord": 0, "ts": WIRE433_A0 + 41 * SEC, "seq": 9},
+    {"type": "unitDispatched", "session": "r-auth", "ord": 1, "attempt": 0, "ts": WIRE433_A0 + 42 * SEC, "seq": 10},
+    {"type": "gateEvaluated", "session": "r-auth", "ord": 1, "ts": WIRE433_A0 + 5 * MIN, "seq": 11,
+     "criterion": "the middleware refactor keeps every existing auth test green",
+     "hasDeterministicFloor": True, "deterministicPass": True, "agentVerdict": "pass",
+     "agentReasoning": "PASS — auth.refresh.spec and the full auth suite are green on the refactor. PASS",
+     "evaluatorPass": True, "evaluatorPolicies": [], "denialReason": None, "denial": None,
+     "combined": True, "judgeCli": "codex", "judgeDistinct": True},
+    {"type": "gateDecided", "session": "r-auth", "ord": 1, "allow": True, "ts": WIRE433_A0 + 5 * MIN, "seq": 12},
+    {"type": "unitDone", "session": "r-auth", "ord": 1, "ts": WIRE433_A0 + 5 * MIN, "seq": 13},
+    {"type": "unitDispatched", "session": "r-auth", "ord": 2, "attempt": 0, "ts": WIRE433_A0 + 5 * MIN + SEC, "seq": 14},
+    {"type": "deliverLiftEvaluated", "session": "r-auth", "ord": 2, "attempt": 0,
+     "outcome": "conflict", "baseRef": "origin/main", "baseBefore": WIRE433_BASE_BEFORE,
+     "baseAfter": WIRE433_BASE_AFTER, "treeBefore": WIRE433_TREE_BEFORE, "treeAfter": None,
+     "conflicts": ["testid-inventory.json"], "note": None,
+     "ts": WIRE433_A0 + 5 * MIN + 4 * SEC, "seq": 15},
+    {"type": "stepFailed", "session": "r-auth", "ord": 2, "attempt": 0, "detail": WIRE433_LIFT_REFUSAL,
+     "ts": WIRE433_A0 + 5 * MIN + 4 * SEC, "seq": 16},
+    {"type": "failureTriaged", "session": "r-auth", "ord": 2, "decision": "escalate",
+     "analysis": "the engine refused the deliver: a git state, not a worker error",
+     "ts": WIRE433_A0 + 5 * MIN + 5 * SEC, "seq": 17},
+    {"type": "sessionFailed", "session": "r-auth", "ord": 2, "ts": NOW0 - 12 * MIN, "seq": 18},
+]
+
 # ── Slice BA (DES-UX-002 §1): the nerve-center plan corpus, behind `nerve` ────
 #
 # r-upload's plan grows to §1.5's shape: 5 ordered units, 2 done, 1 active
@@ -1626,12 +1832,13 @@ def assemble_runs() -> list:
         nerve_on = state["nerve"]
         gate_now = list(state["gate_now"])
         guidance = dict(state["guidance"])
+        wire433_on = state["wire433"]
         # Slice S (DES-UX-001 §2.3): the null-claim run + this-lifetime launches
         # join BOTH wires (list + detail) so the DTO echo decorates identically.
         if project_dto_on and not state["no_runs"]:
             runs = runs + [UNFILED_RUN] + launched_runs
     if viewer_on or repo_refs_on or forensics_on or provenance_on or project_dto_on \
-            or chronicle_on or nerve_on or gate_now or guidance:
+            or chronicle_on or nerve_on or gate_now or guidance or wire433_on:
         runs = json.loads(json.dumps(runs))
         for r in runs:
             # Slice BE (CREW-UX-7, crew#312): the DTO echoes the durable note
@@ -1676,6 +1883,18 @@ def assemble_runs() -> list:
             if forensics_on and r["session"]["id"] == "r-auth":
                 r["units"] = json.loads(json.dumps(FORENSICS_AUTH_UNITS))
                 r["session"]["extra_write_roots"] = [FORENSICS_EVIDENCE_ROOT]
+            # wicked-core#431 (api-types 0.33.0): r-api on the bug workflow's five
+            # units, genuinely ON the denied verify (unit_ix 3); r-auth with its
+            # REJECTED deliver unit (the engine's LIFT-CONFLICT refusal verbatim as
+            # denial_reason) and a workdir, so the Delivery card names the worktree.
+            if wire433_on and r["session"]["id"] == "r-api":
+                r["units"] = json.loads(json.dumps(WIRE433_API_UNITS))
+                r["session"]["unit_ix"] = 3
+                r["session"]["workflow_id"] = "bug"
+            if wire433_on and r["session"]["id"] == "r-auth":
+                r["units"] = json.loads(json.dumps(WIRE433_AUTH_UNITS))
+                r["session"]["workdir"] = WIRE433_AUTH_WORKDIR
+                r["session"]["unit_ix"] = 2
             # Slice S (CREW-UX-2): the DTO echoes the membership record —
             # ALWAYS present with the corpus on (string | null), the
             # api-types 0.8.0 contract. Launched runs arrive pre-stamped;
@@ -2350,6 +2569,13 @@ class W2Handler(SimpleHTTPRequestHandler):
                 self._json(200, {"runId": rid, "ord": 0, "lifecycle": "open",
                                  "prompt": "Approve the deck outline?",
                                  "receivedAt": iso(NOW0 - age)})
+            elif rid == "r-api" and state["wire433"]:
+                # wicked-core#431: the escalated mutation gate on unit 4 with the
+                # engine's NEW prompt (the restored-tree wording); `options: null`
+                # keeps it the COMPLEX shape, answered in the thread.
+                self._json(200, {"runId": rid, "ord": 4, "lifecycle": "open",
+                                 "prompt": WIRE433_RESTORED_PROMPT,
+                                 "receivedAt": iso(NOW0 - 2 * MIN), "options": None})
             elif rid == "r-api":
                 # `options: null` = free text ⇒ the COMPLEX gate shape (§7.11).
                 self._json(200, {"runId": rid, "ord": 0, "lifecycle": "open",
@@ -2384,6 +2610,7 @@ class W2Handler(SimpleHTTPRequestHandler):
                 river_on = state["river"]
                 forensics_on = state["forensics"]
                 timeline_on = state["timeline"]
+                wire433_on = state["wire433"]
             if viewer_on and rid == "r-upload":
                 events = events + VIEWER_EVENTS
             # Slice Q: r-auth's durable tail matches its spread attach clock.
@@ -2400,6 +2627,13 @@ class W2Handler(SimpleHTTPRequestHandler):
             # the full recorded chronology, seq-ordered, deny verdict included.
             if timeline_on and rid == "r-auth":
                 events = list(TIMELINE_AUTH_EVENTS)
+            # wicked-core#431 (api-types 0.33.0): the wire433 corpus SUPERSEDES both
+            # runs' tails — r-api's restored-tree gate fold, r-auth's run base +
+            # lift conflict chronology.
+            if wire433_on and rid == "r-api":
+                events = list(WIRE433_API_EVENTS)
+            if wire433_on and rid == "r-auth":
+                events = list(WIRE433_AUTH_EVENTS)
             # Slice BC: the chain tip's durable tail — the current-state
             # strip's criterion/workflow derivation reads exactly this.
             with state_lock:

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -1335,7 +1335,7 @@ WIRE433_AUTH_EVENTS = [
      "conflicts": ["testid-inventory.json"], "note": None,
      "ts": WIRE433_A0 + 5 * MIN + 4 * SEC, "seq": 15},
     {"type": "stepFailed", "session": "r-auth", "ord": 2, "attempt": 0, "detail": WIRE433_LIFT_REFUSAL,
-     "ts": WIRE433_A0 + 5 * MIN + 4 * SEC, "seq": 16},
+     "failureKind": "workerError", "ts": WIRE433_A0 + 5 * MIN + 4 * SEC, "seq": 16},
     {"type": "failureTriaged", "session": "r-auth", "ord": 2, "decision": "escalate",
      "analysis": "the engine refused the deliver: a git state, not a worker error",
      "ts": WIRE433_A0 + 5 * MIN + 5 * SEC, "seq": 17},

--- a/e2e/wire433_test.py
+++ b/e2e/wire433_test.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""
+wire433_test.py — the wicked-core#431 wire (api-types 0.33.0) on the three
+studio surfaces, in a real browser against the shared loopback fixture
+(uxfix_fixture.py, switch `wire433`). No crew daemon is involved.
+
+  1. GATE CARD (r-api's escalated verify gate): the verdict header names the
+     judge seat (`judge: codex`); the restored-tree denial says "the evaluator's
+     edit was discarded and the creator's verified tree restored", lists the
+     discarded path, and carries the copyable `git show refs/wicked/suggestions/…`
+     hint; Approve reads "Retry against the restored tree" (`data-retry-restored`);
+     the engine's NEW prompt renders whole. No `git read-tree` command is offered
+     (the engine already ran the remedy).
+  2. RUN HEAD / TIMELINE (r-auth, failed): the What / Where card carries the
+     `base` row ("origin/main @ f57069d · 5 behind · lifted to the tip"); the
+     Timeline tab shows the `based on` head row and the `lift` row (LIFT-CONFLICT
+     · testid-inventory.json); clicking the lift row renders the shared
+     DeliverLift card in the detail panel.
+  3. DELIVERY CARD (r-auth's rail Delivery section): `deliver-lift` in the
+     `conflict` outcome — the conflicting file, "nothing was rebased and nothing
+     was pushed", the remedy — and the unit's own refusal ONCE (the lift block
+     omits its copy because `denial_reason` already carries it).
+
+Captures (1440x900, device_scale_factor=1) into e2e/shots/wire433/:
+  wire433-gate-restored.png     the gate card with the restored denial
+  wire433-delivery-conflict.png the rail's Delivery body + the timeline lift detail
+
+Prereqs: Python Playwright. Builds dist-sameorigin/ itself unless
+SKIP_STUDIO_BUILD=1 — ensure_build CACHES: delete a stale dist-sameorigin/ when
+the source changed. Env knobs: FEEDBACK_PORT (default 4433), SKIP_STUDIO_BUILD.
+Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import re
+import sys
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    REPO,
+    WIRE433_BASE_AFTER,
+    WIRE433_RESTORED_PROMPT,
+    WIRE433_SUGGESTION_REF,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4433"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+SHOTS = REPO / "e2e" / "shots" / "wire433"
+
+API_THREAD = "/p/api-migration/build/r-api"
+AUTH_THREAD = "/p/auth-refactor/build/r-auth"
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+def check(step: str, ok: bool, **detail) -> None:
+    report["steps"][step] = {"ok": bool(ok), **detail}
+    if not ok:
+        print(json.dumps(report, indent=2))
+        sys.exit(1)
+
+
+# ── 1. The same-origin build + the fixture with the wire433 corpus on ──────────
+dist = ensure_build(fail)
+start_server(FEEDBACK_PORT, dist)
+set_fixture(ORIGIN, wire433=True)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN}
+
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+SHOTS.mkdir(parents=True, exist_ok=True)
+
+
+def text(page, selector: str) -> str:
+    loc = page.locator(selector)
+    return loc.first.text_content() if loc.count() > 0 else ""
+
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+
+    def settled(expr: str, arg=None, timeout=30000) -> bool:
+        try:
+            page.wait_for_function(expr, arg=arg, timeout=timeout)
+            return True
+        except Exception:
+            return False
+
+    # ── Scene 1: the gate card on r-api's thread ───────────────────────────────
+    page.goto(f"{ORIGIN}{API_THREAD}", wait_until="domcontentloaded")
+    page.locator('[data-testid="steering-gate"]').first.wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    # The verdict block is a view over the hydrated log — wait for it, not just the card.
+    got_verdict = settled("""() => !!document.querySelector('[data-testid="gate-verdict-restored"]')""")
+    gate = page.evaluate(
+        """() => {
+          const q = (s) => document.querySelector(s);
+          const t = (s) => q(s)?.textContent ?? '';
+          const card = q('[data-testid="steering-gate"]');
+          const verdict = q('[data-testid="gate-verdict"]');
+          return {
+            prompt: t('[data-testid="steering-prompt"]'),
+            retryRestored: card?.getAttribute('data-retry-restored'),
+            approve: t('[data-testid="steering-approve"]').trim(),
+            approveSteer: t('[data-testid="steering-approve-steer"]').trim(),
+            verdict: verdict?.getAttribute('data-verdict'),
+            denialSource: verdict?.getAttribute('data-denial-source'),
+            judgeSeat: t('[data-testid="gate-verdict-judge-seat"]'),
+            judgeDistinct: q('[data-testid="gate-verdict-judge-seat"]')?.getAttribute('data-judge-distinct'),
+            sameSeatWarning: !!q('[data-testid="gate-verdict-judge-same-seat"]'),
+            restored: t('[data-testid="gate-verdict-restored"]'),
+            suggestionRef: q('[data-testid="gate-verdict-restored"]')?.getAttribute('data-suggestion-ref'),
+            hint: t('[data-testid="gate-verdict-suggestion-hint"]'),
+            hintTag: q('[data-testid="gate-verdict-suggestion-hint"]')?.tagName,
+            denial: t('[data-testid="gate-verdict-denial"]'),
+            readTreeOffered: /git read-tree/.test(t('[data-testid="gate-verdict"]')),
+            restoreFailed: !!q('[data-testid="gate-verdict-restore-failed"]'),
+            liftBlock: !!q('[data-testid="deliver-lift"]'),
+          };
+        }""")
+    check(
+        "gate_card_restored_denial",
+        got_verdict
+        and gate["prompt"].strip() == WIRE433_RESTORED_PROMPT
+        and gate["retryRestored"] == "true"
+        and gate["approve"] == "Retry against the restored tree"
+        and gate["approveSteer"] == "Retry + steer"
+        and gate["verdict"] == "fail"
+        and gate["denialSource"] == "worktree_guard"
+        and "judge: codex" in gate["judgeSeat"]
+        and gate["judgeDistinct"] == "true"
+        and not gate["sameSeatWarning"]
+        and "the evaluator's edit was discarded and the creator's verified tree restored" in gate["restored"]
+        and "discarded: M src/App.tsx" in gate["restored"]
+        and gate["suggestionRef"] == WIRE433_SUGGESTION_REF
+        and gate["hint"].strip() == f"git show {WIRE433_SUGGESTION_REF}"
+        and gate["hintTag"] == "CODE"
+        and "The evaluator's edit was DISCARDED" in gate["denial"]
+        and not gate["readTreeOffered"]
+        and not gate["restoreFailed"]
+        and not gate["liftBlock"],  # a gate on the verify ord shows no deliver lift
+        **gate,
+    )
+    page.locator('[data-testid="gate-verdict-restored"]').scroll_into_view_if_needed()
+    page.screenshot(path=str(SHOTS / "wire433-gate-restored.png"))
+
+    # ── Scene 2: the run head + timeline on r-auth's thread ───────────────────
+    page.goto(f"{ORIGIN}{AUTH_THREAD}", wait_until="domcontentloaded")
+    page.locator('[data-testid="failure-banner"]').first.wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    # The What / Where accordion may not be the open one — open it if the base row is not visible.
+    if page.locator('[data-testid="run-base"]').count() == 0:
+        page.get_by_role("button", name=re.compile(r"What / Where")).first.click()
+    base_ok = settled("""() => !!document.querySelector('[data-testid="run-base"]')""")
+    base_text = text(page, '[data-testid="run-base"]')
+    check(
+        "run_head_base_row",
+        base_ok
+        and f"origin/main @ {WIRE433_BASE_AFTER[:7]}" in base_text
+        and "5 behind" in base_text
+        and "lifted to the tip" in base_text,
+        base=base_text,
+    )
+
+    # The FEED is the default lens: the narrator speaks the new frames.
+    feed_ok = settled(
+        """() => Array.from(document.querySelectorAll('[data-testid="narration-line"]'))
+              .some(n => /Deliver lift: CONFLICT/.test(n.textContent ?? ''))""")
+    lines = page.evaluate(
+        """() => Array.from(document.querySelectorAll('[data-testid="narration-line"]'))
+              .map(n => (n.textContent ?? '').trim())
+              .filter(t => /Based on|Deliver lift/.test(t))""")
+    check(
+        "feed_narration",
+        feed_ok
+        and any(f"Based on origin/main @ {WIRE433_BASE_AFTER[:7]} · 5 behind · lifted to the tip" in t for t in lines)
+        and any("Deliver lift: CONFLICT in testid-inventory.json — nothing rebased, nothing pushed" in t for t in lines),
+        lines=lines,
+    )
+
+    # The Timeline lens (a terminal run's recorded trail) is demoted behind the
+    # Inspect menu (DES-RUN-NARRATOR §8, revised) — the menu item keeps `tab-timeline`.
+    page.locator('[data-testid="run-inspect"]').first.click()
+    page.locator('[data-testid="tab-timeline"]').first.wait_for(timeout=10000)
+    page.locator('[data-testid="tab-timeline"]').first.click()
+    rows_ok = settled(
+        """() => !!document.querySelector('[data-testid="timeline-row"][data-event-type="runBaseResolved"]')
+              && !!document.querySelector('[data-testid="timeline-row"][data-event-type="deliverLiftEvaluated"]')""")
+    rows = page.evaluate(
+        """() => {
+          const r = (t) => document.querySelector(`[data-testid="timeline-row"][data-event-type="${t}"]`);
+          return {
+            based: r('runBaseResolved')?.textContent ?? '',
+            lift: r('deliverLiftEvaluated')?.textContent ?? '',
+            failed: r('stepFailed')?.textContent ?? '',
+            rowCount: document.querySelectorAll('[data-testid="timeline-row"]').length,
+          };
+        }""")
+    check(
+        "timeline_rows",
+        rows_ok
+        and "based on" in rows["based"]
+        and f"origin/main @ {WIRE433_BASE_AFTER[:7]}" in rows["based"]
+        and "lift" in rows["lift"]
+        and "LIFT-CONFLICT" in rows["lift"]
+        and "testid-inventory.json" in rows["lift"],
+        **rows,
+    )
+    page.locator('[data-testid="timeline-row"][data-event-type="deliverLiftEvaluated"]').first.click()
+    detail_ok = settled(
+        """() => !!document.querySelector('[data-testid="timeline-detail"] [data-testid="deliver-lift"][data-outcome="conflict"]')""")
+    detail = page.evaluate(
+        """() => {
+          const d = document.querySelector('[data-testid="timeline-detail"]');
+          const t = (s) => d?.querySelector(s)?.textContent ?? '';
+          return {
+            outcome: d?.querySelector('[data-testid="deliver-lift"]')?.getAttribute('data-outcome'),
+            conflicts: t('[data-testid="deliver-lift-conflicts"]'),
+            remedy: t('[data-testid="deliver-lift-remedy"]'),
+            failure: t('[data-testid="deliver-lift-failure"]'),
+          };
+        }""")
+    check(
+        "timeline_lift_detail",
+        detail_ok
+        and detail["outcome"] == "conflict"
+        and detail["conflicts"].strip() == "testid-inventory.json"
+        and "rebase onto origin/main" in detail["remedy"]
+        and detail["failure"].startswith("deliver: LIFT-CONFLICT"),
+        **detail,
+    )
+
+    # ── Scene 3: the rail's Delivery section ───────────────────────────────────
+    page.get_by_role("button", name=re.compile(r"^Delivery")).first.click()
+    lift_ok = settled("""() => !!document.querySelector('[data-testid="run-delivery"] [data-testid="deliver-lift"]')""")
+    delivery = page.evaluate(
+        """() => {
+          const card = document.querySelector('[data-testid="run-delivery"]');
+          const t = (s) => card?.querySelector(s)?.textContent ?? '';
+          const all = (s) => card ? card.querySelectorAll(s).length : 0;
+          return {
+            state: card?.getAttribute('data-state'),
+            badge: document.querySelector('[data-testid="run-delivery-badge"]')?.textContent ?? '',
+            outcome: card?.querySelector('[data-testid="deliver-lift"]')?.getAttribute('data-outcome'),
+            summary: t('[data-testid="deliver-lift-summary"]'),
+            conflicts: t('[data-testid="deliver-lift-conflicts"]'),
+            remedy: t('[data-testid="deliver-lift-remedy"]'),
+            reason: t('[data-testid="run-delivery-reason"]'),
+            liftFailureBlocks: all('[data-testid="deliver-lift-failure"]'),
+            refusalMentions: (card?.textContent ?? '').split('LIFT-CONFLICT — lifting').length - 1,
+            worktree: /the work is in/.test(card?.textContent ?? ''),
+            pushOrPrClaimed: /PR open|pushed the branch/.test(card?.textContent ?? ''),
+          };
+        }""")
+    check(
+        "delivery_card_lift_conflict",
+        lift_ok
+        and delivery["state"] == "failed"
+        and delivery["badge"] == "deliver failed"
+        and delivery["outcome"] == "conflict"
+        and "nothing was rebased and nothing was pushed" in delivery["summary"]
+        and delivery["conflicts"].strip() == "testid-inventory.json"
+        and "remedy:" in delivery["remedy"]
+        and delivery["reason"].startswith("deliver: LIFT-CONFLICT")
+        and delivery["liftFailureBlocks"] == 0  # denial_reason already carries the refusal
+        and delivery["refusalMentions"] == 1
+        and delivery["worktree"]
+        and not delivery["pushOrPrClaimed"],
+        **delivery,
+    )
+    page.screenshot(path=str(SHOTS / "wire433-delivery-conflict.png"))
+
+    browser.close()
+
+report["ok"] = all(s.get("ok") for s in report["steps"].values())
+print(json.dumps(report, indent=2))
+sys.exit(0 if report["ok"] else 1)

--- a/e2e/wire433_test.py
+++ b/e2e/wire433_test.py
@@ -8,7 +8,7 @@ studio surfaces, in a real browser against the shared loopback fixture
      judge seat (`judge: codex`); the restored-tree denial says "the evaluator's
      edit was discarded and the creator's verified tree restored", lists the
      discarded path, and carries the copyable `git show refs/wicked/suggestions/…`
-     hint; Approve reads "Retry against the restored tree" (`data-retry-restored`);
+     hint with a real copy button beside it; Approve reads "Retry against the restored tree" (`data-retry-restored`);
      the engine's NEW prompt renders whole. No `git read-tree` command is offered
      (the engine already ran the remedy).
   2. RUN HEAD / TIMELINE (r-auth, failed): the What / Where card carries the
@@ -124,6 +124,7 @@ with sync_playwright() as p:
             suggestionRef: q('[data-testid="gate-verdict-restored"]')?.getAttribute('data-suggestion-ref'),
             hint: t('[data-testid="gate-verdict-suggestion-hint"]'),
             hintTag: q('[data-testid="gate-verdict-suggestion-hint"]')?.tagName,
+            copyButton: !!q('[data-testid="gate-verdict-restored"] button[aria-label^="copy git show refs/wicked/suggestions/"]'),
             denial: t('[data-testid="gate-verdict-denial"]'),
             readTreeOffered: /git read-tree/.test(t('[data-testid="gate-verdict"]')),
             restoreFailed: !!q('[data-testid="gate-verdict-restore-failed"]'),
@@ -147,6 +148,7 @@ with sync_playwright() as p:
         and gate["suggestionRef"] == WIRE433_SUGGESTION_REF
         and gate["hint"].strip() == f"git show {WIRE433_SUGGESTION_REF}"
         and gate["hintTag"] == "CODE"
+        and gate["copyButton"]
         and "The evaluator's edit was DISCARDED" in gate["denial"]
         and not gate["readTreeOffered"]
         and not gate["restoreFailed"]
@@ -273,7 +275,8 @@ with sync_playwright() as p:
         and "nothing was rebased and nothing was pushed" in delivery["summary"]
         and delivery["conflicts"].strip() == "testid-inventory.json"
         and "remedy:" in delivery["remedy"]
-        and delivery["reason"].startswith("deliver: LIFT-CONFLICT")
+        and delivery["reason"].startswith("Worker FAILED on unit 2 (triage:")
+        and "deliver: LIFT-CONFLICT" in delivery["reason"]
         and delivery["liftFailureBlocks"] == 0  # denial_reason already carries the refusal
         and delivery["refusalMentions"] == 1
         and delivery["worktree"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "typescript-eslint": "^8.63.0",
         "vite": "^6.4.3",
         "vitest": "^3.2.6",
-        "wicked-crew-api-types": "0.32.0"
+        "wicked-crew-api-types": "0.33.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -7146,9 +7146,9 @@
       }
     },
     "node_modules/wicked-crew-api-types": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/wicked-crew-api-types/-/wicked-crew-api-types-0.32.0.tgz",
-      "integrity": "sha512-Gs6MC/+VOXs5mDx8kt3VtIET88zXFi71tpEHin3B2gzlrexPCbaaUDO+ITDT+HBh29Ln1LXP6D/V7KWFhm3+YA==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/wicked-crew-api-types/-/wicked-crew-api-types-0.33.0.tgz",
+      "integrity": "sha512-WdXjBkdAWo9jUrnOoPrLAKlW5KOl9MhKlhIbT2HVxyzLuqb24o32RRZEQcy64m5KjBRSceTk97+gflhBcQKFhg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "typescript-eslint": "^8.63.0",
     "vite": "^6.4.3",
     "vitest": "^3.2.6",
-    "wicked-crew-api-types": "0.32.0"
+    "wicked-crew-api-types": "0.33.0"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/src/components/CenterDashboard.tsx
+++ b/src/components/CenterDashboard.tsx
@@ -21,7 +21,7 @@ import { useGateStore } from '../store/gates.js';
 import { useMembershipStore } from '../store/membership.js';
 import { useRunEventStore } from '../store/events.js';
 import { GateVerdict } from './GateVerdict.js';
-import { gateVerdict, phaseLabel } from './gateVerdictModel.js';
+import { gateVerdict, isRestoredRetry, phaseLabel } from './gateVerdictModel.js';
 import { useSteeringStore } from '../store/steering.js';
 import { launchPath, sessionProjectId } from '../hooks/ambientProject.js';
 import { chroniclePath, modePath } from '../hooks/useRoute.js';
@@ -333,6 +333,11 @@ function GateActionCard({
     () => (ready && typeof ord === 'number' ? gateVerdict(events, ord) : null),
     [events, ord, ready],
   );
+  // wicked-core#431 (F-3R2-010 / F-255-01): the SAME relabel the run page's gate card applies, from
+  // the same predicate — an open gate must not read "Retry against the restored tree" there and
+  // "Approve" here. Approve on the restored-tree denial retries the phase against the creator's
+  // verified tree, and the button says so.
+  const restoredRetry = isRestoredRetry(verdict, ord);
 
   const run = useCallback(
     async (action: () => Promise<void>): Promise<void> => {
@@ -352,6 +357,8 @@ function GateActionCard({
 
   return (
     <div
+      data-testid="gate-inbox-card"
+      {...(restoredRetry ? { 'data-retry-restored': 'true' } : {})}
       style={{
         background: 'var(--surface-card)',
         border: `1px solid ${meta.borderColor}`,
@@ -467,6 +474,7 @@ function GateActionCard({
           type="button"
           disabled={loading}
           onClick={() => void run(() => onApprove(runId))}
+          {...(restoredRetry ? { title: "the evaluator's edit was discarded; the phase re-runs against the creator's verified tree" } : {})}
           style={{
             background: 'var(--status-run-dim)',
             color: 'var(--status-run)',
@@ -480,7 +488,7 @@ function GateActionCard({
             opacity: loading ? 0.5 : 1,
           }}
         >
-          Approve
+          {restoredRetry ? 'Retry against the restored tree' : 'Approve'}
         </button>
         <button
           type="button"
@@ -505,7 +513,7 @@ function GateActionCard({
             opacity: loading ? 0.5 : 1,
           }}
         >
-          {steerOpen && amend.trim() ? 'Send steer' : 'Approve + steer'}
+          {steerOpen && amend.trim() ? 'Send steer' : restoredRetry ? 'Retry + steer' : 'Approve + steer'}
         </button>
         <button
           type="button"

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * A real button that puts a command on the clipboard — the keyboard-reachable half of a "copyable"
+ * `<code>` (F-255-06). A `user-select: all` span is a mouse affordance only: not focusable, no
+ * action, no accessible name. This is the same clipboard pattern as the rail's file-path copy
+ * (`RightPanel`: `navigator.clipboard.writeText` + a transient "copied"); where the clipboard API is
+ * unavailable (an insecure origin, an old embedder) the label says "copy failed" instead of
+ * pretending. Accessible name: `copy <command>` — the visible label stays one word.
+ */
+export function CopyButton({ command }: { command: string }): React.ReactElement {
+  const [state, setState] = useState<'idle' | 'copied' | 'failed'>('idle');
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (timer.current !== null) clearTimeout(timer.current);
+    },
+    [],
+  );
+
+  function flash(next: 'copied' | 'failed'): void {
+    setState(next);
+    if (timer.current !== null) clearTimeout(timer.current);
+    timer.current = setTimeout(() => {
+      setState('idle');
+      timer.current = null;
+    }, 2000);
+  }
+
+  function onCopy(): void {
+    const clip = typeof navigator === 'undefined' ? undefined : navigator.clipboard;
+    if (clip === undefined || typeof clip.writeText !== 'function') {
+      flash('failed');
+      return;
+    }
+    clip
+      .writeText(command)
+      .then(() => flash('copied'))
+      .catch(() => flash('failed'));
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onCopy}
+      aria-label={`copy ${command}`}
+      title={`copy ${command} to the clipboard`}
+      data-testid="copy-command"
+      data-command={command}
+      data-state={state}
+      className="px-1.5 rounded text-[10px] font-mono font-semibold align-baseline"
+      style={{
+        background: 'var(--surface-raised)',
+        color: state === 'failed' ? 'var(--status-fail)' : 'var(--ink-muted)',
+        border: '1px solid var(--surface-rail)',
+        cursor: 'pointer',
+      }}
+    >
+      {state === 'copied' ? 'copied' : state === 'failed' ? 'copy failed' : 'copy'}
+    </button>
+  );
+}

--- a/src/components/DeliverLift.tsx
+++ b/src/components/DeliverLift.tsx
@@ -2,9 +2,10 @@ import {
   liftIsFailure,
   liftOutcomeLabel,
   reverifyChangedTree,
+  splitElided,
   type DeliverLiftView,
 } from './deliverLiftModel.js';
-import { checkOutcome, formatDuration, shortId, splitBackticks } from './gateVerdictModel.js';
+import { checkOutcome, checkTails, formatDuration, shortId, splitBackticks } from './gateVerdictModel.js';
 
 /**
  * The deliver lift ON the card (wicked-core#431 / F-3R2-013, api-types 0.33.0): what the engine
@@ -144,6 +145,21 @@ export function DeliverLift({ view, omitFailure = false }: { view: DeliverLiftVi
                     {' · '}
                     {formatDuration(c.durationMs)}
                     {c.source !== '' && <span style={{ color: 'var(--ink-dim)' }}> · {c.source}</span>}
+                  
+                    {/* The evidence behind a red row (F-255-03): the stream tails the engine recorded, collapsed. */}
+                    {checkTails(c).map((t) => (
+                      <details key={t.stream} data-testid="deliver-lift-check-tail" data-stream={t.stream} className="mt-0.5">
+                        <summary className="cursor-pointer" style={{ color: 'var(--ink-muted)' }}>
+                          {t.stream} tail — the check&apos;s own output, verbatim
+                        </summary>
+                        <pre
+                          className="mt-1 p-1.5 rounded overflow-auto text-[10px] leading-snug"
+                          style={{ maxHeight: '12rem', whiteSpace: 'pre-wrap', overflowWrap: 'anywhere', background: 'var(--surface-rail)', color: 'var(--ink-high)' }}
+                        >
+                          {t.text}
+                        </pre>
+                      </details>
+                    ))}
                   </li>
                 );
               })}
@@ -157,16 +173,30 @@ export function DeliverLift({ view, omitFailure = false }: { view: DeliverLiftVi
         </div>
       )}
 
-      {/* The engine's refusal, VERBATIM — it carries the remedy; quoted refs render as copyable code. */}
+      {/* The engine's refusal as the WIRE carries it — `stepFailed.detail` is a head+tail excerpt (actor.rs
+        * `bounded_excerpt`), so an over-long refusal arrives with `[… N chars elided …]` between the kept
+        * halves: the words render verbatim, the marker dimmed; quoted refs render as copyable code (F-255-04).
+        * Omitted (`omitFailure`) when the surface already shows the same text — the gate prompt quotes it, a
+        * rejected unit's denial_reason frames it — so the refusal reads once (F-255-02). */}
       {view.failure !== null && !omitFailure && (
         <p data-testid="deliver-lift-failure" style={{ color: 'var(--status-fail)' }}>
-          {splitBackticks(view.failure).map((part, i) =>
-            i % 2 === 1 ? (
-              <code key={i} className="px-1 rounded" style={{ background: 'var(--surface-rail)', color: 'var(--ink-high)' }}>
-                {part}
-              </code>
+          {splitElided(view.failure).map((segment, s) =>
+            s % 2 === 1 ? (
+              <span key={`elided-${s}`} data-testid="deliver-lift-failure-elided" style={{ color: 'var(--ink-dim)' }}>
+                {' '}
+                {segment}
+                {' '}
+              </span>
             ) : (
-              <span key={i}>{part}</span>
+              splitBackticks(segment).map((part, i) =>
+                i % 2 === 1 ? (
+                  <code key={`${s}-${i}`} className="px-1 rounded" style={{ background: 'var(--surface-rail)', color: 'var(--ink-high)' }}>
+                    {part}
+                  </code>
+                ) : (
+                  <span key={`${s}-${i}`}>{part}</span>
+                ),
+              )
             ),
           )}
         </p>

--- a/src/components/DeliverLift.tsx
+++ b/src/components/DeliverLift.tsx
@@ -1,0 +1,176 @@
+import {
+  liftIsFailure,
+  liftOutcomeLabel,
+  reverifyChangedTree,
+  type DeliverLiftView,
+} from './deliverLiftModel.js';
+import { checkOutcome, formatDuration, shortId, splitBackticks } from './gateVerdictModel.js';
+
+/**
+ * The deliver lift ON the card (wicked-core#431 / F-3R2-013, api-types 0.33.0): what the engine
+ * did to the run's work before letting the deliver phase push, and — when it refused — why, in the
+ * engine's own words. A pure view over {@link DeliverLiftView}; the selection lives in
+ * `deliverLiftModel.ts`. Rendered by the rail's Delivery body, the deliver gate's card and the
+ * timeline's detail panel, so all three say the same thing.
+ *
+ * States, by `data-outcome`:
+ *  - `unchanged` — the base was already the remote tip; the verified tree ships as-is.
+ *  - `lifted`    — re-applied onto the tip (base and tree before → after); the repository's checks
+ *                  re-ran on the lifted tree — every row of that re-verify is listed.
+ *  - `conflict`  — the files the lift would conflict in, the fact that nothing was rebased or
+ *                  pushed, and the LIFT-CONFLICT remedy.
+ *  - `skipped` / `failed` — the engine's note, verbatim.
+ *  - `refused`   — no lift frame at all (a `HEAD` off the run branch, a tree that could not be
+ *                  snapshotted): only the engine-authored `deliver:` failure text exists, rendered
+ *                  on its own (wicked-core#433 final review — never assume the lift event exists).
+ *
+ * Copy rule, load-bearing: nothing here says "pushed" or "PR" — the lift precedes the push, and a
+ * `lifted`/`unchanged` outcome licenses only "the tree that would ship was verified". The push and
+ * the PR claim stay with the Delivery card's own url-gated arms.
+ */
+export function DeliverLift({ view, omitFailure = false }: { view: DeliverLiftView; omitFailure?: boolean }): React.ReactElement {
+  const failing = liftIsFailure(view);
+  const tone = failing ? 'var(--status-fail)' : view.outcome === 'skipped' ? 'var(--ink-muted)' : 'var(--status-done)';
+  const toneDim = failing ? 'var(--status-fail-dim)' : view.outcome === 'skipped' ? 'var(--surface-raised)' : 'var(--status-done-dim)';
+  const short7 = (id: string | null): string => (id === null ? '?' : shortId(id, 7));
+  const base = view.baseRef ?? 'the remote default branch';
+  const floor = view.reverify;
+  const changedTree = floor !== null && reverifyChangedTree(floor);
+
+  return (
+    <div
+      data-testid="deliver-lift"
+      data-outcome={view.outcome ?? 'refused'}
+      {...(view.attempt !== null ? { 'data-attempt': view.attempt } : {})}
+      className="rounded-lg p-2.5 flex flex-col gap-1 font-mono text-[11px]"
+      style={{ background: toneDim, border: `1px solid ${toneDim}`, color: 'var(--ink-body)', overflowWrap: 'anywhere' }}
+    >
+      <p className="text-xs font-semibold" style={{ color: tone }}>
+        Deliver lift — {liftOutcomeLabel(view.outcome)}
+      </p>
+
+      {view.outcome === 'unchanged' && (
+        <p data-testid="deliver-lift-summary">
+          {base} is still at {short7(view.baseBefore)} — the tree the checks verified is the tree that would ship
+          {view.treeBefore !== null && <span style={{ color: 'var(--ink-dim)' }}> (tree {shortId(view.treeBefore)})</span>}
+        </p>
+      )}
+
+      {view.outcome === 'lifted' && (
+        <p data-testid="deliver-lift-summary">
+          re-based onto {base} @ {short7(view.baseAfter)} (was {short7(view.baseBefore)})
+          {view.treeBefore !== null && view.treeAfter !== null && (
+            <span style={{ color: 'var(--ink-dim)' }}> · tree {shortId(view.treeBefore)} → {shortId(view.treeAfter)}</span>
+          )}
+          {floor === null && " · the repository's checks re-run on the lifted tree before any push"}
+        </p>
+      )}
+
+      {view.outcome === 'conflict' && (
+        <>
+          <p data-testid="deliver-lift-summary" style={{ color: 'var(--status-fail)' }}>
+            lifting the run's work onto {base} @ {short7(view.baseAfter)} would conflict in:{' '}
+            <span className="font-semibold" data-testid="deliver-lift-conflicts">
+              {view.conflicts.length === 0 ? '(no path listed)' : view.conflicts.join(', ')}
+            </span>
+            {' — the worktree was left exactly as verified'}
+            {view.baseBefore !== null && ` (base ${short7(view.baseBefore)})`}; nothing was rebased and nothing was pushed
+          </p>
+          <p data-testid="deliver-lift-remedy" style={{ color: 'var(--ink-body)' }}>
+            <span className="font-semibold">remedy:</span> on the run branch, rebase onto {base}, resolve{' '}
+            {view.conflicts.length === 0 ? 'the conflict' : view.conflicts.join(', ')}, regenerate any generated files and
+            re-run the repository's checks — then approve to retry the deliver phase, or reject to leave the work in
+            its worktree (the run reads as stranded until a PR is on record).
+          </p>
+        </>
+      )}
+
+      {view.outcome === 'skipped' && (
+        <p data-testid="deliver-lift-summary">
+          the lift could not be decided — {view.note ?? 'no reason recorded'}; the worktree was not touched and the
+          deliver script's own rebase stands
+        </p>
+      )}
+
+      {view.outcome === 'failed' && (
+        <p data-testid="deliver-lift-summary" style={{ color: 'var(--status-fail)' }}>
+          the lift was decided but could not be applied — {view.note ?? 'no reason recorded'}; the worktree may hold a
+          partial state and nothing was pushed
+        </p>
+      )}
+
+      {view.outcome !== null &&
+        !['unchanged', 'lifted', 'conflict', 'skipped', 'failed'].includes(view.outcome) && (
+          <p data-testid="deliver-lift-summary">
+            outcome &quot;{view.outcome}&quot; (a newer engine than this studio knows)
+            {view.note !== null && ` — ${view.note}`}
+          </p>
+        )}
+
+      {/* A disclosed degradation on an otherwise decided lift (a failed fetch, say) — the engine's words. */}
+      {view.note !== null && (view.outcome === 'unchanged' || view.outcome === 'lifted' || view.outcome === 'conflict') && (
+        <p data-testid="deliver-lift-note" style={{ color: 'var(--ink-muted)' }}>{view.note}</p>
+      )}
+
+      {floor !== null && (
+        <div data-testid="deliver-lift-floor" data-floor={floor.passed ? 'pass' : 'fail'} className="flex flex-col gap-0.5">
+          <p>
+            <span className="font-semibold" style={{ color: floor.passed ? 'var(--status-done)' : 'var(--status-fail)' }}>
+              repository checks re-run on the tree that would ship — {floor.passed ? 'pass' : 'fail'}
+            </span>
+            {floor.criterion !== '' && <span style={{ color: 'var(--ink-muted)' }}> · {floor.criterion}</span>}
+          </p>
+          {changedTree && (
+            <p data-testid="deliver-lift-changed-tree" style={{ color: 'var(--status-fail)' }}>
+              every check exited 0, yet the checks CHANGED the worktree while running — a tree nobody verified, so the
+              deliver failed closed (the refusal below names what moved)
+            </p>
+          )}
+          {floor.checks.length === 0 ? (
+            <p style={{ color: 'var(--ink-muted)' }}>
+              {floor.passed
+                ? 'no detectable check in this repository — a disclosed vacuous pass, not a green suite'
+                : 'the re-verify failed before any check ran'}
+            </p>
+          ) : (
+            <ul className="pl-3 list-disc">
+              {floor.checks.map((c) => {
+                const o = checkOutcome(c);
+                return (
+                  <li key={c.name} data-testid="deliver-lift-check" data-check={c.name} data-ok={o.ok ? 'true' : 'false'}>
+                    <span className="font-semibold">{c.name}</span>
+                    {' · '}
+                    <span style={{ color: o.ok ? 'var(--status-done)' : 'var(--status-fail)' }}>{o.word}</span>
+                    {' · '}
+                    {formatDuration(c.durationMs)}
+                    {c.source !== '' && <span style={{ color: 'var(--ink-dim)' }}> · {c.source}</span>}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+          {floor.skipped.length > 0 && (
+            <p data-testid="deliver-lift-skipped" style={{ color: 'var(--ink-muted)' }}>
+              skipped (an earlier check failed): {floor.skipped.join(', ')}
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* The engine's refusal, VERBATIM — it carries the remedy; quoted refs render as copyable code. */}
+      {view.failure !== null && !omitFailure && (
+        <p data-testid="deliver-lift-failure" style={{ color: 'var(--status-fail)' }}>
+          {splitBackticks(view.failure).map((part, i) =>
+            i % 2 === 1 ? (
+              <code key={i} className="px-1 rounded" style={{ background: 'var(--surface-rail)', color: 'var(--ink-high)' }}>
+                {part}
+              </code>
+            ) : (
+              <span key={i}>{part}</span>
+            ),
+          )}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/GateVerdict.tsx
+++ b/src/components/GateVerdict.tsx
@@ -1,5 +1,7 @@
+import { CopyButton } from './CopyButton.js';
 import {
   checkOutcome,
+  checkTails,
   denialSourceLabel,
   formatDuration,
   shortId,
@@ -170,7 +172,8 @@ export function GateVerdict({ view, phase }: { view: GateVerdictView; phase: str
                 style={{ background: 'var(--surface-rail)', color: 'var(--ink-high)', userSelect: 'all' }}
               >
                 git show {view.restore.suggestionRef}
-              </code>
+              </code>{' '}
+              <CopyButton command={`git show ${view.restore.suggestionRef}`} />
             </>
           )}
           {view.restore !== null && view.restore.suggestionRef === null && ' · the discarded edit was not pinned (no suggestion ref) — only the paths above record it'}
@@ -222,6 +225,21 @@ export function GateVerdict({ view, phase }: { view: GateVerdictView; phase: str
                     {' · '}
                     {formatDuration(c.durationMs)}
                     {c.source !== '' && <span style={{ color: 'var(--ink-dim)' }}> · {c.source}</span>}
+                  
+                    {/* The evidence behind a red row (F-255-03): the stream tails the engine recorded, collapsed. */}
+                    {checkTails(c).map((t) => (
+                      <details key={t.stream} data-testid="gate-verdict-check-tail" data-stream={t.stream} className="mt-0.5">
+                        <summary className="cursor-pointer" style={{ color: 'var(--ink-muted)' }}>
+                          {t.stream} tail — the check&apos;s own output, verbatim
+                        </summary>
+                        <pre
+                          className="mt-1 p-1.5 rounded overflow-auto text-[10px] leading-snug"
+                          style={{ maxHeight: '12rem', whiteSpace: 'pre-wrap', overflowWrap: 'anywhere', background: 'var(--surface-rail)', color: 'var(--ink-high)' }}
+                        >
+                          {t.text}
+                        </pre>
+                      </details>
+                    ))}
                   </li>
                 );
               })}

--- a/src/components/GateVerdict.tsx
+++ b/src/components/GateVerdict.tsx
@@ -2,6 +2,7 @@ import {
   checkOutcome,
   denialSourceLabel,
   formatDuration,
+  shortId,
   splitBackticks,
   type GateVerdictView,
 } from './gateVerdictModel.js';
@@ -22,8 +23,16 @@ import {
  *
  * The repo-checks floor (F-039) lists every check that ran — name, exit code, duration, the
  * manifest line it came from — and what was skipped, so "checks passed" is the exit codes the
- * engine observed, not the seat's account of them. The judge SEAT is not on the wire (api-types
- * 0.31.0), so no line claims one.
+ * engine observed, not the seat's account of them.
+ *
+ * wicked-core#431 (api-types 0.33.0) adds, each only when the frame carries it:
+ *  - the judge SEAT (`judgeCli`) on the header line, and — when `judgeDistinct` is `false` — a
+ *    warning that the judge was the same seat as the creator (evaluator ≠ creator is the doctrine;
+ *    a same-seat judge's independence is prompt-only). A frame without the field claims no seat.
+ *  - the restore state on a worktree-guard denial: `restored: true` says the evaluator's edit was
+ *    discarded and the creator's verified tree restored, lists the discarded paths from the
+ *    `worktreeRestored` record, and — when the edit was pinned — gives `git show <suggestionRef>`
+ *    as copyable code; `restored: false` says the restore failed and the manual remedy stands.
  *
  * Own testids (`gate-verdict-*`): the run page's `verdict-detail` card keeps its selector.
  */
@@ -45,7 +54,31 @@ export function GateVerdict({ view, phase }: { view: GateVerdictView; phase: str
     >
       <p className="text-xs font-semibold" style={{ color: tone }}>
         Evaluator verdict — {phase} · {word}
+        {view.judgeCli !== null && (
+          <span
+            data-testid="gate-verdict-judge-seat"
+            data-judge-cli={view.judgeCli}
+            data-judge-distinct={view.judgeDistinct === null ? 'unknown' : String(view.judgeDistinct)}
+            style={{ color: 'var(--ink-muted)' }}
+            title={
+              view.judgeDistinct === true
+                ? 'the judge ran on a seat identity-distinct from the creator (the rotation pick)'
+                : view.judgeDistinct === false
+                  ? 'the judge fell back to the single default runner — the same seat as the creator'
+                  : 'which seat rendered the judge verdict'
+            }
+          >
+            {' · '}judge: {view.judgeCli}
+          </span>
+        )}
       </p>
+
+      {view.judgeCli !== null && view.judgeDistinct === false && (
+        <p className="text-[11px]" data-testid="gate-verdict-judge-same-seat" style={{ color: 'var(--status-gate)' }}>
+          same seat as the creator — evaluator ≠ creator is not held on this verdict: the judge fell back to the
+          single default runner, so its independence is prompt-only
+        </p>
+      )}
 
       {view.criterion !== null && (
         <p className="text-[11px]" data-testid="gate-verdict-criterion" style={{ color: 'var(--ink-muted)' }}>
@@ -98,6 +131,58 @@ export function GateVerdict({ view, phase }: { view: GateVerdictView; phase: str
             </span>
           )}
           {view.mutation.headMoved && ' · the run branch moved'}
+        </p>
+      )}
+
+      {/* wicked-core#431 (F-3R2-010): the engine already ran the remedy. Say so, list exactly what was
+          thrown away (the worktreeRestored record; the mutation's own list when that frame is absent),
+          and hand over the pinned ref so the discarded edit can still be read. */}
+      {view.mutation !== null && view.mutation.restored === true && (
+        <p
+          className="text-[11px]"
+          data-testid="gate-verdict-restored"
+          {...(view.restore !== null && view.restore.suggestionRef !== null ? { 'data-suggestion-ref': view.restore.suggestionRef } : {})}
+          style={{ color: 'var(--ink-body)', overflowWrap: 'anywhere' }}
+        >
+          <span className="font-semibold" style={{ color: 'var(--status-done)' }}>
+            the evaluator&apos;s edit was discarded and the creator&apos;s verified tree restored
+          </span>
+          {' — discarded: '}
+          {(() => {
+            const paths = view.restore !== null ? view.restore.discarded : view.mutation.changed;
+            return paths.length === 0 ? 'no path listed' : paths.map((c) => `${c.status} ${c.path}`).join(', ');
+          })()}
+          {view.restore !== null && view.restore.tree !== '' && (
+            <span style={{ color: 'var(--ink-dim)' }}> (tree {shortId(view.restore.tree)})</span>
+          )}
+          {view.restore !== null && view.restore.head !== null && ` · HEAD reset to ${shortId(view.restore.head, 7)}`}
+          {view.restore !== null && view.restore.suggestionRef !== null && (
+            <>
+              {' · the edit is kept at '}
+              <code className="px-1 rounded" style={{ background: 'var(--surface-rail)', color: 'var(--ink-high)' }}>
+                {view.restore.suggestionRef}
+              </code>
+              {' — read it back with '}
+              <code
+                data-testid="gate-verdict-suggestion-hint"
+                className="px-1 rounded"
+                title="click to select, then copy"
+                style={{ background: 'var(--surface-rail)', color: 'var(--ink-high)', userSelect: 'all' }}
+              >
+                git show {view.restore.suggestionRef}
+              </code>
+            </>
+          )}
+          {view.restore !== null && view.restore.suggestionRef === null && ' · the discarded edit was not pinned (no suggestion ref) — only the paths above record it'}
+          {view.restore === null && ' (paths from the mutation record — no restore record in the log)'}
+        </p>
+      )}
+
+      {view.mutation !== null && view.mutation.restored === false && (
+        <p className="text-[11px]" data-testid="gate-verdict-restore-failed" style={{ color: 'var(--status-fail)', overflowWrap: 'anywhere' }}>
+          the creator&apos;s tree was NOT restored
+          {view.mutation.restoreError !== null && `: ${view.mutation.restoreError}`}
+          {' — the manual remedy in the denial stands; approving retries against the tree as it is'}
         </p>
       )}
 

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -679,10 +679,12 @@ export function RightPanel({ view, runs, onSelectRun }: Props): React.ReactEleme
                 {openId === id ? '▲' : '▼'}
               </span>
             </button>
-            {/* Delivery derives from the `view` prop alone (zero events, zero
+            {/* Delivery derives its CLAIM from the `view` prop alone (zero
                 model), so it never waits on the snapshot the other bodies need
                 — a run that opened a PR says so on the first paint of the
-                section, not after the re-hydrate lands. */}
+                section, not after the re-hydrate lands. The deliver-lift block
+                it also renders (wicked-core#431) reads the run event store the
+                page already hydrated — still zero requests of its own. */}
             {openId === id && id === 'delivery' && (
               <div className="px-4 py-3" style={{ background: 'var(--surface-base)' }}>
                 <RunDelivery view={view} />

--- a/src/components/RunDelivery.tsx
+++ b/src/components/RunDelivery.tsx
@@ -5,7 +5,7 @@ import { useRunEventStore } from '../store/events.js';
 import { usePostHocDeliverStore } from '../store/postHocDeliver.js';
 import { useIsSystemWorkflow } from '../store/workflowCache.js';
 import { DeliverLift } from './DeliverLift.js';
-import { deliverLift } from './deliverLiftModel.js';
+import { deliverLift, textCarriesFailure } from './deliverLiftModel.js';
 import {
   DELIVERY_COLOR,
   DELIVERY_LABEL,
@@ -268,10 +268,13 @@ export function RunDelivery({ view }: Props): React.ReactElement {
   const events = useRunEventStore((s) => s.byRun[runId]) ?? EMPTY_EVENTS;
   const deliverOrd = unitId === null ? null : (view.units.find((u) => u.id === unitId)?.ord ?? null);
   const lift = useMemo(() => (deliverOrd === null ? null : deliverLift(events, deliverOrd)), [events, deliverOrd]);
-  // A rejected deliver unit's `denial_reason` (rendered VERBATIM below) usually IS the engine's
-  // refusal that the lift view also holds as `failure` — the same text twice on one card is noise,
-  // so the lift block omits its copy when the reason already contains it.
-  const liftOmitsFailure = lift !== null && lift.failure !== null && reason !== null && reason.includes(lift.failure);
+  // A rejected deliver unit's `denial_reason` (rendered VERBATIM below) carries the engine's refusal
+  // the lift view also holds as `failure` — FRAMED (`Worker FAILED on unit N: …`) and excerpted
+  // differently from `stepFailed.detail` (actor.rs: 300/500 vs 150/250 head+tail) — so the lift block
+  // omits its copy when every segment the detail kept is already in the reason (`textCarriesFailure`,
+  // F-255-02/04). `reason` is `null` unless the claim is failed / nothing-to-deliver — exactly when it
+  // renders — so the omission can never hide a refusal the card is not otherwise showing.
+  const liftOmitsFailure = lift !== null && lift.failure !== null && textCarriesFailure(reason, lift.failure);
 
   // The licence — for the remedy line, and (in the caller) for the whole `'none'`
   // arm this body would otherwise open with "This run has no deliver phase":

--- a/src/components/RunDelivery.tsx
+++ b/src/components/RunDelivery.tsx
@@ -1,8 +1,11 @@
-import { useEffect } from 'react';
-import type { SessionView } from '../api/types.js';
+import { useEffect, useMemo } from 'react';
+import type { CoreEvent, SessionView } from '../api/types.js';
 import { useDeliveryStore } from '../store/delivery.js';
+import { useRunEventStore } from '../store/events.js';
 import { usePostHocDeliverStore } from '../store/postHocDeliver.js';
 import { useIsSystemWorkflow } from '../store/workflowCache.js';
+import { DeliverLift } from './DeliverLift.js';
+import { deliverLift } from './deliverLiftModel.js';
 import {
   DELIVERY_COLOR,
   DELIVERY_LABEL,
@@ -12,6 +15,8 @@ import {
   type DeliveryClaim,
 } from './delivery.js';
 import { compactPath } from './WhatWhere.js';
+
+const EMPTY_EVENTS: CoreEvent[] = [];
 
 /**
  * The Delivery views (wicked-studio#122, slice DA) — what a run PRODUCED, in the
@@ -26,6 +31,12 @@ import { compactPath } from './WhatWhere.js';
  *    accent and the link arrive together with the url or not at all.
  *  - The deliver phase opens a PR and STOPS. Nothing here says "shipped" and
  *    nothing says "merged" — merge stays human.
+ *
+ * wicked-core#431 (api-types 0.33.0): the rail body ALSO renders the deliver lift's story off the
+ * run's already-hydrated event log ({@link DeliverLift} — what the engine did to the work before
+ * letting the phase push, the re-verify on the tree that would ship, the engine's refusal verbatim).
+ * Still zero requests: the event store is what the run page hydrated. The badge and the chips stay
+ * DTO-only.
  */
 
 interface Props {
@@ -251,6 +262,17 @@ export function RunDelivery({ view }: Props): React.ReactElement {
 
   const workdir = view.session.workdir;
 
+  // The deliver lift (wicked-core#431 / F-3R2-013): the deliver unit's newest attempt, off the log.
+  // Keyed on the deliver unit's ORD — `deliverLift` scopes to it, so a verify phase's floor is never
+  // read as the deliver re-verify — and `null` without a deliver unit (the post-hoc path has none).
+  const events = useRunEventStore((s) => s.byRun[runId]) ?? EMPTY_EVENTS;
+  const deliverOrd = unitId === null ? null : (view.units.find((u) => u.id === unitId)?.ord ?? null);
+  const lift = useMemo(() => (deliverOrd === null ? null : deliverLift(events, deliverOrd)), [events, deliverOrd]);
+  // A rejected deliver unit's `denial_reason` (rendered VERBATIM below) usually IS the engine's
+  // refusal that the lift view also holds as `failure` — the same text twice on one card is noise,
+  // so the lift block omits its copy when the reason already contains it.
+  const liftOmitsFailure = lift !== null && lift.failure !== null && reason !== null && reason.includes(lift.failure);
+
   // The licence — for the remedy line, and (in the caller) for the whole `'none'`
   // arm this body would otherwise open with "This run has no deliver phase":
   // `is_system === false`, a def IN HAND that carries no flag (the daemon omits
@@ -390,6 +412,12 @@ export function RunDelivery({ view }: Props): React.ReactElement {
             : 'launch with deliver: pr to have the run open a PR from its worktree'}
         </p>
       )}
+
+      {/* What the engine did before the push — and, when it refused, why (wicked-core#431). Last, so
+        * a failed claim's "Crew recorded:" reads straight into the unit's own reason and the lift
+        * card then explains it (the remedy included); absent entirely on a daemon that never sent a
+        * deliver-ord frame. */}
+      {lift !== null && <DeliverLift view={lift} omitFailure={liftOmitsFailure} />}
     </div>
   );
 }

--- a/src/components/RunTimeline.tsx
+++ b/src/components/RunTimeline.tsx
@@ -2,7 +2,11 @@ import { Fragment, useEffect, useMemo, useState } from 'react';
 import type { CoreEvent, SessionView, WorkUnit } from '../api/types.js';
 import { useRunEventStore } from '../store/events.js';
 import { useProvenanceStore } from '../store/provenance.js';
+import { DeliverLift } from './DeliverLift.js';
+import { deliverLift, liftOutcomeLabel } from './deliverLiftModel.js';
+import { shortId } from './gateVerdictModel.js';
 import { ProvenanceLine } from './ProvenanceLine.js';
+import { runBaseLine, runBaseOf } from './runBaseModel.js';
 import { VerdictDetail } from './VerdictDetail.js';
 import { WorkUnitDetail } from './WorkUnitDetail.js';
 
@@ -19,6 +23,13 @@ import { WorkUnitDetail } from './WorkUnitDetail.js';
  * (joined from the SessionView's units by `ord`). The derivation is
  * O(units + events) per render, memoized; CREW-UX-6 (explicit boundary events)
  * remains the optimization seam if logs outgrow it.
+ *
+ * wicked-core#431 (api-types 0.33.0) adds four rows, each only when its frame is
+ * in the log: `runBaseResolved` (the one-line "based on origin/<ref> @ <commit>,
+ * N behind, lifted" note at the head), `worktreeRestored` (the creator's tree put
+ * back after an evaluator mutation), `deliverLiftEvaluated` (the pre-push lift's
+ * outcome — its detail is the shared {@link DeliverLift} card) and
+ * `evaluatorToolCallDenied` (a write-class tool call refused at the ACP boundary).
  */
 
 /** The event types that constitute a run's timeline (§2.2); everything else is skipped. */
@@ -66,6 +77,11 @@ export function timelineRows(events: readonly CoreEvent[], units: readonly WorkU
     };
     switch (e.type) {
       case 'sessionStarted': push('run-started', hhmmss(e.ts), null); break;
+      case 'runBaseResolved': {
+        const base = runBaseOf(e);
+        if (base !== null) push('based on', runBaseLine(base), null);
+        break;
+      }
       case 'workflowSelected': push('workflow', str(e.workflowId) || str(e.workflow_id), null); break;
       case 'unitPlanned': push('planned', str(e.description), null); break;
       case 'unitDispatched':
@@ -75,6 +91,24 @@ export function timelineRows(events: readonly CoreEvent[], units: readonly WorkU
       case 'stepFailed': push('✗ failed', str(e['failureKind']) || str(e.detail), phase, 'fail'); break;
       case 'crashRecoveryRedrive': push('↩ retry', `attempt ${attempt}`, phase); break;
       case 'gateEscalated': push('gate', str(e['condition']), 'gate', 'gate'); break;
+      case 'worktreeRestored': {
+        const n = Array.isArray(e.discarded) ? e.discarded.length : 0;
+        push('↺ restored', `creator tree ${str(e.tree) ? shortId(str(e.tree)) : '?'} · ${n} path${n === 1 ? '' : 's'} discarded`, phase, 'gate');
+        break;
+      }
+      case 'evaluatorToolCallDenied':
+        push('✗ write refused', `${str(e.cli) || '?'} · ${str(e['tool']) || 'a write tool'}${str(e['path']) ? ` ${str(e['path'])}` : ''}`, phase, 'fail');
+        break;
+      case 'deliverLiftEvaluated': {
+        const outcome = str(e.outcome) || null;
+        const conflicts = Array.isArray(e['conflicts']) ? (e['conflicts'] as unknown[]).filter((c): c is string => typeof c === 'string') : [];
+        const meta =
+          outcome === 'conflict' ? `${liftOutcomeLabel(outcome)} · ${conflicts.join(', ') || 'no path listed'}`
+          : outcome === 'lifted' ? `${liftOutcomeLabel(outcome)} · ${str(e['baseRef']) || 'remote'} @ ${str(e['baseAfter']) ? shortId(str(e['baseAfter']), 7) : '?'}`
+          : `${liftOutcomeLabel(outcome)}${str(e['note']) ? ` · ${str(e['note'])}` : ''}`;
+        push('lift', meta, phase, outcome === 'conflict' || outcome === 'failed' ? 'fail' : null);
+        break;
+      }
       case 'gateEvaluated': push('verdict', e.combined === true ? 'pass' : 'deny', 'gate', 'gate'); break;
       case 'unitReworkAmended': push('amended', str(e.amendment), 'gate', 'amend'); break;
       case 'sessionCompleted': push('run-ended', 'completed', null); break;
@@ -198,6 +232,75 @@ export function RunTimeline({ view, navigate, onOpenFile }: Props): React.ReactE
         );
       case 'sessionStarted':
         return <StartDetail runId={session.id} problem={session.problem} />;
+      case 'runBaseResolved': {
+        const base = runBaseOf(e);
+        return (
+          <div data-testid="run-base-detail" className="flex flex-col gap-1.5">
+            <p className="text-xs font-semibold font-mono" style={{ color: 'var(--ink-body)' }}>
+              Run base — {base === null ? '(unreadable frame)' : runBaseLine(base)}
+            </p>
+            {base !== null && (
+              <p className="text-xs font-mono" style={{ color: 'var(--ink-muted)' }}>
+                worktree minted from {base.baseCommit}
+                {base.localHead !== '' && ` · the registered clone's HEAD was ${base.localHead}`}
+                {` · git fetch origin ${base.fetched ? 'succeeded' : 'FAILED (cached refs used)'}`}
+              </p>
+            )}
+            {base !== null && base.note !== null && (
+              <p className="text-xs" style={{ color: 'var(--ink-muted)' }}>{base.note}</p>
+            )}
+          </div>
+        );
+      }
+      case 'deliverLiftEvaluated': {
+        const lift = ord !== null ? deliverLift(events, ord) : null;
+        return lift !== null ? (
+          <DeliverLift view={lift} />
+        ) : (
+          <p className="text-xs font-mono" style={{ color: 'var(--ink-muted)' }}>lift · {str(e.outcome) || '?'}</p>
+        );
+      }
+      case 'worktreeRestored': {
+        const discarded = Array.isArray(e.discarded)
+          ? (e.discarded as unknown[]).filter((c): c is { path: string; status: string } =>
+              typeof c === 'object' && c !== null && typeof (c as { path?: unknown }).path === 'string' && typeof (c as { status?: unknown }).status === 'string')
+          : [];
+        const ref = str(e['suggestionRef']) || null;
+        return (
+          <div data-testid="worktree-restored-detail" className="flex flex-col gap-1.5" style={{ overflowWrap: 'anywhere' }}>
+            <p className="text-xs font-semibold font-mono" style={{ color: 'var(--status-gate)' }}>
+              Creator tree restored — unit {ord ?? '?'} · {str(e.phase) || 'phase'} by {str(e.cli) || 'the seat'}
+            </p>
+            <p className="text-xs font-mono" style={{ color: 'var(--ink-body)' }}>
+              discarded: {discarded.length === 0 ? 'no path listed' : discarded.map((c) => `${c.status} ${c.path}`).join(', ')}
+              {str(e.tree) && <span style={{ color: 'var(--ink-dim)' }}> · tree {shortId(str(e.tree))}</span>}
+              {str(e.head) && ` · HEAD reset to ${shortId(str(e.head), 7)}`}
+            </p>
+            <p className="text-xs font-mono" style={{ color: 'var(--ink-muted)' }}>
+              {ref !== null ? (
+                <>
+                  the discarded edit is kept at <code>{ref}</code> — <code style={{ userSelect: 'all' }}>git show {ref}</code>
+                </>
+              ) : (
+                'the discarded edit was not pinned (no suggestion ref)'
+              )}
+            </p>
+          </div>
+        );
+      }
+      case 'evaluatorToolCallDenied':
+        return (
+          <div data-testid="tool-call-denied-detail" className="flex flex-col gap-1.5" style={{ overflowWrap: 'anywhere' }}>
+            <p className="text-xs font-semibold font-mono" style={{ color: 'var(--status-fail)' }}>
+              Write refused — unit {ord ?? '?'} · {str(e.cli) || 'the seat'} asked for {str(e['tool']) || 'a write tool'}
+              {str(e['path']) && ` on ${str(e['path'])}`}
+            </p>
+            <p className="text-xs font-mono" style={{ color: 'var(--ink-body)' }}>{str(e['reason']) || '(no reason recorded)'}</p>
+            <p className="text-xs font-mono" style={{ color: 'var(--ink-muted)' }}>
+              refused at the {str(e['carrier']) || 'acp'} permission boundary — a read-only phase may not edit; the call cost the seat one tool call, not the phase a retry
+            </p>
+          </div>
+        );
       case 'gateEscalated':
         return (
           <div className="flex flex-col gap-1.5">

--- a/src/components/RunTimeline.tsx
+++ b/src/components/RunTimeline.tsx
@@ -2,6 +2,7 @@ import { Fragment, useEffect, useMemo, useState } from 'react';
 import type { CoreEvent, SessionView, WorkUnit } from '../api/types.js';
 import { useRunEventStore } from '../store/events.js';
 import { useProvenanceStore } from '../store/provenance.js';
+import { CopyButton } from './CopyButton.js';
 import { DeliverLift } from './DeliverLift.js';
 import { deliverLift, liftOutcomeLabel } from './deliverLiftModel.js';
 import { shortId } from './gateVerdictModel.js';
@@ -279,7 +280,9 @@ export function RunTimeline({ view, navigate, onOpenFile }: Props): React.ReactE
             <p className="text-xs font-mono" style={{ color: 'var(--ink-muted)' }}>
               {ref !== null ? (
                 <>
-                  the discarded edit is kept at <code>{ref}</code> — <code style={{ userSelect: 'all' }}>git show {ref}</code>
+                  the discarded edit is kept at <code>{ref}</code> —{' '}
+                  <code style={{ userSelect: 'all' }} title="click to select, then copy">git show {ref}</code>{' '}
+                  <CopyButton command={`git show ${ref}`} />
                 </>
               ) : (
                 'the discarded edit was not pinned (no suggestion ref)'

--- a/src/components/SteeringGate.tsx
+++ b/src/components/SteeringGate.tsx
@@ -9,10 +9,10 @@ import { durableGuidance, useGuidanceStore } from '../store/guidance.js';
 import { useGateStore } from '../store/gates.js';
 import { useSteeringStore, type SteeringAction } from '../store/steering.js';
 import { DeliverLift } from './DeliverLift.js';
-import { deliverLift } from './deliverLiftModel.js';
+import { deliverLift, textCarriesFailure } from './deliverLiftModel.js';
 import { GATE_HASH } from './GateChip.js';
 import { GateVerdict } from './GateVerdict.js';
-import { gateVerdict, phaseLabel } from './gateVerdictModel.js';
+import { gateVerdict, isRestoredRetry, phaseLabel } from './gateVerdictModel.js';
 
 interface Props {
   runId: string;
@@ -68,15 +68,21 @@ export function SteeringGate({ runId, ord, prompt, guidance, repoRef, units, onR
   // what the lift did and the engine's remedy on the card. A pre-run deliver gate has no deliver-ord
   // frames yet and renders nothing; so does every non-deliver gate.
   const lift = useMemo(() => (typeof ord === 'number' ? deliverLift(events, ord) : null), [events, ord]);
-  // wicked-core#431 (F-3R2-010): when the deciding denial is THIS unit's worktree-guard denial and the
+  // wicked-core#431 (F-3R2-010): when the deciding denial is THIS unit's WORKTREE-GUARD denial and the
   // engine restored the creator's tree, Approve no longer means "adopt the evaluator's edit and retry"
   // — it means a retry against the restored, verified tree, and the button says so. The engine's
   // `awaitingHuman.prompt` changed with it ("… its edit was discarded and the creator's verified tree
   // restored. Approve to retry the phase against the restored tree …"); the relabel keys on the
   // EVIDENCE frames, not on that prose, so a daemon that sends the frames with any prompt relabels and
-  // one that predates them never does.
-  const restoredRetry =
-    verdict !== null && verdict.outcome === 'fail' && verdict.ord === ord && verdict.mutation?.restored === true;
+  // one that predates them never does. ONE predicate for every gate card — the landing inbox's card
+  // uses the same `isRestoredRetry` — mirroring the engine's own guard (`denial.source ==
+  // "worktree_guard" && mutation.restored`), so no surface relabels where the engine kept the legacy prompt.
+  const restoredRetry = isRestoredRetry(verdict, ord);
+  // The engine's triage-escalate prompt already QUOTES the deliver refusal (`Unit N failed and triage
+  // escalated: … Failure output: "<excerpt>". Approve to retry …`), so the lift block omits its copy
+  // when the prompt carries it — the refusal reads ONCE on the card (F-255-02). A prompt that does
+  // not (the daemon-restart fallback, an older engine's wording) leaves the block to say it.
+  const liftOmitsFailure = lift !== null && lift.failure !== null && textCarriesFailure(prompt, lift.failure);
   // Slice BD (DES-UX-002 §4.3, EC51): gate arrival pre-populates the steer
   // textarea — the gate card MOUNTING is the arrival on this surface. Slice BE
   // added the durable layer (CREW-UX-7): pre-population order is the run DTO's
@@ -289,7 +295,7 @@ export function SteeringGate({ runId, ord, prompt, guidance, repoRef, units, onR
       )}
 
       {/* The deliver lift + the engine's refusal for a gate on the deliver unit (wicked-core#431). */}
-      {lift !== null && <DeliverLift view={lift} />}
+      {lift !== null && <DeliverLift view={lift} omitFailure={liftOmitsFailure} />}
 
       {/* Coverage stats — shown when evaluator gate fails and we have repo coverage data */}
       {isCoverageFail && coverage && (

--- a/src/components/SteeringGate.tsx
+++ b/src/components/SteeringGate.tsx
@@ -235,8 +235,8 @@ export function SteeringGate({ runId, ord, prompt, guidance, repoRef, units, onR
     prompt ?? 'Prompt unavailable (daemon restarted) — you can still approve or reject.',
   );
 
-  // Both mutation-gate prompts the engine has shipped — the pre-0.33.0 "confirm to retry the phase"
-  // and wicked-core#431's "… Approve to retry the phase against the restored tree …" — carry
+  // Both mutation-gate prompts the engine has shipped — the pre-0.33.0 retry-or-reject wording and
+  // wicked-core#431's "… Approve to retry the phase against the restored tree …" — carry
   // "NOT PASS", so this match holds across the wording change (re-checked for api-types 0.33.0).
   const isCoverageFail = headline.toLowerCase().includes('not pass') || headline.toLowerCase().includes('coverage');
 

--- a/src/components/SteeringGate.tsx
+++ b/src/components/SteeringGate.tsx
@@ -8,6 +8,8 @@ import { useRunEventStore } from '../store/events.js';
 import { durableGuidance, useGuidanceStore } from '../store/guidance.js';
 import { useGateStore } from '../store/gates.js';
 import { useSteeringStore, type SteeringAction } from '../store/steering.js';
+import { DeliverLift } from './DeliverLift.js';
+import { deliverLift } from './deliverLiftModel.js';
 import { GATE_HASH } from './GateChip.js';
 import { GateVerdict } from './GateVerdict.js';
 import { gateVerdict, phaseLabel } from './gateVerdictModel.js';
@@ -61,6 +63,20 @@ export function SteeringGate({ runId, ord, prompt, guidance, repoRef, units, onR
   // the run's own cursor when the daemon-restart fallback lost the prompt.
   const events = useRunEventStore((s) => s.byRun[runId]) ?? EMPTY_EVENTS;
   const verdict = useMemo(() => (typeof ord === 'number' ? gateVerdict(events, ord) : null), [events, ord]);
+  // The deliver lift's story for THIS ord (wicked-core#431 / F-3R2-013): a gate opened on a deliver
+  // unit the engine refused (LIFT-CONFLICT, a failed re-verify, a HEAD off the run branch) renders
+  // what the lift did and the engine's remedy on the card. A pre-run deliver gate has no deliver-ord
+  // frames yet and renders nothing; so does every non-deliver gate.
+  const lift = useMemo(() => (typeof ord === 'number' ? deliverLift(events, ord) : null), [events, ord]);
+  // wicked-core#431 (F-3R2-010): when the deciding denial is THIS unit's worktree-guard denial and the
+  // engine restored the creator's tree, Approve no longer means "adopt the evaluator's edit and retry"
+  // — it means a retry against the restored, verified tree, and the button says so. The engine's
+  // `awaitingHuman.prompt` changed with it ("… its edit was discarded and the creator's verified tree
+  // restored. Approve to retry the phase against the restored tree …"); the relabel keys on the
+  // EVIDENCE frames, not on that prose, so a daemon that sends the frames with any prompt relabels and
+  // one that predates them never does.
+  const restoredRetry =
+    verdict !== null && verdict.outcome === 'fail' && verdict.ord === ord && verdict.mutation?.restored === true;
   // Slice BD (DES-UX-002 §4.3, EC51): gate arrival pre-populates the steer
   // textarea — the gate card MOUNTING is the arrival on this surface. Slice BE
   // added the durable layer (CREW-UX-7): pre-population order is the run DTO's
@@ -219,6 +235,9 @@ export function SteeringGate({ runId, ord, prompt, guidance, repoRef, units, onR
     prompt ?? 'Prompt unavailable (daemon restarted) — you can still approve or reject.',
   );
 
+  // Both mutation-gate prompts the engine has shipped — the pre-0.33.0 "confirm to retry the phase"
+  // and wicked-core#431's "… Approve to retry the phase against the restored tree …" — carry
+  // "NOT PASS", so this match holds across the wording change (re-checked for api-types 0.33.0).
   const isCoverageFail = headline.toLowerCase().includes('not pass') || headline.toLowerCase().includes('coverage');
 
   return (
@@ -236,6 +255,7 @@ export function SteeringGate({ runId, ord, prompt, guidance, repoRef, units, onR
       }}
       data-testid="steering-gate"
       data-run-id={runId}
+      {...(restoredRetry ? { 'data-retry-restored': 'true' } : {})}
     >
       <div className="flex items-center gap-2 mb-2">
         <span className="w-2 h-2 rounded-full animate-pulse" style={{ background: 'var(--status-gate)' }} />
@@ -267,6 +287,9 @@ export function SteeringGate({ runId, ord, prompt, guidance, repoRef, units, onR
       {verdict !== null && (
         <GateVerdict view={verdict} phase={phaseLabel(runId, units ?? EMPTY_UNITS, verdict.ord)} />
       )}
+
+      {/* The deliver lift + the engine's refusal for a gate on the deliver unit (wicked-core#431). */}
+      {lift !== null && <DeliverLift view={lift} />}
 
       {/* Coverage stats — shown when evaluator gate fails and we have repo coverage data */}
       {isCoverageFail && coverage && (
@@ -334,8 +357,9 @@ export function SteeringGate({ runId, ord, prompt, guidance, repoRef, units, onR
           disabled={loading}
           className="rounded-lg px-3 py-2 text-xs font-semibold font-mono disabled:opacity-50 transition-opacity"
           style={{ background: 'var(--status-run)', color: 'var(--surface-base)' }}
+          {...(restoredRetry ? { title: "the evaluator's edit was discarded; the phase re-runs against the creator's verified tree" } : {})}
         >
-          Approve
+          {restoredRetry ? 'Retry against the restored tree' : 'Approve'}
         </button>
         <button
           data-testid="steering-approve-steer"
@@ -344,7 +368,7 @@ export function SteeringGate({ runId, ord, prompt, guidance, repoRef, units, onR
           className="rounded-lg px-3 py-2 text-xs font-semibold font-mono disabled:opacity-50 transition-opacity"
           style={{ background: 'var(--accent)', color: 'var(--accent-fg)' }}
         >
-          Approve + steer
+          {restoredRetry ? 'Retry + steer' : 'Approve + steer'}
         </button>
         <button
           data-testid="steering-reject"
@@ -369,7 +393,7 @@ export function SteeringGate({ runId, ord, prompt, guidance, repoRef, units, onR
       {/* Mode-selector note: workflow gates are always HITL regardless of run-level human_confirm */}
       <p className="text-[10px] font-mono mt-2" style={{ color: 'var(--ink-dim)' }}>
         Workflow-declared gate — run-level human_confirm setting does not apply here.
-        {' '}· a approve · r reject while this card holds focus
+        {' '}· a {restoredRetry ? 'retry' : 'approve'} · r reject while this card holds focus
       </p>
     </div>
   );

--- a/src/components/WhatWhere.tsx
+++ b/src/components/WhatWhere.tsx
@@ -1,7 +1,13 @@
+import { useMemo } from 'react';
+import type { CoreEvent } from '../api/types.js';
 import type { RunModel } from '../hooks/useRunModel.js';
+import { useRunEventStore } from '../store/events.js';
 import type { Provenance } from '../store/provenance.js';
 import { ProvenanceLine } from './ProvenanceLine.js';
+import { runBase, runBaseLine } from './runBaseModel.js';
 import { RunTimes } from './runIdentity.js';
+
+const EMPTY_EVENTS: CoreEvent[] = [];
 
 interface Props {
   model: RunModel;
@@ -12,11 +18,11 @@ interface Props {
   onSelectRun?: (id: string) => void;
 }
 
-function Row({ label, value, mono, title }: {
-  label: string; value: string; mono?: boolean; title?: string;
+function Row({ label, value, mono, title, testId }: {
+  label: string; value: string; mono?: boolean; title?: string; testId?: string;
 }): React.ReactElement {
   return (
-    <div className="flex gap-2 text-[11px]">
+    <div className="flex gap-2 text-[11px]" {...(testId !== undefined ? { 'data-testid': testId } : {})}>
       <span className="w-20 shrink-0 font-mono" style={{ color: 'var(--ink-dim)' }}>{label}</span>
       <span
         className={mono ? 'font-mono break-all' : ''}
@@ -42,6 +48,11 @@ export function compactPath(p: string): string {
 
 export function WhatWhere({ model, provenance, retriedAs, onSelectRun }: Props): React.ReactElement {
   const { session } = model;
+  // wicked-core#431 (api-types 0.33.0): the run's base — "origin/main @ <commit> · N behind · lifted
+  // to the tip" — off the `runBaseResolved` frame the engine emits once per freshly minted worktree.
+  // A resumed run and a pre-0.33.0 daemon send none: the row is then absent, never a guessed base.
+  const events = useRunEventStore((s) => s.byRun[session.id]) ?? EMPTY_EVENTS;
+  const base = useMemo(() => runBase(events), [events]);
 
   return (
     <div data-testid="what-where" className="flex flex-col gap-1.5">
@@ -72,6 +83,15 @@ export function WhatWhere({ model, provenance, retriedAs, onSelectRun }: Props):
         mono
         {...(session.workdir !== undefined && session.workdir !== null ? { title: session.workdir } : {})}
       />
+      {base !== null && (
+        <Row
+          label="base"
+          value={runBaseLine(base)}
+          mono
+          testId="run-base"
+          {...(base.note !== null ? { title: base.note } : {})}
+        />
+      )}
       <Row label="roster" value={session.clis.length > 0 ? session.clis.join(', ') : '—'} mono />
       <Row label="entity" value={session.entity_mode} />
     </div>

--- a/src/components/deliverLiftModel.ts
+++ b/src/components/deliverLiftModel.ts
@@ -173,3 +173,37 @@ export function reverifyChangedTree(floor: GateFloorView): boolean {
     floor.checks.every((c) => c.exitCode === 0 && !c.timedOut && c.spawnError === null)
   );
 }
+
+/** The engine's elision marker, as `bounded_excerpt` (wicked-core `actor.rs`) writes it between the
+ *  kept head and tail of an over-long output: `{head}\n[… N chars elided …]\n{tail}`. */
+export const ELISION_MARKER = /\[… \d+ chars elided …\]/;
+
+/** `text` cut at the engine's elision marker(s): even indices are the words the wire KEPT, odd
+ *  indices the markers themselves — so a view can dim the marker and keep the words verbatim. */
+export function splitElided(text: string): string[] {
+  return text.split(/(\[… \d+ chars elided …\])/);
+}
+
+/**
+ * Whether `text` — a gate prompt, a unit's `denial_reason` — already carries `failure` (the deliver
+ * unit's `stepFailed.detail`), so a surface that renders both never prints the engine's refusal twice
+ * (F-255-02).
+ *
+ * `text.includes(failure)` is not enough because of what the wire does to the words (wicked-core
+ * `actor.rs`): `detail` is a HEAD+TAIL excerpt — `bounded_excerpt(…, 150, 250)` on the failure-triage
+ * path, 300/500 on the plain worker-failure path — with `[… N chars elided …]` between the halves once
+ * the refusal outgrows the bound, while the triage-escalate prompt quotes a WIDER excerpt (450/750:
+ * `… Failure output: "<excerpt>". Approve to retry …`) and a rejected unit's `denial_reason` frames
+ * its own (`Worker FAILED on unit N: <excerpt>`). Every segment the detail kept is a substring of any
+ * wider excerpt of the same output — a head+tail excerpt keeps the original head and the original
+ * tail — so the test is: each kept segment of `failure` occurs in `text`. Nothing on either side is
+ * nothing to compare, never a match.
+ */
+export function textCarriesFailure(text: string | null | undefined, failure: string | null): boolean {
+  if (text === null || text === undefined || failure === null) return false;
+  const kept = splitElided(failure)
+    .filter((_, i) => i % 2 === 0)
+    .map((s) => s.trim())
+    .filter((s) => s !== '');
+  return kept.length > 0 && kept.every((s) => text.includes(s));
+}

--- a/src/components/deliverLiftModel.ts
+++ b/src/components/deliverLiftModel.ts
@@ -1,0 +1,175 @@
+import type { CoreEvent } from '../api/types.js';
+import { floorOf, type GateFloorView } from './gateVerdictModel.js';
+
+/**
+ * deliverLift — the deliver phase's pre-push story, read off the run's event log
+ * (wicked-core#431 / F-3R2-013, api-types 0.33.0; the studio half of wicked-crew#527).
+ *
+ * Before the run's `deliver` Tool phase pushes, the engine LIFTS the run's work onto the remote
+ * default branch's current tip and says what that did (`deliverLiftEvaluated`, once per deliver
+ * attempt): `unchanged` (the base was already the tip), `lifted` (re-applied onto the tip; the
+ * repository's checks were then RE-RUN on the lifted tree — a `repoChecksEvaluated` for the deliver
+ * ord), `conflict` (nothing rebased or pushed; the unit failed with the engine's `deliver:
+ * LIFT-CONFLICT — …` remedy), `skipped` (the lift could not be decided) or `failed` (the apply
+ * failed part-way). A deliver unit the engine REFUSES emits `stepFailed` with a `deliver:`-prefixed
+ * detail — and a refusal that precedes the lift (a worktree whose `HEAD` is not on the run branch,
+ * a tree that could not be snapshotted) has NO `deliverLiftEvaluated` before it at all, so this
+ * derivation never assumes the lift frame exists (wicked-core#433 final review).
+ *
+ * Pure: the delivery card, the deliver gate's card and the timeline all read the same fold, so none
+ * of them can disagree. Zero requests — a view over the log the run page already hydrates.
+ *
+ * WHICH attempt: the frames are folded in log order and a `unitDispatched` for the deliver ord starts
+ * a fresh story (a retry's frames never inherit the previous attempt's conflict or refusal). The view
+ * is therefore the NEWEST attempt's — the one an open retry gate is about, and the one that ended the
+ * run when it is terminal.
+ */
+
+/** The engine's outcome tokens (api-types 0.33.0 `DeliverLiftOutcome`); a newer engine's token is
+ *  kept as it arrived and rendered as such, never guessed at. */
+export type DeliverLiftOutcomeWord = 'unchanged' | 'lifted' | 'conflict' | 'skipped' | 'failed';
+
+export interface DeliverLiftView {
+  ord: number | null;
+  attempt: number | null;
+  /** The lift's outcome token; `null` when no `deliverLiftEvaluated` frame preceded — the deliver
+   *  unit was refused BEFORE the lift and only its `deliver:` failure text exists. */
+  outcome: string | null;
+  /** The remote default ref the lift targets (`origin/main`), when one was resolved. */
+  baseRef: string | null;
+  /** The run branch's `HEAD` before the lift (the base the work was verified on). */
+  baseBefore: string | null;
+  /** The remote tip the work now sits on (`lifted`) or would have (`conflict`). */
+  baseAfter: string | null;
+  treeBefore: string | null;
+  treeAfter: string | null;
+  /** The paths the lift would conflict in (`conflict`); empty otherwise. */
+  conflicts: string[];
+  /** Why the lift was skipped / failed, or a disclosed degradation (a failed fetch). */
+  note: string | null;
+  /** The deliver ord's `repoChecksEvaluated` — the re-verify on the tree that would ship. `passed:
+   *  false` there is a failed re-verify OR a failed post-check proof (the checks passed but CHANGED
+   *  the worktree) — the `failure` text says which. */
+  reverify: GateFloorView | null;
+  /** The deliver unit's `stepFailed.detail` for this attempt — engine-authored (`deliver: …`) or the
+   *  deliver script's own refusal — verbatim; `null` while the unit has not failed. */
+  failure: string | null;
+}
+
+const str = (v: unknown): string | null => (typeof v === 'string' ? v : null);
+const num = (v: unknown): number | null => (typeof v === 'number' && Number.isFinite(v) ? v : null);
+const strings = (v: unknown): string[] =>
+  Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : [];
+
+/** The engine's own prefix on a deliver refusal it authored (wicked-core `deliver_lift.rs`); the
+ *  deliver script's refusals (`deliver: BASE MOVED since verification`, `deliver: LIFT-CONFLICT`)
+ *  wear the same prefix. */
+const DELIVER_PREFIX = /^deliver:/;
+
+function blank(ord: number | null, ev: CoreEvent): DeliverLiftView {
+  return {
+    ord,
+    attempt: num(ev.attempt),
+    outcome: null,
+    baseRef: null,
+    baseBefore: null,
+    baseAfter: null,
+    treeBefore: null,
+    treeAfter: null,
+    conflicts: [],
+    note: null,
+    reverify: null,
+    failure: null,
+  };
+}
+
+function liftOf(ord: number | null, ev: CoreEvent): DeliverLiftView {
+  return {
+    ...blank(ord, ev),
+    outcome: str(ev.outcome),
+    baseRef: str(ev.baseRef),
+    baseBefore: str(ev.baseBefore),
+    baseAfter: str(ev.baseAfter),
+    treeBefore: str(ev.treeBefore),
+    treeAfter: str(ev.treeAfter),
+    conflicts: strings(ev.conflicts),
+    note: str(ev.note),
+  };
+}
+
+/**
+ * The deliver phase's newest-attempt story for `deliverOrd`, or `null` when the log holds none.
+ *
+ * With `deliverOrd` given, a `deliver:` `stepFailed` for that ord builds a view even with no lift
+ * frame before it (the refused-before-the-lift case). A `repoChecksEvaluated` attaches only to a
+ * lift story already in hand — the engine emits `deliverLiftEvaluated` BEFORE any deliver re-verify,
+ * so a floor with no lift before it is some other phase's floor (the verify gate's, say), never a
+ * deliver re-verify. Without `deliverOrd`, only a `deliverLiftEvaluated` starts a story and later
+ * frames attach only when they carry its ord.
+ */
+export function deliverLift(events: readonly CoreEvent[], deliverOrd?: number): DeliverLiftView | null {
+  const scoped = deliverOrd !== undefined;
+  let view: DeliverLiftView | null = null;
+  for (const e of events) {
+    const ord = num(e.ord);
+    if (scoped && ord !== deliverOrd) continue;
+    const mine = view !== null && view.ord === ord;
+    switch (e.type) {
+      case 'unitDispatched':
+        // A retry starts a fresh story: the previous attempt's conflict is that attempt's.
+        if (mine) view = null;
+        break;
+      case 'deliverLiftEvaluated':
+        view = liftOf(ord, e);
+        break;
+      case 'repoChecksEvaluated':
+        if (mine) view = { ...view!, reverify: floorOf(e) };
+        break;
+      case 'stepFailed': {
+        const detail = str(e.detail);
+        if (detail === null || detail === '') break;
+        // With a lift frame in hand any failure of this attempt is the lift's story; without one,
+        // only the engine's own `deliver:` refusal is — a worker's stack trace on a deliver unit
+        // that never reached the lift is the failure banner's business, not this card's.
+        if (mine || (scoped && DELIVER_PREFIX.test(detail))) view = { ...(view ?? blank(ord, e)), failure: detail };
+        break;
+      }
+      default:
+        break;
+    }
+  }
+  return view;
+}
+
+/** The short word the card leads with, per outcome; a newer engine's token passes through. */
+export function liftOutcomeLabel(outcome: string | null): string {
+  switch (outcome) {
+    case 'unchanged': return 'base unchanged';
+    case 'lifted': return 'lifted onto the current tip';
+    case 'conflict': return 'LIFT-CONFLICT';
+    case 'skipped': return 'lift skipped';
+    case 'failed': return 'lift failed';
+    case null: return 'refused before the lift';
+    default: return outcome;
+  }
+}
+
+/** Whether the outcome (or the absence of one beside a failure) is a stop: nothing was pushed. */
+export function liftIsFailure(view: DeliverLiftView): boolean {
+  return view.outcome === 'conflict' || view.outcome === 'failed' || view.failure !== null || view.reverify?.passed === false;
+}
+
+/**
+ * A `passed: false` re-verify whose every check exited 0 is the post-check PROOF failing, not a
+ * red suite: the repository's checks passed but CHANGED the worktree while running (wicked-core
+ * F-433-002) — the refusal text names the tree/HEAD that moved. Said out loud so "repository
+ * checks — fail" over three green rows does not read as a contradiction.
+ */
+export function reverifyChangedTree(floor: GateFloorView): boolean {
+  return (
+    !floor.passed &&
+    floor.checks.length > 0 &&
+    floor.skipped.length === 0 &&
+    floor.checks.every((c) => c.exitCode === 0 && !c.timedOut && c.spawnError === null)
+  );
+}

--- a/src/components/gateVerdictModel.ts
+++ b/src/components/gateVerdictModel.ts
@@ -61,6 +61,11 @@ export interface GateFloorCheck {
   timedOut: boolean;
   spawnError: string | null;
   durationMs: number;
+  /** The last 4 KiB of the check's stdout / stderr as the engine recorded them (`RepoCheckRun`, on the
+   *  wire since api-types 0.31.0) — the evidence behind a failed check, verbatim. `null` when the
+   *  stream was empty or the frame predates the field, so no surface paints an empty box (F-255-03). */
+  stdoutTail: string | null;
+  stderrTail: string | null;
 }
 
 /** The F-039 floor as `repoChecksEvaluated` reported it. */
@@ -138,6 +143,8 @@ export interface GateVerdictView {
 
 const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === 'object' && v !== null;
 const str = (v: unknown): string | null => (typeof v === 'string' ? v : null);
+/** A recorded stream tail: a non-blank string, else `null` — an empty stream is nothing to show. */
+const tail = (v: unknown): string | null => (typeof v === 'string' && v.trim() !== '' ? v : null);
 const strings = (v: unknown): string[] =>
   Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : [];
 
@@ -173,6 +180,8 @@ function checkOf(raw: unknown): GateFloorCheck | null {
     timedOut: c.timedOut === true,
     spawnError: str(c.spawnError),
     durationMs: typeof c.durationMs === 'number' ? c.durationMs : 0,
+    stdoutTail: tail(c.stdoutTail),
+    stderrTail: tail(c.stderrTail),
   };
 }
 
@@ -337,6 +346,42 @@ export function checkOutcome(c: GateFloorCheck): { word: string; ok: boolean } {
   if (c.timedOut) return { word: 'timed out', ok: false };
   if (c.exitCode === null) return { word: 'no exit code', ok: false };
   return { word: c.exitCode === 0 ? 'exit 0' : `exit ${c.exitCode}`, ok: c.exitCode === 0 };
+}
+
+/**
+ * The recorded stream tails of a check that did NOT pass, stderr first — what a collapsed `<details>`
+ * per stream renders on the gate card's floor and on the deliver lift (F-255-03). Empty for a passing
+ * check (its output is not evidence of anything the card claims) and for a check whose streams the
+ * engine recorded as empty.
+ */
+export function checkTails(c: GateFloorCheck): Array<{ stream: 'stderr' | 'stdout'; text: string }> {
+  if (checkOutcome(c).ok) return [];
+  const out: Array<{ stream: 'stderr' | 'stdout'; text: string }> = [];
+  if (c.stderrTail !== null) out.push({ stream: 'stderr', text: c.stderrTail });
+  if (c.stdoutTail !== null) out.push({ stream: 'stdout', text: c.stdoutTail });
+  return out;
+}
+
+/**
+ * Whether Approve on the gate for `gateOrd` means "retry against the restored tree" (wicked-core#431 /
+ * F-3R2-010): the deciding evaluation is THIS unit's, it failed, the WORKTREE GUARD is the layer that
+ * denied it, and the engine reports the creator's tree restored. That is the engine's own condition
+ * for sending the restored-tree prompt (`actor.rs`: `denial.source == "worktree_guard" &&
+ * mutation.restored`) — in a dual-deny another layer wins, the engine keeps the legacy prompt and this
+ * keeps "Approve" (F-255-05). ONE predicate for every gate card — the run page's `SteeringGate` and the
+ * landing inbox's card (F-255-01) — so an open gate never reads "Retry" on one surface and "Approve"
+ * on the other. Keyed on the evidence frames, never on the prompt text; a prose-only denial from an
+ * older engine (`source: null`) cannot be shown to be the guard's and stays "Approve".
+ */
+export function isRestoredRetry(view: GateVerdictView | null, gateOrd: number | null | undefined): boolean {
+  return (
+    view !== null &&
+    typeof gateOrd === 'number' &&
+    view.ord === gateOrd &&
+    view.outcome === 'fail' &&
+    view.denial?.source === 'worktree_guard' &&
+    view.mutation?.restored === true
+  );
 }
 
 /**

--- a/src/components/gateVerdictModel.ts
+++ b/src/components/gateVerdictModel.ts
@@ -34,8 +34,20 @@ import type { CoreEvent, RepoCheckRun, UnitDenial, WorkUnit, WorktreeChangedPath
  *
  * Never overclaimed (FINDING-025): an evaluation with no floor, no judge verdict and no evaluator
  * policy is `'ungated'` — a default-allow the card labels as "nothing gated this phase", not a
- * pass. The judge SEAT is not on this wire (api-types 0.31.0 `gateEvaluated` carries no seat),
- * so no view field exists for it — render nothing rather than infer one from `unitDispatched`.
+ * pass.
+ *
+ * wicked-core#431 (api-types 0.33.0) put three more facts on the same frames, all read here and
+ * all `null` when an older daemon does not send them:
+ *  - `gateEvaluated.judgeCli` / `judgeDistinct` — WHO rendered `agentVerdict`, and whether that
+ *    seat was identity-distinct from the work's author (evaluator ≠ creator is the doctrine;
+ *    `false` means the judge fell back to the single default runner and its independence is
+ *    prompt-only). Read off the frame, never inferred from `unitDispatched`.
+ *  - `evaluatorMutatedWorktree.restored` / `restoreError` — whether the engine already put the
+ *    creator's tree back after the mutation, so a human's Approve now means a retry against the
+ *    VERIFIED tree, not adoption of the evaluator's edit.
+ *  - `worktreeRestored` (a new frame between the mutation record and the verdict) — what was
+ *    discarded and where the discarded edit was pinned (`refs/wicked/suggestions/<run>/<ord>/<attempt>`,
+ *    `null` when the pin failed), attached as `restore`.
  */
 
 export type GateOutcome = 'pass' | 'fail' | 'ungated';
@@ -68,6 +80,26 @@ export interface GateMutationView {
   afterTree: string;
   headMoved: boolean;
   changed: WorktreeChangedPath[];
+  /** wicked-core#431: whether the engine restored the creator's tree right after the mutation.
+   *  `null` when the frame predates the field (an older engine) — the card then keeps the manual
+   *  `git read-tree` remedy the denial prose carries and says nothing about a restore. */
+  restored: boolean | null;
+  /** Why the restore failed or was not attempted, when `restored === false`. */
+  restoreError: string | null;
+}
+
+/** The `worktreeRestored` record (wicked-core#431, api-types 0.33.0): what the engine put back and
+ *  what it threw away. Follows `evaluatorMutatedWorktree` when `restored` is `true`. */
+export interface GateRestoreView {
+  /** The tree id the worktree was restored to (the creator's baseline). */
+  tree: string;
+  /** The commit `HEAD` was reset to when the phase had moved it; `null` when it had not. */
+  head: string | null;
+  /** Exactly what the evaluator's edit was — the same list the mutation event carried as `changed`. */
+  discarded: WorktreeChangedPath[];
+  /** Where the discarded edit was pinned (`refs/wicked/suggestions/<run>/<ord>/<attempt>`), so
+   *  `git show <ref>` reads it back; `null` when the pin failed. */
+  suggestionRef: string | null;
 }
 
 /** The winning denial: structured when the wire carries `denial`, prose-only from an older engine. */
@@ -95,6 +127,13 @@ export interface GateVerdictView {
   denial: GateDenialView | null;
   floor: GateFloorView | null;
   mutation: GateMutationView | null;
+  /** The `worktreeRestored` record for this fold, when the engine restored the creator's tree. */
+  restore: GateRestoreView | null;
+  /** The council seat key the layer-2 judge ran under (`codex`, `pi`, …); `null` when no judge ran,
+   *  on the bus-mediated path, and from a daemon that predates api-types 0.33.0. */
+  judgeCli: string | null;
+  /** Whether that judge seat was identity-distinct from the work's author; `null` when unknown. */
+  judgeDistinct: boolean | null;
 }
 
 const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === 'object' && v !== null;
@@ -137,7 +176,9 @@ function checkOf(raw: unknown): GateFloorCheck | null {
   };
 }
 
-function floorOf(ev: CoreEvent): GateFloorView {
+/** The F-039 floor off a `repoChecksEvaluated` frame — shared with the deliver re-verify
+ *  (`deliverLiftModel.ts`), which is the same frame emitted for the deliver ord. */
+export function floorOf(ev: CoreEvent): GateFloorView {
   return {
     passed: ev.passed === true,
     criterion: str(ev.criterion) ?? '',
@@ -147,19 +188,36 @@ function floorOf(ev: CoreEvent): GateFloorView {
   };
 }
 
-function mutationOf(ev: CoreEvent): GateMutationView {
-  const changed = Array.isArray(ev.changed)
-    ? ev.changed.filter(
+/** Narrow a wire `ChangedPath[]` — anything that is not `{path, status}` strings is dropped. */
+function changedPaths(v: unknown): WorktreeChangedPath[] {
+  return Array.isArray(v)
+    ? v.filter(
         (p): p is WorktreeChangedPath => isRecord(p) && typeof p.path === 'string' && typeof p.status === 'string',
       )
     : [];
+}
+
+function mutationOf(ev: CoreEvent): GateMutationView {
   return {
     cli: str(ev.cli) ?? '',
     phase: str(ev.phase) ?? '',
     beforeTree: str(ev.beforeTree) ?? '',
     afterTree: str(ev.afterTree) ?? '',
     headMoved: ev.headMoved === true,
-    changed,
+    changed: changedPaths(ev.changed),
+    // Absent (an older engine) is `null`, never `false`: `false` is the engine SAYING the restore
+    // failed, and the card renders that as a warning it must not fabricate.
+    restored: typeof ev.restored === 'boolean' ? ev.restored : null,
+    restoreError: str(ev.restoreError),
+  };
+}
+
+function restoreOf(ev: CoreEvent): GateRestoreView {
+  return {
+    tree: str(ev.tree) ?? '',
+    head: str(ev.head),
+    discarded: changedPaths(ev.discarded),
+    suggestionRef: str(ev.suggestionRef),
   };
 }
 
@@ -216,6 +274,9 @@ export function gateVerdict(events: readonly CoreEvent[], gateOrd?: number): Gat
 
   const floorFrame = nearestBefore(events, idx, 'repoChecksEvaluated', ord);
   const mutationFrame = nearestBefore(events, idx, 'evaluatorMutatedWorktree', ord);
+  // The restore record rides the same fold: emitted AFTER the mutation frame and BEFORE the verdict
+  // (wicked-core#431), so the same bounded look-back finds it and a retry never inherits it.
+  const restoreFrame = nearestBefore(events, idx, 'worktreeRestored', ord);
 
   return {
     ord,
@@ -230,6 +291,9 @@ export function gateVerdict(events: readonly CoreEvent[], gateOrd?: number): Gat
     denial,
     floor: floorFrame === null ? null : floorOf(floorFrame),
     mutation: mutationFrame === null ? null : mutationOf(mutationFrame),
+    restore: restoreFrame === null ? null : restoreOf(restoreFrame),
+    judgeCli: str(ev.judgeCli),
+    judgeDistinct: typeof ev.judgeDistinct === 'boolean' ? ev.judgeDistinct : null,
   };
 }
 
@@ -297,4 +361,10 @@ export function formatDuration(ms: number): string {
  */
 export function splitBackticks(text: string): string[] {
   return text.split('`');
+}
+
+/** A git object id cut for display: the first `n` hex chars (trees 10, as the card already prints
+ *  them; commits 7, git's own default). Anything shorter than `n` is shown whole. */
+export function shortId(id: string, n = 10): string {
+  return id.length > n ? id.slice(0, n) : id;
 }

--- a/src/components/gateVerdictModel.ts
+++ b/src/components/gateVerdictModel.ts
@@ -5,7 +5,7 @@ import type { CoreEvent, RepoCheckRun, UnitDenial, WorkUnit, WorktreeChangedPath
  * event log (wicked-studio#250, F-3R2-006 — the UI half of wicked-core F-036/F-039).
  *
  * The gate card asked "Approve unit 4 before it runs: verify" and, one denial later, "Unit 4
- * verdict is NOT PASS — confirm to retry the phase, or reject to cancel the run" — and nothing
+ * verdict is NOT PASS — …" (the pre-0.33.0 retry-or-reject wording) — and nothing
  * else. The verdict the operator was really answering (the `fix` phase PASSED its floor and its
  * judge; the `verify` phase was DENIED because it changed the worktree it was reviewing, here is
  * the path, here is the restore command) sat on the wire the whole time, in `gateEvaluated`,

--- a/src/components/narrator.ts
+++ b/src/components/narrator.ts
@@ -1,5 +1,7 @@
 import type { CoreEvent, SessionView, WorkUnit } from '../api/types.js';
 import { isPrUrl } from './delivery.js';
+import { shortId } from './gateVerdictModel.js';
+import { runBaseLine, runBaseOf } from './runBaseModel.js';
 
 /**
  * The run narrator (DES-RUN-NARRATOR §4-§6): a DETERMINISTIC template layer —
@@ -220,6 +222,53 @@ export function narrate(event: CoreEvent, ctx: NarratorContext): NarrationLine |
         : null;
     case 'governanceUnenforced':
       return line(`Governance was requested but is not enforced for ${str(event.cli) || 'this seat'}`, 'gate');
+    // ── wicked-core#431 (api-types 0.33.0) ──────────────────────────────────
+    case 'runBaseResolved': {
+      const base = runBaseOf(event);
+      return base === null ? null : line(`Based on ${runBaseLine(base)}`, 'info');
+    }
+    case 'worktreeRestored': {
+      const n = Array.isArray(event.discarded) ? event.discarded.length : 0;
+      const ref = str(event['suggestionRef']);
+      return line(
+        `Restored the creator's tree for ${phase} — ${str(event.cli) || 'the seat'}'s edit (${n} path${n === 1 ? '' : 's'}) was discarded${ref ? `, kept at ${ref}` : ''}`,
+        'gate',
+      );
+    }
+    case 'deliverLiftEvaluated': {
+      const outcome = str(event.outcome);
+      const base = str(event['baseRef']) || 'the remote default branch';
+      const tip = str(event['baseAfter']) ? shortId(str(event['baseAfter']), 7) : '?';
+      const note = str(event['note']);
+      switch (outcome) {
+        case 'unchanged':
+          return line(`Deliver lift: base unchanged — ${base} is still at ${str(event['baseBefore']) ? shortId(str(event['baseBefore']), 7) : '?'}`, 'info');
+        case 'lifted':
+          return line(`Deliver lift: lifted onto ${base} @ ${tip} — re-running the repository's checks on the lifted tree`, 'work');
+        case 'conflict': {
+          const files = Array.isArray(event['conflicts']) ? (event['conflicts'] as unknown[]).filter((c): c is string => typeof c === 'string') : [];
+          return line(`Deliver lift: CONFLICT in ${files.join(', ') || 'unlisted paths'} — nothing rebased, nothing pushed`, 'fail');
+        }
+        case 'skipped':
+          return line(`Deliver lift: skipped${note ? ` — ${clip(note)}` : ''}`, 'info');
+        case 'failed':
+          return line(`Deliver lift: FAILED${note ? ` — ${clip(note)}` : ''} — nothing pushed`, 'fail');
+        default:
+          return line(`Deliver lift: ${outcome || 'unknown outcome'}${note ? ` — ${clip(note)}` : ''}`, 'info');
+      }
+    }
+    case 'evaluatorToolCallDenied':
+      return line(
+        `Refused a write by ${str(event.cli) || 'the seat'} during ${phase} — ${str(event['tool']) || 'a write tool'}${str(event['path']) ? ` on ${str(event['path'])}` : ''} (a read-only phase may not edit)`,
+        'fail',
+      );
+    case 'acpFallback':
+      // The one deliberate reroute the feed speaks: a read-only phase on an ACP seat whose adapter
+      // cannot enforce the write lock moves to the wrapped carrier BEFORE any turn. Routing, not a
+      // failure — the other kinds (binary_unavailable, session_died, …) stay silent as before.
+      return str(event.fallbackKind) === 'read_only_requires_wrapped'
+        ? line(`${str(event.cliKey) || 'The seat'} moved to the wrapped carrier for its read-only turn — the write lock is an argv fact there, not a failure`, 'info')
+        : null;
     case 'sessionCompleted':
       return line('Run completed', 'work');
     case 'sessionFailed':
@@ -229,7 +278,7 @@ export function narrate(event: CoreEvent, ctx: NarratorContext): NarrationLine |
     case 'error':
       return line(`Error: ${clip(str(event.message)) || 'unspecified'}`, 'fail');
     default:
-      return null; // silent: deltas, heartbeat, terminal*, cliUsage, workerSession*, acp*, …
+      return null; // silent: deltas, heartbeat, terminal*, cliUsage, workerSession*, acpSession*, …
   }
 }
 

--- a/src/components/runBaseModel.ts
+++ b/src/components/runBaseModel.ts
@@ -1,0 +1,75 @@
+import type { CoreEvent } from '../api/types.js';
+import { shortId } from './gateVerdictModel.js';
+
+/**
+ * runBase — how the run's BASE commit was chosen when its worktree was minted (wicked-core#431 /
+ * F-3R2-013, api-types 0.33.0 `runBaseResolved`): the engine fetches `origin` and, when the
+ * registered clone's `HEAD` is strictly behind the remote default branch's tip, bases the run on
+ * that tip — so the worker starts from the current code and the deliver lift has nothing to move.
+ *
+ * Session-level (no `ord`), emitted once per freshly minted worktree BEFORE `worktreeReady`; a
+ * resumed run reuses its live worktree and emits nothing, and a daemon that predates the frame
+ * never sends it — every surface renders NOTHING then, never a base it did not see.
+ */
+export interface RunBaseView {
+  /** The remote default ref (`origin/main`), or `null` when none could be resolved. */
+  baseRef: string | null;
+  /** The commit the run worktree was minted from. */
+  baseCommit: string;
+  /** The registered clone's `HEAD` at mint time. */
+  localHead: string;
+  /** How many commits `localHead` was behind `baseRef`; `0` when not behind or unknown. */
+  behind: number;
+  /** Whether `git fetch origin` succeeded (a failed fetch is disclosed in `note`, cached refs used). */
+  fetched: boolean;
+  /** `true` = the base moved off the clone's `HEAD` by `behind` commits. */
+  lifted: boolean;
+  /** Local unpushed work kept, a failed fetch, … — the engine's own words. */
+  note: string | null;
+}
+
+const str = (v: unknown): string | null => (typeof v === 'string' ? v : null);
+
+/** One `runBaseResolved` frame narrowed, or `null` for any other frame / a frame with no commit. */
+export function runBaseOf(ev: CoreEvent): RunBaseView | null {
+  if (ev.type !== 'runBaseResolved') return null;
+  const baseCommit = str(ev.baseCommit);
+  if (baseCommit === null || baseCommit === '') return null;
+  return {
+    baseRef: str(ev.baseRef),
+    baseCommit,
+    localHead: str(ev.localHead) ?? '',
+    behind: typeof ev.behind === 'number' && Number.isFinite(ev.behind) && ev.behind > 0 ? Math.floor(ev.behind) : 0,
+    fetched: ev.fetched !== false,
+    lifted: ev.lifted === true,
+    note: str(ev.note),
+  };
+}
+
+/** The run's base as the LAST `runBaseResolved` in the log says it, or `null` when none was sent. */
+export function runBase(events: readonly CoreEvent[]): RunBaseView | null {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const v = runBaseOf(events[i]!);
+    if (v !== null) return v;
+  }
+  return null;
+}
+
+/**
+ * The one-line note every surface prints (the run header row, the timeline, the feed):
+ * "origin/main @ f57069d · 5 behind · lifted to the tip". Facts only, in the engine's own terms —
+ * `lifted` is the engine's word for "the base moved off the clone's HEAD", not a claim about a PR.
+ */
+export function runBaseLine(v: RunBaseView): string {
+  const at = `@ ${shortId(v.baseCommit, 7)}`;
+  const parts: string[] = [];
+  if (v.baseRef === null) {
+    parts.push(`local HEAD ${at}`, 'no remote default branch resolved');
+  } else if (v.lifted) {
+    parts.push(`${v.baseRef} ${at}`, `${v.behind} behind`, 'lifted to the tip');
+  } else {
+    parts.push(`${v.baseRef} ${at}`, v.note === null ? 'at the tip' : 'local HEAD kept');
+  }
+  if (!v.fetched) parts.push('fetch failed — cached refs');
+  return parts.join(' · ');
+}

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -10,9 +10,9 @@
   "version": 1,
   "studioVersion": "0.5.5",
   "counts": {
-    "files": 140,
-    "occurrences": 1192,
-    "static": 1023,
+    "files": 141,
+    "occurrences": 1216,
+    "static": 1041,
     "dynamic": 59,
     "computed": 7
   },
@@ -1308,6 +1308,66 @@
       ]
     },
     {
+      "testId": "deliver-lift",
+      "files": [
+        "src/components/DeliverLift.tsx"
+      ]
+    },
+    {
+      "testId": "deliver-lift-changed-tree",
+      "files": [
+        "src/components/DeliverLift.tsx"
+      ]
+    },
+    {
+      "testId": "deliver-lift-check",
+      "files": [
+        "src/components/DeliverLift.tsx"
+      ]
+    },
+    {
+      "testId": "deliver-lift-conflicts",
+      "files": [
+        "src/components/DeliverLift.tsx"
+      ]
+    },
+    {
+      "testId": "deliver-lift-failure",
+      "files": [
+        "src/components/DeliverLift.tsx"
+      ]
+    },
+    {
+      "testId": "deliver-lift-floor",
+      "files": [
+        "src/components/DeliverLift.tsx"
+      ]
+    },
+    {
+      "testId": "deliver-lift-note",
+      "files": [
+        "src/components/DeliverLift.tsx"
+      ]
+    },
+    {
+      "testId": "deliver-lift-remedy",
+      "files": [
+        "src/components/DeliverLift.tsx"
+      ]
+    },
+    {
+      "testId": "deliver-lift-skipped",
+      "files": [
+        "src/components/DeliverLift.tsx"
+      ]
+    },
+    {
+      "testId": "deliver-lift-summary",
+      "files": [
+        "src/components/DeliverLift.tsx"
+      ]
+    },
+    {
       "testId": "deliver-notice",
       "files": [
         "src/components/ChatInput.tsx"
@@ -2070,6 +2130,18 @@
       ]
     },
     {
+      "testId": "gate-verdict-judge-same-seat",
+      "files": [
+        "src/components/GateVerdict.tsx"
+      ]
+    },
+    {
+      "testId": "gate-verdict-judge-seat",
+      "files": [
+        "src/components/GateVerdict.tsx"
+      ]
+    },
+    {
       "testId": "gate-verdict-layers",
       "files": [
         "src/components/GateVerdict.tsx"
@@ -2082,7 +2154,25 @@
       ]
     },
     {
+      "testId": "gate-verdict-restore-failed",
+      "files": [
+        "src/components/GateVerdict.tsx"
+      ]
+    },
+    {
+      "testId": "gate-verdict-restored",
+      "files": [
+        "src/components/GateVerdict.tsx"
+      ]
+    },
+    {
       "testId": "gate-verdict-skipped",
+      "files": [
+        "src/components/GateVerdict.tsx"
+      ]
+    },
+    {
+      "testId": "gate-verdict-suggestion-hint",
       "files": [
         "src/components/GateVerdict.tsx"
       ]
@@ -3879,6 +3969,12 @@
       "testId": "routing-provenance",
       "files": [
         "src/components/RoutingProvenance.tsx"
+      ]
+    },
+    {
+      "testId": "run-base-detail",
+      "files": [
+        "src/components/RunTimeline.tsx"
       ]
     },
     {
@@ -5800,6 +5896,12 @@
       ]
     },
     {
+      "testId": "tool-call-denied-detail",
+      "files": [
+        "src/components/RunTimeline.tsx"
+      ]
+    },
+    {
       "testId": "triage-hint",
       "files": [
         "src/components/HomeBoard.tsx"
@@ -6178,6 +6280,12 @@
       "testId": "worker-root-invalid",
       "files": [
         "src/components/SystemSettings.tsx"
+      ]
+    },
+    {
+      "testId": "worktree-restored-detail",
+      "files": [
+        "src/components/RunTimeline.tsx"
       ]
     }
   ],
@@ -6577,6 +6685,7 @@
         "src/components/SkillChips.tsx",
         "src/components/SkillFindings.tsx",
         "src/components/SkillsPage.tsx",
+        "src/components/WhatWhere.tsx",
         "src/components/dashboardKit.tsx"
       ]
     },

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -10,9 +10,9 @@
   "version": 1,
   "studioVersion": "0.5.5",
   "counts": {
-    "files": 141,
-    "occurrences": 1216,
-    "static": 1041,
+    "files": 142,
+    "occurrences": 1221,
+    "static": 1046,
     "dynamic": 59,
     "computed": 7
   },
@@ -1140,6 +1140,12 @@
       ]
     },
     {
+      "testId": "copy-command",
+      "files": [
+        "src/components/CopyButton.tsx"
+      ]
+    },
+    {
       "testId": "create-first-project",
       "files": [
         "src/components/HomeBoard.tsx"
@@ -1326,6 +1332,12 @@
       ]
     },
     {
+      "testId": "deliver-lift-check-tail",
+      "files": [
+        "src/components/DeliverLift.tsx"
+      ]
+    },
+    {
       "testId": "deliver-lift-conflicts",
       "files": [
         "src/components/DeliverLift.tsx"
@@ -1333,6 +1345,12 @@
     },
     {
       "testId": "deliver-lift-failure",
+      "files": [
+        "src/components/DeliverLift.tsx"
+      ]
+    },
+    {
+      "testId": "deliver-lift-failure-elided",
       "files": [
         "src/components/DeliverLift.tsx"
       ]
@@ -2052,6 +2070,12 @@
       ]
     },
     {
+      "testId": "gate-inbox-card",
+      "files": [
+        "src/components/CenterDashboard.tsx"
+      ]
+    },
+    {
       "testId": "gate-inbox-pill",
       "files": [
         "src/components/CenterDashboard.tsx"
@@ -2101,6 +2125,12 @@
     },
     {
       "testId": "gate-verdict-check",
+      "files": [
+        "src/components/GateVerdict.tsx"
+      ]
+    },
+    {
+      "testId": "gate-verdict-check-tail",
       "files": [
         "src/components/GateVerdict.tsx"
       ]

--- a/tests/CenterDashboard.build.test.tsx
+++ b/tests/CenterDashboard.build.test.tsx
@@ -11,7 +11,7 @@
  *   - the gate inbox appears only when a gate is pending (W4).
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { act, render, screen } from '@testing-library/react';
+import { act, render, screen, within } from '@testing-library/react';
 import {
   BUILD_PURPOSE,
   CenterDashboard,
@@ -22,6 +22,7 @@ import { useGateStore } from '../src/store/gates.js';
 import { useRunEventStore } from '../src/store/events.js';
 import { makeUnit, makeView } from './factories.js';
 import { G4_EVENTS, G4_GATE, G5_EVENTS, G5_GATE, GATE_RUN, GATE_UNITS, REPO_CHECKS_FAIL } from './fixtures/gateEvidence.js';
+import { G5R_EVENTS, G5R_GATE } from './fixtures/wire433.js';
 import type { SessionView } from '../src/api/types.js';
 
 /** `GET /runs/:id/events`, swappable per test — the gate inbox backfills it for open-gate runs. */
@@ -207,6 +208,41 @@ describe('the gate inbox (W4, §2.7 rule 5)', () => {
     expect(card).toHaveTextContent('Evaluator verdict — fix · PASS');
     expect(screen.getByTestId('gate-verdict-criterion')).toHaveTextContent('the run left a change in its worktree');
     expect(screen.getByTestId('gate-verdict-judge')).toHaveTextContent('judge: pass');
+  });
+
+  it("F-255-01: the restored-tree denial gate relabels the inbox card's Approve too — the same predicate as the run page", async () => {
+    getRunEvents.mockImplementation(async (id) => ({ events: id === GATE_RUN ? G5R_EVENTS : [] }));
+    useGateStore.setState({
+      gates: {
+        [GATE_RUN]: { runId: GATE_RUN, ord: G5R_GATE.ord, prompt: G5R_GATE.prompt, lifecycle: 'open', receivedAt: 1 },
+      },
+    });
+    useRunEventStore.setState({ byRun: { [GATE_RUN]: G5R_EVENTS } });
+    dash([makeView({ id: GATE_RUN, problem: 'fix the reported issue', status: 'awaiting_human', unit_ix: 3 }, GATE_UNITS)]);
+    expect(await screen.findByTestId('gate-verdict-restored')).toBeInTheDocument();
+    const card = screen.getByTestId('gate-inbox-card');
+    expect(card).toHaveAttribute('data-retry-restored', 'true');
+    expect(within(card).getByRole('button', { name: 'Retry against the restored tree' })).toBeInTheDocument();
+    expect(within(card).getByRole('button', { name: 'Retry + steer' })).toBeInTheDocument();
+    expect(within(card).queryByRole('button', { name: 'Approve' })).toBeNull();
+    // The copyable git show hint is a real button here as well (F-255-06).
+    expect(within(card).getByRole('button', { name: /^copy git show refs\/wicked\/suggestions\// })).toBeInTheDocument();
+  });
+
+  it('F-255-01: a gate whose deciding verdict PASSED keeps "Approve" on the inbox card', async () => {
+    getRunEvents.mockImplementation(async (id) => ({ events: id === GATE_RUN ? G4_EVENTS : [] }));
+    useGateStore.setState({
+      gates: {
+        [GATE_RUN]: { runId: GATE_RUN, ord: G4_GATE.ord, prompt: G4_GATE.prompt, lifecycle: 'open', receivedAt: 1 },
+      },
+    });
+    useRunEventStore.setState({ byRun: { [GATE_RUN]: G4_EVENTS } });
+    dash([makeView({ id: GATE_RUN, problem: 'fix the reported issue', status: 'awaiting_human', unit_ix: 3 }, GATE_UNITS)]);
+    await screen.findByTestId('gate-verdict');
+    const card = screen.getByTestId('gate-inbox-card');
+    expect(card).not.toHaveAttribute('data-retry-restored');
+    expect(within(card).getByRole('button', { name: 'Approve' })).toBeInTheDocument();
+    expect(within(card).getByRole('button', { name: 'Approve + steer' })).toBeInTheDocument();
   });
 
   it('after a reload the inbox backfills the open-gate run\'s event log ONCE, so a persisted verdict still renders (Copilot on #252)', async () => {

--- a/tests/RunDelivery.lift.test.tsx
+++ b/tests/RunDelivery.lift.test.tsx
@@ -1,0 +1,171 @@
+// wicked-core#431 / api-types 0.33.0 on the DELIVERY CARD (the rail's Delivery body): the deliver
+// lift's story off the run's event log — every outcome, the re-verify on the tree that would ship
+// (forced-install source, a failed re-verify, a failed post-check proof), the engine's refusal
+// verbatim (once — never duplicated under the unit's own denial_reason), the addendum's
+// refused-before-the-lift case, and silence for a daemon that never sent a deliver-ord frame.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { RunDelivery } from '../src/components/RunDelivery.js';
+import { useDeliveryStore } from '../src/store/delivery.js';
+import { useRunEventStore } from '../src/store/events.js';
+import { usePostHocDeliverStore } from '../src/store/postHocDeliver.js';
+import { clearCachedWorkflows } from '../src/store/workflowCache.js';
+import type { CoreEvent, SessionView, UnitStatus } from '../src/api/types.js';
+import { makeUnit, makeView } from './factories.js';
+import { G6_EVENTS, GATE_RUN } from './fixtures/gateEvidence.js';
+import {
+  BASE_AFTER,
+  BASE_BEFORE,
+  DELIVER_CHANGED_TREE_TAIL,
+  DELIVER_CONFLICT_TAIL,
+  DELIVER_FAILED_TAIL,
+  DELIVER_LIFTED_TAIL,
+  DELIVER_REVERIFY_FAILED_TAIL,
+  DELIVER_SKIPPED_TAIL,
+  DELIVER_UNCHANGED_TAIL,
+  DELIVER_WRONG_HEAD_TAIL,
+  REFUSAL_CONFLICT,
+  REFUSAL_WRONG_HEAD,
+} from './fixtures/wire433.js';
+
+/** The recorded run's view with its deliver unit (ord 5) in `status`, filed on a plain workflow. */
+function view(status: UnitStatus, denial: string | null = null, workdir = '/w/trees/run-3r2'): SessionView {
+  return makeView(
+    { id: GATE_RUN, workflow_id: 'feature', status: status === 'done' ? 'completed' : 'failed', workdir, repo_ref: 'studio-api' },
+    [
+      makeUnit({ id: `${GATE_RUN}:fix`, session_id: GATE_RUN, ord: 3, status: 'done' }),
+      makeUnit({ id: `${GATE_RUN}:verify`, session_id: GATE_RUN, ord: 4, status: 'done' }),
+      makeUnit({ id: `${GATE_RUN}:deliver`, session_id: GATE_RUN, ord: 5, status, denial_reason: denial }),
+    ],
+  );
+}
+
+function seed(tail: CoreEvent[]): void {
+  useRunEventStore.setState({ byRun: { [GATE_RUN]: [...G6_EVENTS, ...tail] } });
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  clearCachedWorkflows();
+  useDeliveryStore.setState({ byRun: {} });
+  usePostHocDeliverStore.setState({ byRun: {} });
+  useRunEventStore.setState({ byRun: {} });
+});
+afterEach(() => { cleanup(); clearCachedWorkflows(); });
+
+describe('RunDelivery — the deliver lift block', () => {
+  it('unchanged: the base was already the tip — the verified tree is the tree that would ship; no push or PR claim', () => {
+    seed(DELIVER_UNCHANGED_TAIL);
+    render(<RunDelivery view={view('done')} />);
+    const lift = screen.getByTestId('deliver-lift');
+    expect(lift).toHaveAttribute('data-outcome', 'unchanged');
+    expect(lift).toHaveAttribute('data-attempt', '0');
+    expect(lift).toHaveTextContent('Deliver lift — base unchanged');
+    expect(screen.getByTestId('deliver-lift-summary')).toHaveTextContent(`origin/main is still at ${BASE_BEFORE.slice(0, 7)}`);
+    expect(lift.textContent).not.toMatch(/pushed|PR open/);
+    expect(screen.queryByTestId('deliver-lift-floor')).toBeNull();
+    expect(screen.queryByTestId('deliver-lift-failure')).toBeNull();
+    // The card's own claim is untouched: `done` without a url is still only "deliver ran".
+    expect(screen.getByTestId('run-delivery')).toHaveAttribute('data-state', 'delivered');
+  });
+
+  it('lifted: base before → after, tree before → after, and the re-verify per check — the forced install named by its source', () => {
+    seed(DELIVER_LIFTED_TAIL);
+    render(<RunDelivery view={view('done')} />);
+    expect(screen.getByTestId('deliver-lift')).toHaveAttribute('data-outcome', 'lifted');
+    expect(screen.getByTestId('deliver-lift-summary')).toHaveTextContent(
+      `re-based onto origin/main @ ${BASE_AFTER.slice(0, 7)} (was ${BASE_BEFORE.slice(0, 7)})`,
+    );
+    const floor = screen.getByTestId('deliver-lift-floor');
+    expect(floor).toHaveAttribute('data-floor', 'pass');
+    expect(floor).toHaveTextContent('repository checks re-run on the tree that would ship — pass');
+    const rows = screen.getAllByTestId('deliver-lift-check');
+    expect(rows.map((r) => r.getAttribute('data-check'))).toEqual(['install', 'typecheck', 'lint', 'test']);
+    expect(rows[0]).toHaveTextContent('install · exit 0 · 21.4s · package-lock.json (forced: lockfile drift)');
+    expect(rows.every((r) => r.getAttribute('data-ok') === 'true')).toBe(true);
+    expect(screen.queryByTestId('deliver-lift-changed-tree')).toBeNull();
+    expect(screen.queryByTestId('deliver-lift-failure')).toBeNull();
+  });
+
+  it('conflict on a rejected unit: files, remedy, and the refusal ONCE — omitted from the lift block when denial_reason already carries it', () => {
+    seed(DELIVER_CONFLICT_TAIL);
+    render(<RunDelivery view={view('rejected', REFUSAL_CONFLICT)} />);
+    expect(screen.getByTestId('run-delivery')).toHaveAttribute('data-state', 'failed');
+    const lift = screen.getByTestId('deliver-lift');
+    expect(lift).toHaveAttribute('data-outcome', 'conflict');
+    expect(screen.getByTestId('deliver-lift-conflicts')).toHaveTextContent('testid-inventory.json');
+    expect(screen.getByTestId('deliver-lift-remedy')).toHaveTextContent('remedy:');
+    // The unit's own reason renders verbatim below; the lift block does not repeat it.
+    expect(screen.getByTestId('run-delivery-reason')).toHaveTextContent(REFUSAL_CONFLICT);
+    expect(screen.queryByTestId('deliver-lift-failure')).toBeNull();
+    expect(screen.getAllByText(/LIFT-CONFLICT — lifting/)).toHaveLength(1);
+  });
+
+  it('conflict when the unit has NOT resolved yet (the retry gate is open): the refusal renders in the lift block', () => {
+    seed(DELIVER_CONFLICT_TAIL);
+    render(<RunDelivery view={view('distributed')} />);
+    expect(screen.getByTestId('run-delivery')).toHaveAttribute('data-state', 'in-flight');
+    expect(screen.getByTestId('deliver-lift-failure')).toHaveTextContent(REFUSAL_CONFLICT);
+  });
+
+  it('skipped and failed carry the engine\'s note', () => {
+    seed(DELIVER_SKIPPED_TAIL);
+    const { unmount } = render(<RunDelivery view={view('done')} />);
+    expect(screen.getByTestId('deliver-lift')).toHaveAttribute('data-outcome', 'skipped');
+    expect(screen.getByTestId('deliver-lift-summary')).toHaveTextContent('the lift could not be decided — no remote default branch resolved');
+    expect(screen.getByTestId('deliver-lift-summary')).toHaveTextContent("the deliver script's own rebase stands");
+    unmount();
+
+    seed(DELIVER_FAILED_TAIL);
+    render(<RunDelivery view={view('distributed')} />);
+    expect(screen.getByTestId('deliver-lift')).toHaveAttribute('data-outcome', 'failed');
+    expect(screen.getByTestId('deliver-lift-summary')).toHaveTextContent('could not be applied — git read-tree -m -u exited 128');
+    expect(screen.getByTestId('deliver-lift-failure')).toHaveTextContent('deliver: the lift onto origin/main');
+  });
+
+  it('the addendum: refused for a wrong HEAD ref — no lift frame, the engine\'s deliver: text on its own', () => {
+    seed(DELIVER_WRONG_HEAD_TAIL);
+    render(<RunDelivery view={view('distributed')} />);
+    const lift = screen.getByTestId('deliver-lift');
+    expect(lift).toHaveAttribute('data-outcome', 'refused');
+    expect(lift).toHaveTextContent('refused before the lift');
+    expect(screen.queryByTestId('deliver-lift-summary')).toBeNull();
+    expect(screen.getByTestId('deliver-lift-failure')).toHaveTextContent(REFUSAL_WRONG_HEAD.replace(/`/g, ''));
+  });
+
+  it('a FAILED re-verify: floor fail, the red check marked, the skipped one named, the refusal names the lockfile drift', () => {
+    seed(DELIVER_REVERIFY_FAILED_TAIL);
+    render(<RunDelivery view={view('distributed')} />);
+    const floor = screen.getByTestId('deliver-lift-floor');
+    expect(floor).toHaveAttribute('data-floor', 'fail');
+    const rows = screen.getAllByTestId('deliver-lift-check');
+    expect(rows.map((r) => [r.getAttribute('data-check'), r.getAttribute('data-ok')])).toEqual([
+      ['install', 'true'], ['typecheck', 'true'], ['lint', 'false'],
+    ]);
+    expect(screen.getByTestId('deliver-lift-skipped')).toHaveTextContent('skipped (an earlier check failed): test');
+    expect(screen.queryByTestId('deliver-lift-changed-tree')).toBeNull();
+    expect(screen.getByTestId('deliver-lift-failure')).toHaveTextContent('Lockfile drift between the old base and the tip (package-lock.json)');
+  });
+
+  it('a failed POST-CHECK PROOF: passed:false over all-green rows is explained as "the checks CHANGED the worktree"', () => {
+    seed(DELIVER_CHANGED_TREE_TAIL);
+    render(<RunDelivery view={view('distributed')} />);
+    expect(screen.getByTestId('deliver-lift-floor')).toHaveAttribute('data-floor', 'fail');
+    expect(screen.getAllByTestId('deliver-lift-check').every((r) => r.getAttribute('data-ok') === 'true')).toBe(true);
+    expect(screen.getByTestId('deliver-lift-changed-tree')).toHaveTextContent('the checks CHANGED the worktree while running');
+    expect(screen.getByTestId('deliver-lift-failure')).toHaveTextContent("deliver: the repository's checks passed but CHANGED the worktree while running");
+  });
+
+  it('no deliver-ord frame (an older daemon, or the phase not yet dispatched) ⇒ no block; no deliver unit ⇒ no block', () => {
+    useRunEventStore.setState({ byRun: { [GATE_RUN]: G6_EVENTS } });
+    const { unmount } = render(<RunDelivery view={view('pending')} />);
+    expect(screen.queryByTestId('deliver-lift')).toBeNull();
+    unmount();
+    // A post-hoc-delivered run has no deliver unit to key the lift on.
+    seed(DELIVER_LIFTED_TAIL);
+    const v = makeView({ id: GATE_RUN, workflow_id: 'feature', status: 'completed' }, [makeUnit({ id: `${GATE_RUN}:fix`, session_id: GATE_RUN, ord: 3, status: 'done' })]);
+    render(<RunDelivery view={v} />);
+    expect(screen.queryByTestId('deliver-lift')).toBeNull();
+  });
+});

--- a/tests/RunDelivery.lift.test.tsx
+++ b/tests/RunDelivery.lift.test.tsx
@@ -5,7 +5,7 @@
 // refused-before-the-lift case, and silence for a daemon that never sent a deliver-ord frame.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, render, screen, within } from '@testing-library/react';
 import { RunDelivery } from '../src/components/RunDelivery.js';
 import { useDeliveryStore } from '../src/store/delivery.js';
 import { useRunEventStore } from '../src/store/events.js';
@@ -25,8 +25,12 @@ import {
   DELIVER_SKIPPED_TAIL,
   DELIVER_UNCHANGED_TAIL,
   DELIVER_WRONG_HEAD_TAIL,
+  DETAIL_REVERIFY_FAILED,
   REFUSAL_CONFLICT,
+  REFUSAL_REVERIFY_FAILED,
   REFUSAL_WRONG_HEAD,
+  deliverRejectedReason,
+  deliverWorkerFailedReason,
 } from './fixtures/wire433.js';
 
 /** The recorded run's view with its deliver unit (ord 5) in `status`, filed on a plain workflow. */
@@ -88,18 +92,31 @@ describe('RunDelivery — the deliver lift block', () => {
     expect(screen.queryByTestId('deliver-lift-failure')).toBeNull();
   });
 
-  it('conflict on a rejected unit: files, remedy, and the refusal ONCE — omitted from the lift block when denial_reason already carries it', () => {
+  it("conflict on a rejected unit: files, remedy, and the refusal ONCE — the engine's FRAMED denial_reason (Worker FAILED on unit 5: …) already carries it, so the lift block omits its copy", () => {
     seed(DELIVER_CONFLICT_TAIL);
-    render(<RunDelivery view={view('rejected', REFUSAL_CONFLICT)} />);
+    // As the engine frames it on the plain worker-failure path (actor.rs) — never the bare refusal.
+    const reason = deliverWorkerFailedReason(REFUSAL_CONFLICT);
+    expect(reason.startsWith('Worker FAILED on unit 5: deliver: LIFT-CONFLICT')).toBe(true);
+    render(<RunDelivery view={view('rejected', reason)} />);
     expect(screen.getByTestId('run-delivery')).toHaveAttribute('data-state', 'failed');
     const lift = screen.getByTestId('deliver-lift');
     expect(lift).toHaveAttribute('data-outcome', 'conflict');
     expect(screen.getByTestId('deliver-lift-conflicts')).toHaveTextContent('testid-inventory.json');
     expect(screen.getByTestId('deliver-lift-remedy')).toHaveTextContent('remedy:');
     // The unit's own reason renders verbatim below; the lift block does not repeat it.
-    expect(screen.getByTestId('run-delivery-reason')).toHaveTextContent(REFUSAL_CONFLICT);
+    expect(screen.getByTestId('run-delivery-reason')).toHaveTextContent(reason);
     expect(screen.queryByTestId('deliver-lift-failure')).toBeNull();
     expect(screen.getAllByText(/LIFT-CONFLICT — lifting/)).toHaveLength(1);
+  });
+
+  it("a rejected re-verify failure: the triage-Fail framing (Worker FAILED on unit 5 (triage: …): <150/250 excerpt>) carries the elided detail — omitted from the lift block, said once", () => {
+    seed(DELIVER_REVERIFY_FAILED_TAIL);
+    const reason = deliverRejectedReason(REFUSAL_REVERIFY_FAILED);
+    render(<RunDelivery view={view('rejected', reason)} />);
+    expect(screen.getByTestId('run-delivery-reason')).toHaveTextContent('Worker FAILED on unit 5 (triage:');
+    expect(screen.queryByTestId('deliver-lift-failure')).toBeNull();
+    const card = screen.getByTestId('run-delivery');
+    expect((card.textContent ?? '').split('deliver: the tree that would ship').length - 1).toBe(1);
   });
 
   it('conflict when the unit has NOT resolved yet (the retry gate is open): the refusal renders in the lift block', () => {
@@ -134,7 +151,7 @@ describe('RunDelivery — the deliver lift block', () => {
     expect(screen.getByTestId('deliver-lift-failure')).toHaveTextContent(REFUSAL_WRONG_HEAD.replace(/`/g, ''));
   });
 
-  it('a FAILED re-verify: floor fail, the red check marked, the skipped one named, the refusal names the lockfile drift', () => {
+  it('a FAILED re-verify: floor fail, the red check marked (its stderr tail behind a collapsed block), the skipped one named, the refusal as the wire carries it — elided', () => {
     seed(DELIVER_REVERIFY_FAILED_TAIL);
     render(<RunDelivery view={view('distributed')} />);
     const floor = screen.getByTestId('deliver-lift-floor');
@@ -145,7 +162,23 @@ describe('RunDelivery — the deliver lift block', () => {
     ]);
     expect(screen.getByTestId('deliver-lift-skipped')).toHaveTextContent('skipped (an earlier check failed): test');
     expect(screen.queryByTestId('deliver-lift-changed-tree')).toBeNull();
-    expect(screen.getByTestId('deliver-lift-failure')).toHaveTextContent('Lockfile drift between the old base and the tip (package-lock.json)');
+    // What the wire carries (F-255-04): the 150/250 head+tail of the 532-char refusal — the marker
+    // renders dimmed between the kept words; the lockfile-drift sentence sits in the elided middle.
+    expect(DETAIL_REVERIFY_FAILED).toMatch(/chars elided/);
+    const failure = screen.getByTestId('deliver-lift-failure');
+    expect(failure).toHaveTextContent('deliver: the tree that would ship');
+    expect(within(failure).getByTestId('deliver-lift-failure-elided')).toHaveTextContent(/\[… \d+ chars elided …\]/);
+    expect(failure).not.toHaveTextContent('Lockfile drift between the old base and the tip');
+    expect(failure).toHaveTextContent('the checks run again until the tree passes');
+    // The evidence behind the red row (F-255-03): lint's stderr tail, collapsed; the green rows carry none.
+    const lint = rows.find((r) => r.getAttribute('data-check') === 'lint')!;
+    const tail = within(lint).getByTestId('deliver-lift-check-tail');
+    expect(tail.tagName).toBe('DETAILS');
+    expect(tail).toHaveAttribute('data-stream', 'stderr');
+    expect((tail as HTMLDetailsElement).open).toBe(false);
+    expect(tail).toHaveTextContent('@typescript-eslint/no-explicit-any');
+    expect(within(tail).getByText(/stderr tail/)).toBeInTheDocument();
+    expect(screen.getAllByTestId('deliver-lift-check-tail')).toHaveLength(1);
   });
 
   it('a failed POST-CHECK PROOF: passed:false over all-green rows is explained as "the checks CHANGED the worktree"', () => {

--- a/tests/RunTimeline.wire433.test.tsx
+++ b/tests/RunTimeline.wire433.test.tsx
@@ -1,0 +1,122 @@
+// wicked-core#431 / api-types 0.33.0 in the run evidence TIMELINE (DES-UX-002 §2): the run-base
+// note at the head, the creator-tree restore, the deliver lift (its detail is the shared
+// DeliverLift card) and a refused write — each a row only when its frame is in the log, each with
+// a detail panel that states the engine's facts.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as client from '../src/api/client.js';
+import { RunTimeline, timelineRows } from '../src/components/RunTimeline.js';
+import { useRunEventStore } from '../src/store/events.js';
+import type { CoreEvent } from '../src/api/types.js';
+import { makeUnit, makeView } from './factories.js';
+import { G6_EVENTS, GATE_RUN, GATE_UNITS } from './fixtures/gateEvidence.js';
+import {
+  BASE_AFTER,
+  DELIVER_CONFLICT_TAIL,
+  DELIVER_LIFTED_TAIL,
+  G5R_EVENTS,
+  RUN_BASE_LIFTED,
+  SUGGESTION_REF,
+  TOOL_DENIED,
+} from './fixtures/wire433.js';
+
+const LOG: CoreEvent[] = [
+  { type: 'sessionStarted', session: GATE_RUN, seq: 1, ts: 1789079790000, problem: 'p', workflowId: 'bug', cliCount: 1, governed: true, entityMode: 'shared' },
+  RUN_BASE_LIFTED,
+  ...G5R_EVENTS.slice(0, 1), // the first awaitingHuman (ord 1)
+  TOOL_DENIED,
+  ...G5R_EVENTS.slice(1),
+  ...G6_EVENTS.slice(G5R_EVENTS.length - 4), // the retry through the deliver pre-run gate (approximate seam; ords hold)
+  ...DELIVER_CONFLICT_TAIL,
+];
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  useRunEventStore.setState({ byRun: { [GATE_RUN]: LOG } });
+  vi.spyOn(client.api, 'getUnitOutput').mockResolvedValue({ output: 'x' });
+});
+
+describe('timelineRows — the wicked-core#431 rows', () => {
+  it('runBaseResolved is a head row (no phase) reading the one-line base note', () => {
+    const rows = timelineRows(LOG, GATE_UNITS);
+    const base = rows.find((r) => r.event.type === 'runBaseResolved')!;
+    expect(base.label).toBe('based on');
+    expect(base.meta).toBe(`origin/main @ ${BASE_AFTER.slice(0, 7)} · 5 behind · lifted to the tip`);
+    expect(base.group).toBeNull();
+    expect(base.border).toBeNull();
+  });
+
+  it('worktreeRestored, evaluatorToolCallDenied and deliverLiftEvaluated bucket under their unit\'s phase with the right border', () => {
+    const rows = timelineRows(LOG, GATE_UNITS);
+    const restored = rows.find((r) => r.event.type === 'worktreeRestored')!;
+    expect(restored.label).toBe('↺ restored');
+    expect(restored.meta).toMatch(/creator tree [0-9a-f]{10} · 1 path discarded/);
+    expect(restored.group).toBe('phase: test');
+    expect(restored.border).toBe('gate');
+    const denied = rows.find((r) => r.event.type === 'evaluatorToolCallDenied')!;
+    expect(denied.label).toBe('✗ write refused');
+    expect(denied.meta).toBe('claude · edit src/App.tsx');
+    expect(denied.border).toBe('fail');
+    const lift = rows.find((r) => r.event.type === 'deliverLiftEvaluated')!;
+    expect(lift.label).toBe('lift');
+    expect(lift.meta).toBe('LIFT-CONFLICT · testid-inventory.json');
+    expect(lift.group).toBe('phase: build');
+    expect(lift.border).toBe('fail');
+  });
+
+  it('a lifted outcome names the tip; unchanged/skipped have no failure border', () => {
+    const rows = timelineRows([...G6_EVENTS, ...DELIVER_LIFTED_TAIL], GATE_UNITS);
+    const lift = rows.find((r) => r.event.type === 'deliverLiftEvaluated')!;
+    expect(lift.meta).toBe(`lifted onto the current tip · origin/main @ ${BASE_AFTER.slice(0, 7)}`);
+    expect(lift.border).toBeNull();
+  });
+
+  it('a log without the frames (the recorded pre-0.33.0 corpus) grows no rows', () => {
+    const types = new Set(timelineRows(G6_EVENTS, GATE_UNITS).map((r) => r.event.type));
+    for (const t of ['runBaseResolved', 'worktreeRestored', 'deliverLiftEvaluated', 'evaluatorToolCallDenied']) expect(types.has(t)).toBe(false);
+  });
+});
+
+describe('RunTimeline — the detail panels', () => {
+  const view = makeView({ id: GATE_RUN, status: 'failed', problem: 'p' }, GATE_UNITS);
+
+  it('the base row\'s detail states the commits and the fetch; the lift row\'s detail is the shared DeliverLift card', async () => {
+    render(<RunTimeline view={view} />);
+    const rows = screen.getAllByTestId('timeline-row');
+    await userEvent.click(rows.find((r) => r.getAttribute('data-event-type') === 'runBaseResolved')!);
+    const base = screen.getByTestId('run-base-detail');
+    expect(base).toHaveTextContent(`Run base — origin/main @ ${BASE_AFTER.slice(0, 7)} · 5 behind · lifted to the tip`);
+    expect(base).toHaveTextContent(`worktree minted from ${BASE_AFTER}`);
+    expect(base).toHaveTextContent('git fetch origin succeeded');
+
+    await userEvent.click(rows.find((r) => r.getAttribute('data-event-type') === 'deliverLiftEvaluated')!);
+    const lift = within(screen.getByTestId('timeline-detail')).getByTestId('deliver-lift');
+    expect(lift).toHaveAttribute('data-outcome', 'conflict');
+    expect(within(lift).getByTestId('deliver-lift-failure')).toHaveTextContent('deliver: LIFT-CONFLICT');
+  });
+
+  it('the restore row\'s detail lists the discarded paths and the git show hint; the refused write\'s detail states the reason', async () => {
+    render(<RunTimeline view={view} />);
+    const rows = screen.getAllByTestId('timeline-row');
+    await userEvent.click(rows.find((r) => r.getAttribute('data-event-type') === 'worktreeRestored')!);
+    const restored = screen.getByTestId('worktree-restored-detail');
+    expect(restored).toHaveTextContent('Creator tree restored — unit 4 · verify by pi');
+    expect(restored).toHaveTextContent('discarded: M src/App.tsx');
+    expect(restored).toHaveTextContent(`git show ${SUGGESTION_REF}`);
+
+    await userEvent.click(rows.find((r) => r.getAttribute('data-event-type') === 'evaluatorToolCallDenied')!);
+    const denied = screen.getByTestId('tool-call-denied-detail');
+    expect(denied).toHaveTextContent('Write refused — unit 4 · claude asked for edit on src/App.tsx');
+    expect(denied).toHaveTextContent('write-class tool call from an executes_code:false phase');
+    expect(denied).toHaveTextContent('refused at the acp permission boundary');
+  });
+
+  it('a restore record with no pin says so in the detail', async () => {
+    useRunEventStore.setState({ byRun: { [GATE_RUN]: LOG.map((e) => (e.type === 'worktreeRestored' ? { ...e, suggestionRef: null } : e)) } });
+    render(<RunTimeline view={makeView({ id: GATE_RUN, status: 'failed', problem: 'p' }, [makeUnit({ id: `${GATE_RUN}:verify`, ord: 4, stage: 'test' })])} />);
+    await userEvent.click(screen.getAllByTestId('timeline-row').find((r) => r.getAttribute('data-event-type') === 'worktreeRestored')!);
+    expect(screen.getByTestId('worktree-restored-detail')).toHaveTextContent('the discarded edit was not pinned (no suggestion ref)');
+  });
+});

--- a/tests/SteeringGate.wire433.test.tsx
+++ b/tests/SteeringGate.wire433.test.tsx
@@ -1,0 +1,252 @@
+// wicked-core#431 / api-types 0.33.0 on the GATE CARD (studio #250/#252 follow-through):
+//
+//   1. the judge SEAT on the verdict header (`judgeCli`), and a same-seat warning when
+//      `judgeDistinct` is false — evaluator ≠ creator is the doctrine, so "the judge fell back to
+//      the single default runner" is said on the card, not buried; a frame without the fields
+//      claims no seat (the recorded pre-0.33.0 corpus keeps its "no seat" line);
+//   2. the RESTORED denial: "the evaluator's edit was discarded and the creator's verified tree
+//      restored", the worktreeRestored record's discarded paths, the pinned ref with a copyable
+//      `git show <ref>` hint (or the honest "not pinned"); a FAILED restore says so and keeps the
+//      manual remedy; the recorded pre-0.33.0 fold renders neither;
+//   3. Approve relabelled "Retry against the restored tree" on that gate ONLY — keyed on the
+//      evidence frames, never on the prompt text, which changed with the engine ("confirm to retry
+//      the phase" → "Approve to retry the phase against the restored tree") and still matches the
+//      card's NOT PASS classification either way;
+//   4. the deliver lift on a gate opened on the deliver unit (a LIFT-CONFLICT retry gate; the
+//      addendum's refused-before-the-lift gate), and NOT on the pre-run deliver gate.
+
+import { cleanup, render, screen, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as client from '../src/api/client.js';
+import { SteeringGate } from '../src/components/SteeringGate.js';
+import { useAnnotationStore } from '../src/store/annotations.js';
+import { useRunEventStore } from '../src/store/events.js';
+import { useGateStore } from '../src/store/gates.js';
+import { G4_EVENTS, G4_GATE, G5_EVENTS, G5_GATE, G6_EVENTS, G6_GATE, GATE_RUN, GATE_UNITS, TREE_BEFORE } from './fixtures/gateEvidence.js';
+import {
+  DELIVER_CONFLICT_TAIL,
+  DELIVER_RETRY_GATE,
+  DELIVER_WRONG_HEAD_TAIL,
+  G4_SAME_SEAT_EVENTS,
+  G5R_EVENTS,
+  G5R_GATE,
+  G5R_UNPINNED_EVENTS,
+  G5_RESTORE_FAILED_EVENTS,
+  LEGACY_PROMPT,
+  RESTORE_FAILED_ERROR,
+  RUN_BRANCH,
+  SUGGESTION_REF,
+} from './fixtures/wire433.js';
+
+function mount(events: readonly unknown[], gate: { ord: number; prompt: string }): { unmount: () => void } {
+  useRunEventStore.setState({ byRun: { [GATE_RUN]: events as never } });
+  return render(<SteeringGate runId={GATE_RUN} ord={gate.ord} prompt={gate.prompt} units={GATE_UNITS} />);
+}
+
+afterEach(() => cleanup());
+
+describe('SteeringGate — the judge seat (F-3R2-007)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    useGateStore.setState({ gates: {} });
+    useAnnotationStore.setState({ drafts: {} });
+    useRunEventStore.setState({ byRun: {} });
+    vi.spyOn(client.api, 'confirmGate').mockResolvedValue({ status: 'ok' });
+  });
+
+  it('a distinct judge seat is named on the header; no same-seat warning', () => {
+    mount(G5R_EVENTS, G5R_GATE);
+    const seat = screen.getByTestId('gate-verdict-judge-seat');
+    expect(seat).toHaveTextContent('judge: codex');
+    expect(seat).toHaveAttribute('data-judge-cli', 'codex');
+    expect(seat).toHaveAttribute('data-judge-distinct', 'true');
+    expect(screen.getByTestId('gate-verdict')).toHaveTextContent('Evaluator verdict — verify · DENIED · judge: codex');
+    expect(screen.queryByTestId('gate-verdict-judge-same-seat')).toBeNull();
+    // The judge's own verdict word is still stated beside its seat.
+    expect(screen.getByTestId('gate-verdict-judge')).toHaveTextContent('judge: pass');
+  });
+
+  it('judgeDistinct:false flags "same seat as the creator" — evaluator ≠ creator not held on this verdict', () => {
+    mount(G4_SAME_SEAT_EVENTS, G4_GATE);
+    expect(screen.getByTestId('gate-verdict-judge-seat')).toHaveTextContent('judge: claude');
+    expect(screen.getByTestId('gate-verdict-judge-seat')).toHaveAttribute('data-judge-distinct', 'false');
+    const warn = screen.getByTestId('gate-verdict-judge-same-seat');
+    expect(warn).toHaveTextContent('same seat as the creator');
+    expect(warn).toHaveTextContent('evaluator ≠ creator is not held on this verdict');
+  });
+
+  it('a frame without the fields (the recorded pre-0.33.0 corpus) claims no seat', () => {
+    mount(G4_EVENTS, G4_GATE);
+    expect(screen.queryByTestId('gate-verdict-judge-seat')).toBeNull();
+    expect(screen.queryByTestId('gate-verdict-judge-same-seat')).toBeNull();
+    expect(screen.getByTestId('gate-verdict').textContent).not.toMatch(/judge: (codex|claude|pi)/);
+  });
+});
+
+describe('SteeringGate — the restored-tree denial (F-3R2-010)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    useGateStore.setState({ gates: {} });
+    useAnnotationStore.setState({ drafts: {} });
+    useRunEventStore.setState({ byRun: {} });
+    vi.spyOn(client.api, 'confirmGate').mockResolvedValue({ status: 'ok' });
+  });
+
+  it('restored:true — the discard/restore sentence, the discarded path, the pinned ref and a copyable git show hint; the denial prose still verbatim', () => {
+    mount(G5R_EVENTS, G5R_GATE);
+    expect(screen.getByTestId('steering-prompt')).toHaveTextContent("its edit was discarded and the creator's verified tree restored");
+
+    const card = screen.getByTestId('gate-verdict');
+    expect(card).toHaveAttribute('data-verdict', 'fail');
+    expect(card).toHaveAttribute('data-denial-source', 'worktree_guard');
+
+    const restored = screen.getByTestId('gate-verdict-restored');
+    expect(restored).toHaveTextContent("the evaluator's edit was discarded and the creator's verified tree restored");
+    expect(restored).toHaveTextContent('discarded: M src/App.tsx');
+    expect(restored).toHaveTextContent(`(tree ${TREE_BEFORE.slice(0, 10)})`);
+    expect(restored).toHaveAttribute('data-suggestion-ref', SUGGESTION_REF);
+    expect(restored).toHaveTextContent(`the edit is kept at ${SUGGESTION_REF}`);
+    const hint = screen.getByTestId('gate-verdict-suggestion-hint');
+    expect(hint.tagName).toBe('CODE');
+    expect(hint).toHaveTextContent(`git show ${SUGGESTION_REF}`);
+    expect(hint.style.userSelect).toBe('all');
+    expect(restored).not.toHaveTextContent('HEAD reset'); // head: null — the branch had not moved
+
+    // The engine's own prose still renders verbatim — it now SAYS the edit was discarded, and no
+    // longer carries a read-tree command to run by hand.
+    const denial = screen.getByTestId('gate-verdict-denial');
+    expect(denial).toHaveTextContent("The evaluator's edit was DISCARDED: the engine restored the creator's tree");
+    expect(within(denial).queryByText((_, el) => el?.tagName === 'CODE' && (el.textContent ?? '').startsWith('git read-tree'))).toBeNull();
+    expect(screen.queryByTestId('gate-verdict-restore-failed')).toBeNull();
+    // The mutation line keeps its own facts.
+    expect(screen.getByTestId('gate-verdict-mutation')).toHaveTextContent('worktree changed by pi during verify: M src/App.tsx');
+  });
+
+  it('a failed pin says the edit was not pinned — no git show hint invented', () => {
+    mount(G5R_UNPINNED_EVENTS, G5R_GATE);
+    const restored = screen.getByTestId('gate-verdict-restored');
+    expect(restored).toHaveTextContent('the discarded edit was not pinned (no suggestion ref)');
+    expect(restored).not.toHaveAttribute('data-suggestion-ref');
+    expect(screen.queryByTestId('gate-verdict-suggestion-hint')).toBeNull();
+  });
+
+  it('restored:false — the restore failed, the error is named, the manual remedy (the read-tree command) stands as code', () => {
+    mount(G5_RESTORE_FAILED_EVENTS, { ord: 4, prompt: LEGACY_PROMPT });
+    expect(screen.queryByTestId('gate-verdict-restored')).toBeNull();
+    const failed = screen.getByTestId('gate-verdict-restore-failed');
+    expect(failed).toHaveTextContent("the creator's tree was NOT restored");
+    expect(failed).toHaveTextContent(RESTORE_FAILED_ERROR);
+    expect(failed).toHaveTextContent('the manual remedy in the denial stands');
+    const denial = screen.getByTestId('gate-verdict-denial');
+    const codes = within(denial).getAllByText((_, el) => el?.tagName === 'CODE' && (el.textContent ?? '').startsWith('git read-tree'));
+    expect(codes).toHaveLength(1);
+    expect(codes[0]).toHaveTextContent(`git read-tree --reset -u ${TREE_BEFORE}`);
+  });
+
+  it('the recorded pre-0.33.0 fold (no restored field) renders neither block — nothing is fabricated for an older daemon', () => {
+    mount(G5_EVENTS, G5_GATE);
+    expect(screen.getByTestId('gate-verdict-mutation')).toBeInTheDocument();
+    expect(screen.queryByTestId('gate-verdict-restored')).toBeNull();
+    expect(screen.queryByTestId('gate-verdict-restore-failed')).toBeNull();
+  });
+});
+
+describe('SteeringGate — Approve means "retry against the restored tree" exactly when the engine restored it', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    useGateStore.setState({ gates: {} });
+    useAnnotationStore.setState({ drafts: {} });
+    useRunEventStore.setState({ byRun: {} });
+    vi.spyOn(client.api, 'confirmGate').mockResolvedValue({ status: 'ok' });
+  });
+
+  it('relabels Approve / Approve + steer on the restored-tree denial gate and marks the card', () => {
+    mount(G5R_EVENTS, G5R_GATE);
+    expect(screen.getByTestId('steering-gate')).toHaveAttribute('data-retry-restored', 'true');
+    expect(screen.getByTestId('steering-approve')).toHaveTextContent('Retry against the restored tree');
+    expect(screen.getByTestId('steering-approve-steer')).toHaveTextContent('Retry + steer');
+    expect(screen.getByTestId('steering-reject')).toHaveTextContent('Reject');
+    expect(screen.getByTestId('steering-gate')).toHaveTextContent('a retry · r reject');
+  });
+
+  it('the relabel keys on the frames, not the prompt: the same frames with the OLD prompt still relabel', () => {
+    mount(G5R_EVENTS, { ord: 4, prompt: LEGACY_PROMPT });
+    expect(screen.getByTestId('steering-approve')).toHaveTextContent('Retry against the restored tree');
+  });
+
+  it('stays "Approve" when the restore failed, on the recorded pre-0.33.0 fold, and on a pre-run gate whose deciding verdict passed', () => {
+    let m = mount(G5_RESTORE_FAILED_EVENTS, { ord: 4, prompt: LEGACY_PROMPT });
+    expect(screen.getByTestId('steering-approve')).toHaveTextContent('Approve');
+    expect(screen.getByTestId('steering-gate')).not.toHaveAttribute('data-retry-restored');
+    m.unmount();
+
+    m = mount(G5_EVENTS, G5_GATE);
+    expect(screen.getByTestId('steering-approve')).toHaveTextContent('Approve');
+    expect(screen.getByTestId('steering-approve')).not.toHaveTextContent('Retry');
+    m.unmount();
+
+    // The gate BEFORE unit #5 after the restored-and-retried verify PASSED: its deciding verdict is
+    // the ord-4 PASS (no mutation on that fold), so the button is the ordinary Approve.
+    mount([...G5R_EVENTS, ...G6_EVENTS.slice(G5_EVENTS.length)], G6_GATE);
+    expect(screen.getByTestId('gate-verdict')).toHaveAttribute('data-verdict', 'pass');
+    expect(screen.getByTestId('steering-approve')).toHaveTextContent('Approve');
+    expect(screen.queryByTestId('gate-verdict-restored')).toBeNull();
+  });
+
+  it('the NOT PASS classification holds for both prompt spellings (the old string match re-checked)', () => {
+    // Neither prompt has coverage data behind it here, so the only observable is that the card
+    // renders the headline whole — the isCoverageFail branch is exercised without asserting a
+    // fetch. Both spellings contain "NOT PASS".
+    const m = mount(G5R_EVENTS, G5R_GATE);
+    expect(screen.getByTestId('steering-prompt')).toHaveTextContent(/NOT PASS/);
+    m.unmount();
+    mount(G5_EVENTS, G5_GATE);
+    expect(screen.getByTestId('steering-prompt')).toHaveTextContent(/NOT PASS/);
+  });
+});
+
+describe('SteeringGate — the deliver lift on a gate opened on the deliver unit (F-3R2-013)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    useGateStore.setState({ gates: {} });
+    useAnnotationStore.setState({ drafts: {} });
+    useRunEventStore.setState({ byRun: {} });
+    vi.spyOn(client.api, 'confirmGate').mockResolvedValue({ status: 'ok' });
+  });
+
+  it('a LIFT-CONFLICT retry gate renders the lift block: outcome, files, the remedy, the engine\'s refusal verbatim', () => {
+    mount([...G6_EVENTS, ...DELIVER_CONFLICT_TAIL], DELIVER_RETRY_GATE);
+    // The deciding evaluation is still the ord-4 PASS — the deliver unit never reached a verdict.
+    expect(screen.getByTestId('gate-verdict')).toHaveAttribute('data-verdict', 'pass');
+    const lift = screen.getByTestId('deliver-lift');
+    expect(lift).toHaveAttribute('data-outcome', 'conflict');
+    expect(lift).toHaveTextContent('Deliver lift — LIFT-CONFLICT');
+    expect(screen.getByTestId('deliver-lift-conflicts')).toHaveTextContent('testid-inventory.json');
+    expect(screen.getByTestId('deliver-lift-summary')).toHaveTextContent('nothing was rebased and nothing was pushed');
+    expect(screen.getByTestId('deliver-lift-remedy')).toHaveTextContent('rebase onto origin/main, resolve testid-inventory.json');
+    expect(screen.getByTestId('deliver-lift-failure')).toHaveTextContent('deliver: LIFT-CONFLICT — lifting the run\'s work onto origin/main');
+    expect(screen.getByTestId('steering-approve')).toHaveTextContent('Approve'); // not a restored-tree gate
+  });
+
+  it('the addendum: refused for a wrong HEAD ref with NO lift frame — the deliver: text renders on its own', () => {
+    mount([...G6_EVENTS, ...DELIVER_WRONG_HEAD_TAIL], DELIVER_RETRY_GATE);
+    const lift = screen.getByTestId('deliver-lift');
+    expect(lift).toHaveAttribute('data-outcome', 'refused');
+    expect(lift).toHaveTextContent('Deliver lift — refused before the lift');
+    expect(screen.queryByTestId('deliver-lift-summary')).toBeNull();
+    expect(screen.queryByTestId('deliver-lift-remedy')).toBeNull();
+    const failure = screen.getByTestId('deliver-lift-failure');
+    expect(failure).toHaveTextContent("deliver: the worktree's HEAD is attached to refs/heads/main, not the run branch");
+    // Quoted refs render as code, so the remedy's branch name is copyable.
+    const codes = within(failure).getAllByText((_, el) => el?.tagName === 'CODE' && (el.textContent ?? '') === RUN_BRANCH);
+    expect(codes.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('the pre-run deliver gate (no deliver-ord frames yet) and a non-deliver gate render no lift block', () => {
+    const m = mount(G6_EVENTS, G6_GATE);
+    expect(screen.queryByTestId('deliver-lift')).toBeNull();
+    m.unmount();
+    mount([...G6_EVENTS, ...DELIVER_CONFLICT_TAIL], G5R_GATE); // a gate on ord 4 sees no ord-5 lift
+    expect(screen.queryByTestId('deliver-lift')).toBeNull();
+  });
+});

--- a/tests/SteeringGate.wire433.test.tsx
+++ b/tests/SteeringGate.wire433.test.tsx
@@ -15,33 +15,42 @@
 //   4. the deliver lift on a gate opened on the deliver unit (a LIFT-CONFLICT retry gate; the
 //      addendum's refused-before-the-lift gate), and NOT on the pre-run deliver gate.
 
-import { cleanup, render, screen, within } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as client from '../src/api/client.js';
+import type { CoreEvent } from '../src/api/types.js';
 import { SteeringGate } from '../src/components/SteeringGate.js';
 import { useAnnotationStore } from '../src/store/annotations.js';
 import { useRunEventStore } from '../src/store/events.js';
 import { useGateStore } from '../src/store/gates.js';
-import { G4_EVENTS, G4_GATE, G5_EVENTS, G5_GATE, G6_EVENTS, G6_GATE, GATE_RUN, GATE_UNITS, TREE_BEFORE } from './fixtures/gateEvidence.js';
+import { G4_EVENTS, G4_GATE, G5_EVENTS, G5_GATE, G6_EVENTS, G6_GATE, GATE_RUN, GATE_UNITS, REPO_CHECKS_FAIL, TREE_BEFORE } from './fixtures/gateEvidence.js';
 import {
   DELIVER_CONFLICT_TAIL,
-  DELIVER_RETRY_GATE,
+  DELIVER_REVERIFY_FAILED_TAIL,
   DELIVER_WRONG_HEAD_TAIL,
+  DETAIL_REVERIFY_FAILED,
   G4_SAME_SEAT_EVENTS,
   G5R_EVENTS,
   G5R_GATE,
   G5R_UNPINNED_EVENTS,
   G5_RESTORE_FAILED_EVENTS,
   LEGACY_PROMPT,
+  REFUSAL_CONFLICT,
+  REFUSAL_REVERIFY_FAILED,
+  REFUSAL_WRONG_HEAD,
   RESTORE_FAILED_ERROR,
   RUN_BRANCH,
   SUGGESTION_REF,
+  deliverRetryGate,
 } from './fixtures/wire433.js';
 
 function mount(events: readonly unknown[], gate: { ord: number; prompt: string }): { unmount: () => void } {
   useRunEventStore.setState({ byRun: { [GATE_RUN]: events as never } });
   return render(<SteeringGate runId={GATE_RUN} ord={gate.ord} prompt={gate.prompt} units={GATE_UNITS} />);
 }
+
+/** How many times `needle` occurs in the element's text — "the refusal reads once" is a count, not a presence. */
+const mentions = (el: HTMLElement, needle: string): number => (el.textContent ?? '').split(needle).length - 1;
 
 afterEach(() => cleanup());
 
@@ -92,7 +101,7 @@ describe('SteeringGate — the restored-tree denial (F-3R2-010)', () => {
     vi.spyOn(client.api, 'confirmGate').mockResolvedValue({ status: 'ok' });
   });
 
-  it('restored:true — the discard/restore sentence, the discarded path, the pinned ref and a copyable git show hint; the denial prose still verbatim', () => {
+  it('restored:true — the discard/restore sentence, the discarded path, the pinned ref and a copyable git show hint; the denial prose still verbatim', async () => {
     mount(G5R_EVENTS, G5R_GATE);
     expect(screen.getByTestId('steering-prompt')).toHaveTextContent("its edit was discarded and the creator's verified tree restored");
 
@@ -110,6 +119,16 @@ describe('SteeringGate — the restored-tree denial (F-3R2-010)', () => {
     expect(hint.tagName).toBe('CODE');
     expect(hint).toHaveTextContent(`git show ${SUGGESTION_REF}`);
     expect(hint.style.userSelect).toBe('all');
+    // F-255-06: the hint is also a REAL button — focusable, with an accessible name — that puts the
+    // command on the clipboard and says so.
+    const writeText = vi.fn(async () => {});
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
+    const copy = within(restored).getByRole('button', { name: `copy git show ${SUGGESTION_REF}` });
+    expect(copy.tagName).toBe('BUTTON');
+    expect(copy).toHaveAttribute('data-command', `git show ${SUGGESTION_REF}`);
+    fireEvent.click(copy);
+    expect(writeText).toHaveBeenCalledWith(`git show ${SUGGESTION_REF}`);
+    expect(await screen.findByText('copied')).toBe(copy);
     expect(restored).not.toHaveTextContent('HEAD reset'); // head: null — the branch had not moved
 
     // The engine's own prose still renders verbatim — it now SAYS the edit was discarded, and no
@@ -128,6 +147,7 @@ describe('SteeringGate — the restored-tree denial (F-3R2-010)', () => {
     expect(restored).toHaveTextContent('the discarded edit was not pinned (no suggestion ref)');
     expect(restored).not.toHaveAttribute('data-suggestion-ref');
     expect(screen.queryByTestId('gate-verdict-suggestion-hint')).toBeNull();
+    expect(within(restored).queryByRole('button', { name: /^copy / })).toBeNull();
   });
 
   it('restored:false — the restore failed, the error is named, the manual remedy (the read-tree command) stands as code', () => {
@@ -214,32 +234,61 @@ describe('SteeringGate — the deliver lift on a gate opened on the deliver unit
     vi.spyOn(client.api, 'confirmGate').mockResolvedValue({ status: 'ok' });
   });
 
-  it('a LIFT-CONFLICT retry gate renders the lift block: outcome, files, the remedy, the engine\'s refusal verbatim', () => {
-    mount([...G6_EVENTS, ...DELIVER_CONFLICT_TAIL], DELIVER_RETRY_GATE);
+  it("a LIFT-CONFLICT retry gate renders the lift block — outcome, files, the remedy — and the refusal ONCE: the engine's escalate prompt already quotes it", () => {
+    mount([...G6_EVENTS, ...DELIVER_CONFLICT_TAIL], deliverRetryGate(REFUSAL_CONFLICT));
     // The deciding evaluation is still the ord-4 PASS — the deliver unit never reached a verdict.
     expect(screen.getByTestId('gate-verdict')).toHaveAttribute('data-verdict', 'pass');
+    // The engine's prompt, format string filled (actor.rs TriageDecision::Escalate): it QUOTES the failure.
+    expect(screen.getByTestId('steering-prompt')).toHaveTextContent('Unit 5 failed and triage escalated');
+    expect(screen.getByTestId('steering-prompt')).toHaveTextContent('Failure output: "deliver: LIFT-CONFLICT');
     const lift = screen.getByTestId('deliver-lift');
     expect(lift).toHaveAttribute('data-outcome', 'conflict');
     expect(lift).toHaveTextContent('Deliver lift — LIFT-CONFLICT');
     expect(screen.getByTestId('deliver-lift-conflicts')).toHaveTextContent('testid-inventory.json');
     expect(screen.getByTestId('deliver-lift-summary')).toHaveTextContent('nothing was rebased and nothing was pushed');
     expect(screen.getByTestId('deliver-lift-remedy')).toHaveTextContent('rebase onto origin/main, resolve testid-inventory.json');
-    expect(screen.getByTestId('deliver-lift-failure')).toHaveTextContent('deliver: LIFT-CONFLICT — lifting the run\'s work onto origin/main');
+    // Once on the whole card (F-255-02): the prompt carries it, so the lift block omits its copy.
+    expect(screen.queryByTestId('deliver-lift-failure')).toBeNull();
+    expect(mentions(screen.getByTestId('steering-gate'), "LIFT-CONFLICT — lifting the run's work")).toBe(1);
     expect(screen.getByTestId('steering-approve')).toHaveTextContent('Approve'); // not a restored-tree gate
   });
 
-  it('the addendum: refused for a wrong HEAD ref with NO lift frame — the deliver: text renders on its own', () => {
-    mount([...G6_EVENTS, ...DELIVER_WRONG_HEAD_TAIL], DELIVER_RETRY_GATE);
+  it('the addendum: refused for a wrong HEAD ref with NO lift frame — the deliver: text once, from the prompt', () => {
+    mount([...G6_EVENTS, ...DELIVER_WRONG_HEAD_TAIL], deliverRetryGate(REFUSAL_WRONG_HEAD));
     const lift = screen.getByTestId('deliver-lift');
     expect(lift).toHaveAttribute('data-outcome', 'refused');
     expect(lift).toHaveTextContent('Deliver lift — refused before the lift');
     expect(screen.queryByTestId('deliver-lift-summary')).toBeNull();
     expect(screen.queryByTestId('deliver-lift-remedy')).toBeNull();
+    expect(screen.queryByTestId('deliver-lift-failure')).toBeNull();
+    expect(mentions(screen.getByTestId('steering-gate'), "deliver: the worktree's HEAD is attached to")).toBe(1);
+  });
+
+  it('a prompt that does NOT carry the refusal (the daemon-restart fallback) leaves the lift block to say it — quoted refs as copyable code', () => {
+    mount([...G6_EVENTS, ...DELIVER_WRONG_HEAD_TAIL], { ord: 5, prompt: 'Prompt unavailable (daemon restarted) — you can still approve or reject.' });
     const failure = screen.getByTestId('deliver-lift-failure');
     expect(failure).toHaveTextContent("deliver: the worktree's HEAD is attached to refs/heads/main, not the run branch");
-    // Quoted refs render as code, so the remedy's branch name is copyable.
     const codes = within(failure).getAllByText((_, el) => el?.tagName === 'CODE' && (el.textContent ?? '') === RUN_BRANCH);
     expect(codes.length).toBeGreaterThanOrEqual(1);
+    expect(mentions(screen.getByTestId('steering-gate'), "deliver: the worktree's HEAD is attached to")).toBe(1);
+  });
+
+  it('a failed re-verify: the 532-char refusal reaches the wire ELIDED (150/250) yet the wider prompt excerpt still dedupes it; the red lint row exposes its stderr tail, collapsed', () => {
+    mount([...G6_EVENTS, ...DELIVER_REVERIFY_FAILED_TAIL], deliverRetryGate(REFUSAL_REVERIFY_FAILED));
+    expect(DETAIL_REVERIFY_FAILED).toMatch(/chars elided/);
+    expect(screen.queryByTestId('deliver-lift-failure')).toBeNull();
+    expect(mentions(screen.getByTestId('steering-gate'), 'deliver: the tree that would ship')).toBe(1);
+    expect(screen.getByTestId('deliver-lift-floor')).toHaveAttribute('data-floor', 'fail');
+    // F-255-03: only the red row carries a tail — a passing check's output is not evidence of anything.
+    const tails = screen.getAllByTestId('deliver-lift-check-tail');
+    expect(tails).toHaveLength(1);
+    expect(tails[0]).toHaveAttribute('data-stream', 'stderr');
+    expect(tails[0]!.tagName).toBe('DETAILS');
+    expect((tails[0] as HTMLDetailsElement).open).toBe(false);
+    expect(tails[0]).toHaveTextContent('@typescript-eslint/no-explicit-any');
+    expect(within(tails[0]!).getByText(/stderr tail/)).toBeInTheDocument();
+    const lint = screen.getAllByTestId('deliver-lift-check').find((r) => r.getAttribute('data-check') === 'lint')!;
+    expect(within(lint).getByTestId('deliver-lift-check-tail')).toBe(tails[0]);
   });
 
   it('the pre-run deliver gate (no deliver-ord frames yet) and a non-deliver gate render no lift block', () => {
@@ -248,5 +297,42 @@ describe('SteeringGate — the deliver lift on a gate opened on the deliver unit
     m.unmount();
     mount([...G6_EVENTS, ...DELIVER_CONFLICT_TAIL], G5R_GATE); // a gate on ord 4 sees no ord-5 lift
     expect(screen.queryByTestId('deliver-lift')).toBeNull();
+  });
+});
+
+describe('GateVerdict — the evidence behind a red repository check (F-255-03)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    useGateStore.setState({ gates: {} });
+    useAnnotationStore.setState({ drafts: {} });
+    useRunEventStore.setState({ byRun: {} });
+    vi.spyOn(client.api, 'confirmGate').mockResolvedValue({ status: 'ok' });
+  });
+
+  it('a failed check exposes its recorded stderr tail as a collapsed block on the gate card; passing rows and empty streams show none', () => {
+    // The recorded repo-checks denial fold (the same frames the inbox test uses): the floor failed on lint.
+    const REPO_CHECKS_DENY: CoreEvent = {
+      type: 'gateEvaluated', session: GATE_RUN, ord: 4, seq: 403, ts: 1789081879700,
+      criterion: "the repository's own checks pass in the run's worktree",
+      hasDeterministicFloor: true, deterministicPass: false, agentVerdict: 'pass', agentReasoning: null,
+      evaluatorPass: true, evaluatorPolicies: [],
+      denialReason: 'repository checks failed in the worktree: lint exited 1',
+      denial: { source: 'repo_checks', reason: 'repository checks failed in the worktree: lint exited 1', claimId: null, ruleIds: [], deniedTool: null, phase: 'unit-4' },
+      combined: false, judgeCli: null, judgeDistinct: null,
+    };
+    mount([...G5_EVENTS, REPO_CHECKS_FAIL, REPO_CHECKS_DENY], { ord: 4, prompt: G5_GATE.prompt });
+    expect(screen.getByTestId('gate-verdict-floor')).toHaveAttribute('data-floor', 'fail');
+    const tails = screen.getAllByTestId('gate-verdict-check-tail');
+    expect(tails).toHaveLength(1);
+    expect(tails[0]).toHaveAttribute('data-stream', 'stderr');
+    expect(tails[0]!.tagName).toBe('DETAILS');
+    expect((tails[0] as HTMLDetailsElement).open).toBe(false);
+    expect(tails[0]).toHaveTextContent('@typescript-eslint/no-explicit-any');
+    const red = screen.getAllByTestId('gate-verdict-check').find((r) => r.getAttribute('data-ok') === 'false')!;
+    expect(within(red).getByTestId('gate-verdict-check-tail')).toBe(tails[0]);
+    // The recorded pre-0.33.0 fold's floor (pass, every row green) shows no tail at all.
+    cleanup();
+    mount(G6_EVENTS, G6_GATE);
+    expect(screen.queryByTestId('gate-verdict-check-tail')).toBeNull();
   });
 });

--- a/tests/WhatWhere.base.test.tsx
+++ b/tests/WhatWhere.base.test.tsx
@@ -1,0 +1,52 @@
+// wicked-core#431 / api-types 0.33.0 on the run HEADER's context rows (WhatWhere): the one-line
+// "based on origin/<ref> @ <commit>, N behind, lifted" note, present exactly when the run's log
+// carries `runBaseResolved` — a resumed run and a pre-0.33.0 daemon show no base row at all.
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { mergeRunModel } from '../src/hooks/useRunModel.js';
+import { WhatWhere } from '../src/components/WhatWhere.js';
+import { useRunEventStore } from '../src/store/events.js';
+import type { CoreEvent } from '../src/api/types.js';
+import { makeUnit, makeView } from './factories.js';
+import { G4_EVENTS, GATE_RUN } from './fixtures/gateEvidence.js';
+import { BASE_AFTER, BASE_BEFORE, RUN_BASE_FETCH_FAILED, RUN_BASE_LIFTED, RUN_BASE_NO_REMOTE } from './fixtures/wire433.js';
+
+function mount(events: CoreEvent[]): void {
+  useRunEventStore.setState({ byRun: { [GATE_RUN]: events } });
+  const view = makeView({ id: GATE_RUN, status: 'executing', problem: 'fix the reported issue', clis: ['claude'], repo_ref: 'studio-api' }, [
+    makeUnit({ id: `${GATE_RUN}:triage`, session_id: GATE_RUN, ord: 1, stage: 'recon', status: 'done' }),
+  ]);
+  render(<WhatWhere model={mergeRunModel(view, events)} />);
+}
+
+beforeEach(() => useRunEventStore.setState({ byRun: {} }));
+
+describe('WhatWhere — the base row', () => {
+  it('lifted: "origin/main @ <commit> · N behind · lifted to the tip"', () => {
+    mount([RUN_BASE_LIFTED, ...G4_EVENTS]);
+    const row = screen.getByTestId('run-base');
+    expect(row).toHaveTextContent('base');
+    expect(row).toHaveTextContent(`origin/main @ ${BASE_AFTER.slice(0, 7)} · 5 behind · lifted to the tip`);
+    expect(row.querySelector('[title]')).toBeNull(); // no note ⇒ no hover text
+  });
+
+  it('no remote default branch: the local HEAD is named, the engine\'s note is the hover text', () => {
+    mount([RUN_BASE_NO_REMOTE]);
+    const row = screen.getByTestId('run-base');
+    expect(row).toHaveTextContent(`local HEAD @ ${BASE_BEFORE.slice(0, 7)} · no remote default branch resolved`);
+    expect(row.querySelector('[title]')).toHaveAttribute('title', 'no remote default branch resolved (origin/HEAD is unset)');
+  });
+
+  it('a failed fetch is disclosed on the row', () => {
+    mount([RUN_BASE_FETCH_FAILED]);
+    expect(screen.getByTestId('run-base')).toHaveTextContent('fetch failed — cached refs');
+  });
+
+  it('no runBaseResolved in the log (a resumed run, an older daemon) ⇒ no base row; the other rows stand', () => {
+    mount(G4_EVENTS);
+    expect(screen.queryByTestId('run-base')).toBeNull();
+    expect(screen.getByTestId('what-where')).toHaveTextContent('repo');
+    expect(screen.getByTestId('what-where')).toHaveTextContent('studio-api');
+  });
+});

--- a/tests/fixtures/wire433.ts
+++ b/tests/fixtures/wire433.ts
@@ -1,0 +1,386 @@
+import type { CoreEvent } from '../../src/api/types.js';
+import { G4_EVENTS, GATE_RUN, TREE_AFTER, TREE_BEFORE } from './gateEvidence.js';
+
+/**
+ * wicked-core#431's wire (api-types 0.33.0 — the shapes wicked-crew#527's wire-contract test pins),
+ * as SYNTHETIC frames in the exact `event_to_json` spelling: camelCase, every key present, `null`
+ * never absent. Not a recording: the #431 engine (core-ts 0.7.19) had not been through a governed
+ * run on a rig when this was written, so every literal mirrors wicked-core's own `to_json` tests and
+ * crew's `wire-contract.test.ts` — the same run id, ords, seat keys, paths and tree ids as the
+ * recorded Phase 3 frames in `gateEvidence.ts`, so the two corpora compose (`G4_EVENTS` + these).
+ * Privacy-scrubbed by construction: no operator text, no host paths, synthetic hex.
+ *
+ * Denial prose and refusal texts are the engine's own format strings (`worktree_guard.rs`
+ * `denial_reason`, `deliver_lift.rs`, `actor.rs`'s mutation-gate prompt) with the placeholders
+ * filled — byte-for-byte the sentences a 0.7.19 engine emits for these inputs.
+ */
+
+const T10 = (id: string): string => id.slice(0, 10);
+const T7 = (id: string): string => id.slice(0, 7);
+
+/** Synthetic commit ids (git's 40-hex width) for the deliver lift and the run base. */
+export const BASE_BEFORE = '1432c96e0f1a2b3c4d5e6f708192a3b4c5d6e7f8';
+export const BASE_AFTER = 'f57069d1e2f3a4b5c6d7e8f90a1b2c3d4e5f6a7b';
+export const TREE_LIFTED = '9f8e7d6c5b4a39281706f5e4d3c2b1a0f9e8d7c6';
+export const SUGGESTION_REF = `refs/wicked/suggestions/${GATE_RUN}/4/0`;
+export const RUN_BRANCH = `wicked/${GATE_RUN}`;
+
+// ── (1)+(2) the gate: a named judge, a restored creator tree ─────────────────────────────────────
+
+/** `worktree_guard::denial_reason` with `restored: true` — the engine already ran the remedy. */
+export const RESTORED_GUARD_REASON =
+  'evaluator≠creator: phase `verify` declares `executes_code: false` but changed the worktree it was reviewing — ' +
+  `1 path(s): M src/App.tsx (tree ${T10(TREE_BEFORE)} → ${T10(TREE_AFTER)}). ` +
+  "The change under review is no longer the creator's, so this phase's verdict cannot certify it. " +
+  `The evaluator's edit was DISCARDED: the engine restored the creator's tree (${T10(TREE_BEFORE)}) in the worktree, ` +
+  'so approving this gate retries the phase against the verified tree. ' +
+  'A phase that must change code declares `executes_code: true` in the workflow def.';
+
+/** `worktree_guard::denial_reason` with `restored: false` + `restore_error` — the manual remedy stands. */
+export const RESTORE_FAILED_ERROR = 'git read-tree exited 128: index.lock exists';
+export const RESTORE_FAILED_GUARD_REASON =
+  'evaluator≠creator: phase `verify` declares `executes_code: false` but changed the worktree it was reviewing — ' +
+  `1 path(s): M src/App.tsx (tree ${T10(TREE_BEFORE)} → ${T10(TREE_AFTER)}). ` +
+  "The change under review is no longer the creator's, so this phase's verdict cannot certify it. " +
+  `Restore the creator's tree in the worktree with \`git read-tree --reset -u ${TREE_BEFORE}\` ` +
+  `(the engine's own restore failed: ${RESTORE_FAILED_ERROR}), or reject the run; ` +
+  'a phase that must change code declares `executes_code: true` in the workflow def.';
+
+/** `actor.rs`: the mutation-gate prompt once the tree was restored (the pre-0.33.0 prompt was
+ *  "… confirm to retry the phase, or reject to cancel the run"). */
+export const RESTORED_PROMPT =
+  'Unit 4 verdict is NOT PASS — the evaluator changed the tree under review; its edit was discarded and ' +
+  "the creator's verified tree restored. Approve to retry the phase against the restored tree, or reject to cancel the run";
+export const LEGACY_PROMPT = 'Unit 4 verdict is NOT PASS — confirm to retry the phase, or reject to cancel the run';
+
+export const MUTATION_RESTORED: CoreEvent = {
+  type: 'evaluatorMutatedWorktree',
+  session: GATE_RUN,
+  ord: 4,
+  seq: 245,
+  ts: 1789081439093,
+  attempt: 0,
+  cli: 'pi',
+  phase: 'verify',
+  beforeTree: TREE_BEFORE,
+  afterTree: TREE_AFTER,
+  headMoved: false,
+  changed: [{ path: 'src/App.tsx', status: 'M' }],
+  restored: true,
+  restoreError: null,
+};
+
+export const WORKTREE_RESTORED: CoreEvent = {
+  type: 'worktreeRestored',
+  session: GATE_RUN,
+  ord: 4,
+  seq: 246,
+  ts: 1789081439150,
+  attempt: 0,
+  cli: 'pi',
+  phase: 'verify',
+  tree: TREE_BEFORE,
+  head: null,
+  discarded: [{ path: 'src/App.tsx', status: 'M' }],
+  suggestionRef: SUGGESTION_REF,
+};
+
+/** The worktree-guard denial with the judge NAMED (a distinct seat) and the restored prose. */
+export const GATE_DENY_RESTORED: CoreEvent = {
+  type: 'gateEvaluated',
+  session: GATE_RUN,
+  ord: 4,
+  seq: 247,
+  ts: 1789081439237,
+  criterion: 'the run left a change in its worktree (done is re-derived from the diff, never asserted)',
+  hasDeterministicFloor: true,
+  deterministicPass: true,
+  agentVerdict: 'pass',
+  agentReasoning: 'PASS — The worktree evidence shows modified tracked files, satisfying the criterion. PASS',
+  evaluatorPass: true,
+  evaluatorPolicies: [],
+  denialReason: RESTORED_GUARD_REASON,
+  denial: { source: 'worktree_guard', reason: RESTORED_GUARD_REASON, claimId: null, ruleIds: [], deniedTool: null, phase: 'unit-4' },
+  combined: false,
+  judgeCli: 'codex',
+  judgeDistinct: true,
+};
+
+function escalation(seq: number, prompt: string): CoreEvent[] {
+  return [
+    { type: 'gateDecided', session: GATE_RUN, ord: 4, seq, ts: 1789081439237, allow: false },
+    { type: 'unitDenied', session: GATE_RUN, ord: 4, seq: seq + 1, ts: 1789081439237 },
+    { type: 'gateEscalated', session: GATE_RUN, ord: 4, seq: seq + 2, ts: 1789081439237, condition: 'verdict_not_pass', verdictSummary: RESTORED_GUARD_REASON },
+    { type: 'awaitingHuman', session: GATE_RUN, ord: 4, seq: seq + 3, ts: 1789081439238, prompt, reviewingOrd: 4 },
+  ];
+}
+
+const DISPATCH_4: CoreEvent[] = [
+  { type: 'resumed', session: GATE_RUN, ord: 4, seq: 201, ts: 1789081094441 },
+  { type: 'unitDispatched', session: GATE_RUN, ord: 4, seq: 202, ts: 1789081095027, attempt: 0 },
+  { type: 'unitExecuting', session: GATE_RUN, ord: 4, seq: 203, ts: 1789081095027 },
+];
+
+/** G5 on the #431 engine: the mutation, the restore, the named-judge denial, the NEW prompt. */
+export const G5R_EVENTS: CoreEvent[] = [
+  ...G4_EVENTS,
+  ...DISPATCH_4,
+  MUTATION_RESTORED,
+  WORKTREE_RESTORED,
+  GATE_DENY_RESTORED,
+  ...escalation(248, RESTORED_PROMPT),
+];
+export const G5R_GATE = { ord: 4, prompt: RESTORED_PROMPT };
+
+/** The same fold with the pin FAILED — `suggestionRef: null` (the discarded tree is only gc-prunable). */
+export const G5R_UNPINNED_EVENTS: CoreEvent[] = [
+  ...G4_EVENTS,
+  ...DISPATCH_4,
+  MUTATION_RESTORED,
+  { ...WORKTREE_RESTORED, suggestionRef: null },
+  GATE_DENY_RESTORED,
+  ...escalation(248, RESTORED_PROMPT),
+];
+
+/** The restore itself FAILED: `restored: false` + `restoreError`, no `worktreeRestored`, the legacy
+ *  prompt and the manual `git read-tree` remedy in the prose. */
+export const G5_RESTORE_FAILED_EVENTS: CoreEvent[] = [
+  ...G4_EVENTS,
+  ...DISPATCH_4,
+  { ...MUTATION_RESTORED, restored: false, restoreError: RESTORE_FAILED_ERROR },
+  {
+    ...GATE_DENY_RESTORED,
+    seq: 246,
+    denialReason: RESTORE_FAILED_GUARD_REASON,
+    denial: { source: 'worktree_guard', reason: RESTORE_FAILED_GUARD_REASON, claimId: null, ruleIds: [], deniedTool: null, phase: 'unit-4' },
+    judgeCli: null,
+    judgeDistinct: null,
+  },
+  ...escalation(247, LEGACY_PROMPT),
+];
+
+/** G4 with the fix phase's judge named and NOT distinct — the single default runner judged its own
+ *  seat's work (prompt-only independence). */
+export const G4_SAME_SEAT_EVENTS: CoreEvent[] = G4_EVENTS.map((e) =>
+  e.type === 'gateEvaluated' && e.ord === 3 ? { ...e, judgeCli: 'claude', judgeDistinct: false } : e,
+);
+
+// ── (3) the deliver ord (5): the lift, the re-verify, the engine's refusals ──────────────────────
+
+const REPO_CHECKS_CRITERION =
+  "the repository's own checks pass in the run's worktree (every detected check exits 0 — done is re-derived by running them, never asserted)";
+
+function lift(seq: number, over: Record<string, unknown>): CoreEvent {
+  return {
+    type: 'deliverLiftEvaluated',
+    session: GATE_RUN,
+    ord: 5,
+    seq,
+    ts: 1789082000000 + seq,
+    attempt: 0,
+    outcome: 'unchanged',
+    baseRef: 'origin/main',
+    baseBefore: BASE_BEFORE,
+    baseAfter: BASE_BEFORE,
+    treeBefore: TREE_BEFORE,
+    treeAfter: TREE_BEFORE,
+    conflicts: [],
+    note: null,
+    ...over,
+  };
+}
+
+export const DISPATCH_5: CoreEvent[] = [
+  { type: 'resumed', session: GATE_RUN, ord: 5, seq: 307, ts: 1789082000000 },
+  { type: 'unitDispatched', session: GATE_RUN, ord: 5, seq: 308, ts: 1789082000308, attempt: 0 },
+];
+
+export const LIFT_UNCHANGED: CoreEvent = lift(310, {});
+export const LIFT_LIFTED: CoreEvent = lift(310, { outcome: 'lifted', baseAfter: BASE_AFTER, treeAfter: TREE_LIFTED });
+export const LIFT_CONFLICT: CoreEvent = lift(310, {
+  outcome: 'conflict', baseAfter: BASE_AFTER, treeAfter: null, conflicts: ['testid-inventory.json'],
+});
+export const LIFT_SKIPPED: CoreEvent = lift(310, {
+  outcome: 'skipped', baseRef: null, baseBefore: BASE_BEFORE, baseAfter: null, treeBefore: null, treeAfter: null,
+  note: 'no remote default branch resolved (origin/HEAD is unset and origin/main does not exist)',
+});
+export const LIFT_FAILED: CoreEvent = lift(310, {
+  outcome: 'failed', baseAfter: BASE_AFTER, treeAfter: null,
+  note: 'git read-tree -m -u exited 128 after the merge-tree succeeded',
+});
+
+/** A lifted tree's re-verify — the deliver ord's `repoChecksEvaluated`; the lockfile moved with the
+ *  base, so a frozen `--ignore-scripts` install ran first and says so in its `source`. */
+export const DELIVER_REVERIFY_PASS: CoreEvent = {
+  type: 'repoChecksEvaluated',
+  session: GATE_RUN,
+  ord: 5,
+  seq: 320,
+  ts: 1789082090000,
+  attempt: 0,
+  passed: true,
+  criterion: REPO_CHECKS_CRITERION,
+  checks: [
+    { name: 'install', argv: ['npm', 'ci', '--ignore-scripts'], source: 'package-lock.json (forced: lockfile drift)', exitCode: 0, timedOut: false, spawnError: null, durationMs: 21400, stdoutTail: '', stderrTail: '' },
+    { name: 'typecheck', argv: ['npm', 'run', 'typecheck'], source: 'package.json scripts.typecheck', exitCode: 0, timedOut: false, spawnError: null, durationMs: 6893, stdoutTail: '', stderrTail: '' },
+    { name: 'lint', argv: ['npm', 'run', 'lint'], source: 'package.json scripts.lint', exitCode: 0, timedOut: false, spawnError: null, durationMs: 6118, stdoutTail: '', stderrTail: '' },
+    { name: 'test', argv: ['npm', 'run', 'test'], source: 'package.json scripts.test', exitCode: 0, timedOut: false, spawnError: null, durationMs: 79191, stdoutTail: '', stderrTail: '' },
+  ],
+  skipped: [],
+};
+
+/** The deliver unit's own `gateEvaluated` after a passing re-verify: the floor is the repo checks. */
+export const GATE_DELIVER_PASS: CoreEvent = {
+  type: 'gateEvaluated',
+  session: GATE_RUN,
+  ord: 5,
+  seq: 321,
+  ts: 1789082090010,
+  criterion: REPO_CHECKS_CRITERION,
+  hasDeterministicFloor: true,
+  deterministicPass: true,
+  agentVerdict: null,
+  agentReasoning: null,
+  evaluatorPass: true,
+  evaluatorPolicies: [],
+  denialReason: null,
+  denial: null,
+  combined: true,
+  judgeCli: null,
+  judgeDistinct: null,
+};
+
+/** A FAILED re-verify: lint exited 1 on the lifted tree, test skipped. */
+export const DELIVER_REVERIFY_FAIL: CoreEvent = {
+  ...DELIVER_REVERIFY_PASS,
+  passed: false,
+  checks: [
+    (DELIVER_REVERIFY_PASS.checks as Array<Record<string, unknown>>)[0]!,
+    (DELIVER_REVERIFY_PASS.checks as Array<Record<string, unknown>>)[1]!,
+    { ...(DELIVER_REVERIFY_PASS.checks as Array<Record<string, unknown>>)[2]!, exitCode: 1, durationMs: 5402 },
+  ],
+  skipped: ['test'],
+};
+
+/** A failed POST-CHECK PROOF: every check exited 0 but the tree moved while they ran — `passed:
+ *  false` with three green rows (wicked-core F-433-002). */
+export const DELIVER_REVERIFY_CHANGED_TREE: CoreEvent = {
+  ...DELIVER_REVERIFY_PASS,
+  passed: false,
+  checks: (DELIVER_REVERIFY_PASS.checks as Array<Record<string, unknown>>).slice(1),
+};
+
+function stepFailed(seq: number, detail: string): CoreEvent {
+  return { type: 'stepFailed', session: GATE_RUN, ord: 5, seq, ts: 1789082100000 + seq, attempt: 0, detail };
+}
+
+/** `deliver_lift.rs` — the engine's refusals, format strings filled. */
+export const REFUSAL_CONFLICT =
+  `deliver: LIFT-CONFLICT — lifting the run's work onto origin/main (${T7(BASE_AFTER)}) would conflict in: testid-inventory.json. ` +
+  `The worktree was left exactly as verified (base ${T7(BASE_BEFORE)}); nothing was rebased and nothing was pushed. ` +
+  "Resolve on the branch (rebase onto origin/main, regenerate any generated files, re-run the repository's checks) and approve to retry the deliver phase.";
+export const REFUSAL_APPLY_FAILED =
+  `deliver: the lift onto origin/main (${T7(BASE_AFTER)}) could not be applied cleanly — git read-tree -m -u exited 128 after the merge-tree succeeded. ` +
+  'Nothing was pushed — the deliver gate never pushes a tree that was not verified. ' +
+  'Inspect the worktree (it may hold a partial checkout), restore or fix it, and approve to retry the deliver phase.';
+export const REFUSAL_WRONG_HEAD =
+  `deliver: the worktree's HEAD is attached to \`refs/heads/main\`, not the run branch \`${RUN_BRANCH}\` — nothing was lifted, reset or pushed; ` +
+  `the deliver script only pushes the run branch. Switch the worktree back to \`${RUN_BRANCH}\` and approve to retry.`;
+export const REFUSAL_REVERIFY_FAILED =
+  `deliver: the tree that would ship is the run's work lifted onto origin/main (${T7(BASE_AFTER)}), not the tree the run verified, ` +
+  "and the repository's own checks FAILED on it: lint exited 1 (test skipped). " +
+  'Lockfile drift between the old base and the tip (package-lock.json): dependencies were re-installed (frozen lockfile, --ignore-scripts) before the checks. ' +
+  'Nothing was pushed — the deliver gate never pushes a tree that was not verified. ' +
+  'Fix the worktree (or reject the run) and approve to retry; the checks run again until the tree passes.';
+export const REFUSAL_CHANGED_TREE =
+  `deliver: the repository's checks passed but CHANGED the worktree while running (tree ${T10(TREE_LIFTED)} → 0a1b2c3d4e, ` +
+  `HEAD ${T10(BASE_AFTER)} → ${T10(BASE_AFTER)}, HEAD ref Some("refs/heads/${RUN_BRANCH}") → Some("refs/heads/${RUN_BRANCH}")) — ` +
+  'a check script that edits tracked files, moves HEAD or switches the branch leaves a tree nobody verified. ' +
+  "Nothing was pushed. Inspect the worktree, fix or ignore the check's writes, and approve to retry.";
+
+export const STEP_FAILED_CONFLICT: CoreEvent = stepFailed(311, REFUSAL_CONFLICT);
+export const STEP_FAILED_APPLY: CoreEvent = stepFailed(311, REFUSAL_APPLY_FAILED);
+export const STEP_FAILED_WRONG_HEAD: CoreEvent = stepFailed(311, REFUSAL_WRONG_HEAD);
+export const STEP_FAILED_REVERIFY: CoreEvent = stepFailed(322, REFUSAL_REVERIFY_FAILED);
+export const STEP_FAILED_CHANGED_TREE: CoreEvent = stepFailed(322, REFUSAL_CHANGED_TREE);
+
+/** The retry gate the engine opens on the refused deliver unit (failure triage → escalate). */
+export const DELIVER_RETRY_PROMPT = 'Unit 5 failed — approve to retry the deliver phase, or reject to cancel the run';
+export const DELIVER_RETRY_GATE = { ord: 5, prompt: DELIVER_RETRY_PROMPT };
+function deliverRetry(seq: number): CoreEvent[] {
+  return [
+    { type: 'failureTriaged', session: GATE_RUN, ord: 5, seq, ts: 1789082200000, decision: 'escalate', analysis: 'the engine refused the deliver: a git state, not a worker error' },
+    { type: 'awaitingHuman', session: GATE_RUN, ord: 5, seq: seq + 1, ts: 1789082200001, prompt: DELIVER_RETRY_PROMPT, reviewingOrd: 5 },
+  ];
+}
+
+/** Deliver stories, each `G6_EVENTS`-shaped tails for ord 5 — append to `G6_EVENTS` (the gate before
+ *  unit #5) so the run's earlier folds stay in the log. */
+export const DELIVER_UNCHANGED_TAIL: CoreEvent[] = [...DISPATCH_5, LIFT_UNCHANGED];
+export const DELIVER_LIFTED_TAIL: CoreEvent[] = [...DISPATCH_5, LIFT_LIFTED, DELIVER_REVERIFY_PASS, GATE_DELIVER_PASS];
+export const DELIVER_CONFLICT_TAIL: CoreEvent[] = [...DISPATCH_5, LIFT_CONFLICT, STEP_FAILED_CONFLICT, ...deliverRetry(312)];
+export const DELIVER_SKIPPED_TAIL: CoreEvent[] = [...DISPATCH_5, LIFT_SKIPPED];
+export const DELIVER_FAILED_TAIL: CoreEvent[] = [...DISPATCH_5, LIFT_FAILED, STEP_FAILED_APPLY, ...deliverRetry(312)];
+/** The addendum: refused for a wrong HEAD ref — NO `deliverLiftEvaluated` precedes the failure. */
+export const DELIVER_WRONG_HEAD_TAIL: CoreEvent[] = [...DISPATCH_5, STEP_FAILED_WRONG_HEAD, ...deliverRetry(312)];
+export const DELIVER_REVERIFY_FAILED_TAIL: CoreEvent[] = [...DISPATCH_5, LIFT_LIFTED, DELIVER_REVERIFY_FAIL, STEP_FAILED_REVERIFY, ...deliverRetry(323)];
+export const DELIVER_CHANGED_TREE_TAIL: CoreEvent[] = [...DISPATCH_5, LIFT_LIFTED, DELIVER_REVERIFY_CHANGED_TREE, STEP_FAILED_CHANGED_TREE, ...deliverRetry(323)];
+
+// ── (4) the run base ─────────────────────────────────────────────────────────────────────────────
+
+export const RUN_BASE_LIFTED: CoreEvent = {
+  type: 'runBaseResolved',
+  session: GATE_RUN,
+  seq: 2,
+  ts: 1789079790000,
+  baseRef: 'origin/main',
+  baseCommit: BASE_AFTER,
+  localHead: BASE_BEFORE,
+  behind: 5,
+  fetched: true,
+  lifted: true,
+  note: null,
+};
+export const RUN_BASE_AT_TIP: CoreEvent = { ...RUN_BASE_LIFTED, baseCommit: BASE_BEFORE, behind: 0, lifted: false };
+export const RUN_BASE_LOCAL_KEPT: CoreEvent = {
+  ...RUN_BASE_LIFTED, baseCommit: BASE_BEFORE, behind: 0, lifted: false,
+  note: "the registered clone's HEAD is ahead of origin/main by 2 commit(s) (local unpushed work) — kept as the base",
+};
+export const RUN_BASE_NO_REMOTE: CoreEvent = {
+  ...RUN_BASE_LIFTED, baseRef: null, baseCommit: BASE_BEFORE, behind: 0, lifted: false,
+  note: 'no remote default branch resolved (origin/HEAD is unset)',
+};
+export const RUN_BASE_FETCH_FAILED: CoreEvent = {
+  ...RUN_BASE_LIFTED, baseCommit: BASE_BEFORE, behind: 0, fetched: false, lifted: false,
+  note: 'git fetch origin failed (exit 128: could not resolve host) — cached refs used',
+};
+
+// ── (5) the feed: a refused write, a deliberate reroute ──────────────────────────────────────────
+
+export const TOOL_DENIED: CoreEvent = {
+  type: 'evaluatorToolCallDenied',
+  session: GATE_RUN,
+  ord: 4,
+  seq: 230,
+  ts: 1789081300000,
+  attempt: 0,
+  cli: 'claude',
+  carrier: 'acp',
+  tool: 'edit',
+  kind: 'edit',
+  path: 'src/App.tsx',
+  reason: 'write-class tool call from an executes_code:false phase',
+};
+// `kind: null` is the 0.33.0 spelling (`CoreEvent.kind` widened to `string | null` for this frame);
+// the installed 0.32.0 types still say `string`, hence the bag — the pin bump makes it a plain literal.
+export const TOOL_DENIED_KINDLESS: CoreEvent = { ...TOOL_DENIED, kind: null, path: null } as unknown as CoreEvent;
+
+export const READ_ONLY_REROUTE: CoreEvent = {
+  type: 'acpFallback',
+  session: GATE_RUN,
+  seq: 204,
+  ts: 1789081095100,
+  cliKey: 'pi',
+  reason: 'executes_code:false unit on an ACP seat not admitted to input governance',
+  fallbackKind: 'read_only_requires_wrapped',
+};

--- a/tests/fixtures/wire433.ts
+++ b/tests/fixtures/wire433.ts
@@ -1,4 +1,15 @@
-import type { CoreEvent } from '../../src/api/types.js';
+import type {
+  AcpFallbackEvent,
+  CoreEvent,
+  DeliverLiftEvaluatedEvent,
+  EvaluatorMutatedWorktreeEvent,
+  EvaluatorToolCallDeniedEvent,
+  GateEvaluatedEvent,
+  RepoChecksEvaluatedEvent,
+  RunBaseResolvedEvent,
+  StepFailedEvent,
+  WorktreeRestoredEvent,
+} from '../../src/api/types.js';
 import { G4_EVENTS, GATE_RUN, TREE_AFTER, TREE_BEFORE } from './gateEvidence.js';
 
 /**
@@ -14,6 +25,13 @@ import { G4_EVENTS, GATE_RUN, TREE_AFTER, TREE_BEFORE } from './gateEvidence.js'
  * `denial_reason`, `deliver_lift.rs`, `actor.rs`'s mutation-gate prompt) with the placeholders
  * filled — byte-for-byte the sentences a 0.7.19 engine emits for these inputs.
  */
+
+/** A frame as the daemon relays it: the engine's `event_to_json` shape plus the `seq` / `ts` envelope
+ *  crew stamps on every CoreEvent. Every #431 frame below is declared `satisfies` its 0.33.0 named
+ *  type, so a drifted key, a wrong nullability or a token outside the declared union fails `tsc` —
+ *  the fixtures ARE the declared shapes, not a studio-side guess (`tests/wire433.shapes.test.ts`
+ *  re-derives the same diff at run time against the installed `index.d.ts`). */
+export type Wire<T> = T & { seq: number; ts: number };
 
 const T10 = (id: string): string => id.slice(0, 10);
 const T7 = (id: string): string => id.slice(0, 7);
@@ -53,7 +71,7 @@ export const RESTORED_PROMPT =
   "the creator's verified tree restored. Approve to retry the phase against the restored tree, or reject to cancel the run";
 export const LEGACY_PROMPT = 'Unit 4 verdict is NOT PASS — confirm to retry the phase, or reject to cancel the run';
 
-export const MUTATION_RESTORED: CoreEvent = {
+export const MUTATION_RESTORED = {
   type: 'evaluatorMutatedWorktree',
   session: GATE_RUN,
   ord: 4,
@@ -68,9 +86,9 @@ export const MUTATION_RESTORED: CoreEvent = {
   changed: [{ path: 'src/App.tsx', status: 'M' }],
   restored: true,
   restoreError: null,
-};
+} satisfies Wire<EvaluatorMutatedWorktreeEvent>;
 
-export const WORKTREE_RESTORED: CoreEvent = {
+export const WORKTREE_RESTORED = {
   type: 'worktreeRestored',
   session: GATE_RUN,
   ord: 4,
@@ -83,10 +101,10 @@ export const WORKTREE_RESTORED: CoreEvent = {
   head: null,
   discarded: [{ path: 'src/App.tsx', status: 'M' }],
   suggestionRef: SUGGESTION_REF,
-};
+} satisfies Wire<WorktreeRestoredEvent>;
 
 /** The worktree-guard denial with the judge NAMED (a distinct seat) and the restored prose. */
-export const GATE_DENY_RESTORED: CoreEvent = {
+export const GATE_DENY_RESTORED = {
   type: 'gateEvaluated',
   session: GATE_RUN,
   ord: 4,
@@ -104,7 +122,7 @@ export const GATE_DENY_RESTORED: CoreEvent = {
   combined: false,
   judgeCli: 'codex',
   judgeDistinct: true,
-};
+} satisfies Wire<GateEvaluatedEvent>;
 
 function escalation(seq: number, prompt: string): CoreEvent[] {
   return [
@@ -170,8 +188,8 @@ export const G4_SAME_SEAT_EVENTS: CoreEvent[] = G4_EVENTS.map((e) =>
 const REPO_CHECKS_CRITERION =
   "the repository's own checks pass in the run's worktree (every detected check exits 0 — done is re-derived by running them, never asserted)";
 
-function lift(seq: number, over: Record<string, unknown>): CoreEvent {
-  return {
+function lift(seq: number, over: Partial<DeliverLiftEvaluatedEvent>): Wire<DeliverLiftEvaluatedEvent> {
+  const unchanged = {
     type: 'deliverLiftEvaluated',
     session: GATE_RUN,
     ord: 5,
@@ -186,8 +204,8 @@ function lift(seq: number, over: Record<string, unknown>): CoreEvent {
     treeAfter: TREE_BEFORE,
     conflicts: [],
     note: null,
-    ...over,
-  };
+  } satisfies Wire<DeliverLiftEvaluatedEvent>;
+  return { ...unchanged, ...over };
 }
 
 export const DISPATCH_5: CoreEvent[] = [
@@ -195,23 +213,23 @@ export const DISPATCH_5: CoreEvent[] = [
   { type: 'unitDispatched', session: GATE_RUN, ord: 5, seq: 308, ts: 1789082000308, attempt: 0 },
 ];
 
-export const LIFT_UNCHANGED: CoreEvent = lift(310, {});
-export const LIFT_LIFTED: CoreEvent = lift(310, { outcome: 'lifted', baseAfter: BASE_AFTER, treeAfter: TREE_LIFTED });
-export const LIFT_CONFLICT: CoreEvent = lift(310, {
+export const LIFT_UNCHANGED = lift(310, {});
+export const LIFT_LIFTED = lift(310, { outcome: 'lifted', baseAfter: BASE_AFTER, treeAfter: TREE_LIFTED });
+export const LIFT_CONFLICT = lift(310, {
   outcome: 'conflict', baseAfter: BASE_AFTER, treeAfter: null, conflicts: ['testid-inventory.json'],
 });
-export const LIFT_SKIPPED: CoreEvent = lift(310, {
+export const LIFT_SKIPPED = lift(310, {
   outcome: 'skipped', baseRef: null, baseBefore: BASE_BEFORE, baseAfter: null, treeBefore: null, treeAfter: null,
   note: 'no remote default branch resolved (origin/HEAD is unset and origin/main does not exist)',
 });
-export const LIFT_FAILED: CoreEvent = lift(310, {
+export const LIFT_FAILED = lift(310, {
   outcome: 'failed', baseAfter: BASE_AFTER, treeAfter: null,
   note: 'git read-tree -m -u exited 128 after the merge-tree succeeded',
 });
 
 /** A lifted tree's re-verify — the deliver ord's `repoChecksEvaluated`; the lockfile moved with the
  *  base, so a frozen `--ignore-scripts` install ran first and says so in its `source`. */
-export const DELIVER_REVERIFY_PASS: CoreEvent = {
+export const DELIVER_REVERIFY_PASS = {
   type: 'repoChecksEvaluated',
   session: GATE_RUN,
   ord: 5,
@@ -227,10 +245,10 @@ export const DELIVER_REVERIFY_PASS: CoreEvent = {
     { name: 'test', argv: ['npm', 'run', 'test'], source: 'package.json scripts.test', exitCode: 0, timedOut: false, spawnError: null, durationMs: 79191, stdoutTail: '', stderrTail: '' },
   ],
   skipped: [],
-};
+} satisfies Wire<RepoChecksEvaluatedEvent>;
 
 /** The deliver unit's own `gateEvaluated` after a passing re-verify: the floor is the repo checks. */
-export const GATE_DELIVER_PASS: CoreEvent = {
+export const GATE_DELIVER_PASS = {
   type: 'gateEvaluated',
   session: GATE_RUN,
   ord: 5,
@@ -248,30 +266,37 @@ export const GATE_DELIVER_PASS: CoreEvent = {
   combined: true,
   judgeCli: null,
   judgeDistinct: null,
-};
+} satisfies Wire<GateEvaluatedEvent>;
 
 /** A FAILED re-verify: lint exited 1 on the lifted tree, test skipped. */
-export const DELIVER_REVERIFY_FAIL: CoreEvent = {
+export const DELIVER_REVERIFY_FAIL = {
   ...DELIVER_REVERIFY_PASS,
   passed: false,
   checks: [
-    (DELIVER_REVERIFY_PASS.checks as Array<Record<string, unknown>>)[0]!,
-    (DELIVER_REVERIFY_PASS.checks as Array<Record<string, unknown>>)[1]!,
-    { ...(DELIVER_REVERIFY_PASS.checks as Array<Record<string, unknown>>)[2]!, exitCode: 1, durationMs: 5402 },
+    DELIVER_REVERIFY_PASS.checks[0]!,
+    DELIVER_REVERIFY_PASS.checks[1]!,
+    { ...DELIVER_REVERIFY_PASS.checks[2]!, exitCode: 1, durationMs: 5402 },
   ],
   skipped: ['test'],
-};
+} satisfies Wire<RepoChecksEvaluatedEvent>;
 
 /** A failed POST-CHECK PROOF: every check exited 0 but the tree moved while they ran — `passed:
  *  false` with three green rows (wicked-core F-433-002). */
-export const DELIVER_REVERIFY_CHANGED_TREE: CoreEvent = {
+export const DELIVER_REVERIFY_CHANGED_TREE = {
   ...DELIVER_REVERIFY_PASS,
   passed: false,
-  checks: (DELIVER_REVERIFY_PASS.checks as Array<Record<string, unknown>>).slice(1),
-};
+  checks: DELIVER_REVERIFY_PASS.checks.slice(1),
+} satisfies Wire<RepoChecksEvaluatedEvent>;
 
-function stepFailed(seq: number, detail: string): CoreEvent {
-  return { type: 'stepFailed', session: GATE_RUN, ord: 5, seq, ts: 1789082100000 + seq, attempt: 0, detail };
+/** The deliver unit's failure frame. Every `deliver:` refusal reaches the operator by the
+ *  unrecognized-failure route (`actor.rs`: `StepFailed` fires at once, then failure triage
+ *  escalates), which stamps `failureKind: "workerError"` — the engine's token for "the unit's
+ *  process ended non-zero", not a judgement on the seat. Declared `string` on the wire; the
+ *  engine's three tokens are `workerError` / `environmentRefused` / `substanceRejected`. */
+function stepFailed(seq: number, detail: string) {
+  return {
+    type: 'stepFailed', session: GATE_RUN, ord: 5, seq, ts: 1789082100000 + seq, attempt: 0, detail, failureKind: 'workerError',
+  } satisfies Wire<StepFailedEvent>;
 }
 
 /** `deliver_lift.rs` — the engine's refusals, format strings filled. */
@@ -298,11 +323,11 @@ export const REFUSAL_CHANGED_TREE =
   'a check script that edits tracked files, moves HEAD or switches the branch leaves a tree nobody verified. ' +
   "Nothing was pushed. Inspect the worktree, fix or ignore the check's writes, and approve to retry.";
 
-export const STEP_FAILED_CONFLICT: CoreEvent = stepFailed(311, REFUSAL_CONFLICT);
-export const STEP_FAILED_APPLY: CoreEvent = stepFailed(311, REFUSAL_APPLY_FAILED);
-export const STEP_FAILED_WRONG_HEAD: CoreEvent = stepFailed(311, REFUSAL_WRONG_HEAD);
-export const STEP_FAILED_REVERIFY: CoreEvent = stepFailed(322, REFUSAL_REVERIFY_FAILED);
-export const STEP_FAILED_CHANGED_TREE: CoreEvent = stepFailed(322, REFUSAL_CHANGED_TREE);
+export const STEP_FAILED_CONFLICT = stepFailed(311, REFUSAL_CONFLICT);
+export const STEP_FAILED_APPLY = stepFailed(311, REFUSAL_APPLY_FAILED);
+export const STEP_FAILED_WRONG_HEAD = stepFailed(311, REFUSAL_WRONG_HEAD);
+export const STEP_FAILED_REVERIFY = stepFailed(322, REFUSAL_REVERIFY_FAILED);
+export const STEP_FAILED_CHANGED_TREE = stepFailed(322, REFUSAL_CHANGED_TREE);
 
 /** The retry gate the engine opens on the refused deliver unit (failure triage → escalate). */
 export const DELIVER_RETRY_PROMPT = 'Unit 5 failed — approve to retry the deliver phase, or reject to cancel the run';
@@ -328,7 +353,7 @@ export const DELIVER_CHANGED_TREE_TAIL: CoreEvent[] = [...DISPATCH_5, LIFT_LIFTE
 
 // ── (4) the run base ─────────────────────────────────────────────────────────────────────────────
 
-export const RUN_BASE_LIFTED: CoreEvent = {
+export const RUN_BASE_LIFTED = {
   type: 'runBaseResolved',
   session: GATE_RUN,
   seq: 2,
@@ -340,24 +365,24 @@ export const RUN_BASE_LIFTED: CoreEvent = {
   fetched: true,
   lifted: true,
   note: null,
-};
-export const RUN_BASE_AT_TIP: CoreEvent = { ...RUN_BASE_LIFTED, baseCommit: BASE_BEFORE, behind: 0, lifted: false };
-export const RUN_BASE_LOCAL_KEPT: CoreEvent = {
+} satisfies Wire<RunBaseResolvedEvent>;
+export const RUN_BASE_AT_TIP = { ...RUN_BASE_LIFTED, baseCommit: BASE_BEFORE, behind: 0, lifted: false } satisfies Wire<RunBaseResolvedEvent>;
+export const RUN_BASE_LOCAL_KEPT = {
   ...RUN_BASE_LIFTED, baseCommit: BASE_BEFORE, behind: 0, lifted: false,
   note: "the registered clone's HEAD is ahead of origin/main by 2 commit(s) (local unpushed work) — kept as the base",
-};
-export const RUN_BASE_NO_REMOTE: CoreEvent = {
+} satisfies Wire<RunBaseResolvedEvent>;
+export const RUN_BASE_NO_REMOTE = {
   ...RUN_BASE_LIFTED, baseRef: null, baseCommit: BASE_BEFORE, behind: 0, lifted: false,
   note: 'no remote default branch resolved (origin/HEAD is unset)',
-};
-export const RUN_BASE_FETCH_FAILED: CoreEvent = {
+} satisfies Wire<RunBaseResolvedEvent>;
+export const RUN_BASE_FETCH_FAILED = {
   ...RUN_BASE_LIFTED, baseCommit: BASE_BEFORE, behind: 0, fetched: false, lifted: false,
   note: 'git fetch origin failed (exit 128: could not resolve host) — cached refs used',
-};
+} satisfies Wire<RunBaseResolvedEvent>;
 
 // ── (5) the feed: a refused write, a deliberate reroute ──────────────────────────────────────────
 
-export const TOOL_DENIED: CoreEvent = {
+export const TOOL_DENIED = {
   type: 'evaluatorToolCallDenied',
   session: GATE_RUN,
   ord: 4,
@@ -370,12 +395,12 @@ export const TOOL_DENIED: CoreEvent = {
   kind: 'edit',
   path: 'src/App.tsx',
   reason: 'write-class tool call from an executes_code:false phase',
-};
-// `kind: null` is the 0.33.0 spelling (`CoreEvent.kind` widened to `string | null` for this frame);
-// the installed 0.32.0 types still say `string`, hence the bag — the pin bump makes it a plain literal.
-export const TOOL_DENIED_KINDLESS: CoreEvent = { ...TOOL_DENIED, kind: null, path: null } as unknown as CoreEvent;
+} satisfies Wire<EvaluatorToolCallDeniedEvent>;
+/** `kind: null` / `path: null` — the 0.33.0 spelling for a denied call the adapter could not classify
+ *  (`CoreEvent.kind` is `string | null` since that pin, so this is a plain literal — no cast). */
+export const TOOL_DENIED_KINDLESS = { ...TOOL_DENIED, kind: null, path: null } satisfies Wire<EvaluatorToolCallDeniedEvent>;
 
-export const READ_ONLY_REROUTE: CoreEvent = {
+export const READ_ONLY_REROUTE = {
   type: 'acpFallback',
   session: GATE_RUN,
   seq: 204,
@@ -383,4 +408,4 @@ export const READ_ONLY_REROUTE: CoreEvent = {
   cliKey: 'pi',
   reason: 'executes_code:false unit on an ACP seat not admitted to input governance',
   fallbackKind: 'read_only_requires_wrapped',
-};
+} satisfies Wire<AcpFallbackEvent>;

--- a/tests/fixtures/wire433.ts
+++ b/tests/fixtures/wire433.ts
@@ -22,8 +22,13 @@ import { G4_EVENTS, GATE_RUN, TREE_AFTER, TREE_BEFORE } from './gateEvidence.js'
  * Privacy-scrubbed by construction: no operator text, no host paths, synthetic hex.
  *
  * Denial prose and refusal texts are the engine's own format strings (`worktree_guard.rs`
- * `denial_reason`, `deliver_lift.rs`, `actor.rs`'s mutation-gate prompt) with the placeholders
- * filled — byte-for-byte the sentences a 0.7.19 engine emits for these inputs.
+ * `denial_reason`, `deliver_lift.rs`, `actor.rs`'s mutation-gate and triage-escalate prompts) with the
+ * placeholders filled — the sentences a 0.7.19 engine composes. What the WIRE then does to them is
+ * modelled too (F-255-04): a deliver refusal reaches `stepFailed.detail` as `bounded_excerpt`'s
+ * head+tail (150/250 on the failure-triage path, `[… N chars elided …]` between the halves once it
+ * outgrows 400 chars), the retry gate's prompt quotes a wider excerpt (450/750) after `Failure
+ * output:`, and a rejected unit's `denial_reason` is framed (`Worker FAILED on unit N …`) — see
+ * `boundedExcerpt` and the `deliver*Reason` / `deliverRetryGate` helpers below.
  */
 
 /** A frame as the daemon relays it: the engine's `event_to_json` shape plus the `seq` / `ts` envelope
@@ -32,6 +37,26 @@ import { G4_EVENTS, GATE_RUN, TREE_AFTER, TREE_BEFORE } from './gateEvidence.js'
  *  the fixtures ARE the declared shapes, not a studio-side guess (`tests/wire433.shapes.test.ts`
  *  re-derives the same diff at run time against the installed `index.d.ts`). */
 export type Wire<T> = T & { seq: number; ts: number };
+
+/** wicked-core `actor.rs` `bounded_excerpt(raw, head, tail)`: the whole string when it fits the cap,
+ *  else its first `head` and last `tail` CHARACTERS (code points, as Rust's `chars()`) around the
+ *  marker `\n[… N chars elided …]\n`. */
+export function boundedExcerpt(raw: string, head: number, tail: number): string {
+  const chars = Array.from(raw);
+  const n = chars.length;
+  const cap = head + tail;
+  if (n <= cap) return raw;
+  return `${chars.slice(0, head).join('')}\n[… ${n - cap} chars elided …]\n${chars.slice(n - tail).join('')}`;
+}
+/** `triage_judge_excerpt` (450/750): what the failure-triage judge reads, what the escalate prompt
+ *  quotes, and the `triage escalation: …` denial_reason while that gate is open. */
+export const triageExcerpt = (raw: string): string => boundedExcerpt(raw.trim(), 450, 750);
+/** `failure_detail_excerpt` of the triage excerpt (150/250): `stepFailed.detail` on the triage path,
+ *  and the excerpt inside a triage-Fail `Worker FAILED on unit N (triage: …): …` denial_reason. */
+export const detailExcerpt = (raw: string): string => boundedExcerpt(triageExcerpt(raw), 150, 250);
+/** The plain worker-failure path (no human present, no triage): `detail` and the framed
+ *  `Worker FAILED on unit N: …` denial_reason both carry the 300/500 excerpt. */
+export const failureExcerpt = (raw: string): string => boundedExcerpt(raw.trim(), 300, 500);
 
 const T10 = (id: string): string => id.slice(0, 10);
 const T7 = (id: string): string => id.slice(0, 7);
@@ -268,14 +293,21 @@ export const GATE_DELIVER_PASS = {
   judgeDistinct: null,
 } satisfies Wire<GateEvaluatedEvent>;
 
-/** A FAILED re-verify: lint exited 1 on the lifted tree, test skipped. */
+/** The red check's evidence — `RepoCheckRun.stderrTail`, "the last 4 KiB of the stream", as eslint
+ *  writes it (a synthetic path inside the run worktree). */
+export const LINT_STDERR_TAIL =
+  '\n/w/trees/run-3r2/src/components/DeliverLift.tsx\n' +
+  '  41:9  error  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any\n\n' +
+  '✖ 1 problem (1 error, 0 warnings)\n';
+
+/** A FAILED re-verify: lint exited 1 on the lifted tree (its stderr tail recorded), test skipped. */
 export const DELIVER_REVERIFY_FAIL = {
   ...DELIVER_REVERIFY_PASS,
   passed: false,
   checks: [
     DELIVER_REVERIFY_PASS.checks[0]!,
     DELIVER_REVERIFY_PASS.checks[1]!,
-    { ...DELIVER_REVERIFY_PASS.checks[2]!, exitCode: 1, durationMs: 5402 },
+    { ...DELIVER_REVERIFY_PASS.checks[2]!, exitCode: 1, durationMs: 5402, stderrTail: LINT_STDERR_TAIL },
   ],
   skipped: ['test'],
 } satisfies Wire<RepoChecksEvaluatedEvent>;
@@ -292,10 +324,13 @@ export const DELIVER_REVERIFY_CHANGED_TREE = {
  *  unrecognized-failure route (`actor.rs`: `StepFailed` fires at once, then failure triage
  *  escalates), which stamps `failureKind: "workerError"` — the engine's token for "the unit's
  *  process ended non-zero", not a judgement on the seat. Declared `string` on the wire; the
- *  engine's three tokens are `workerError` / `environmentRefused` / `substanceRejected`. */
-function stepFailed(seq: number, detail: string) {
+ *  engine's three tokens are `workerError` / `environmentRefused` / `substanceRejected`. The
+ *  `detail` is what the wire carries — `failure_detail_excerpt(&failure_excerpt)`, the 150/250
+ *  head+tail of the refusal — never the refusal itself (F-255-04). */
+function stepFailed(seq: number, refusal: string) {
   return {
-    type: 'stepFailed', session: GATE_RUN, ord: 5, seq, ts: 1789082100000 + seq, attempt: 0, detail, failureKind: 'workerError',
+    type: 'stepFailed', session: GATE_RUN, ord: 5, seq, ts: 1789082100000 + seq, attempt: 0,
+    detail: detailExcerpt(refusal), failureKind: 'workerError',
   } satisfies Wire<StepFailedEvent>;
 }
 
@@ -329,13 +364,39 @@ export const STEP_FAILED_WRONG_HEAD = stepFailed(311, REFUSAL_WRONG_HEAD);
 export const STEP_FAILED_REVERIFY = stepFailed(322, REFUSAL_REVERIFY_FAILED);
 export const STEP_FAILED_CHANGED_TREE = stepFailed(322, REFUSAL_CHANGED_TREE);
 
-/** The retry gate the engine opens on the refused deliver unit (failure triage → escalate). */
-export const DELIVER_RETRY_PROMPT = 'Unit 5 failed — approve to retry the deliver phase, or reject to cancel the run';
-export const DELIVER_RETRY_GATE = { ord: 5, prompt: DELIVER_RETRY_PROMPT };
-function deliverRetry(seq: number): CoreEvent[] {
+/** The `detail` each refusal reaches the wire as — intact when the refusal fits 400 chars
+ *  (LIFT-CONFLICT, apply-failed, wrong-HEAD), elided in the middle when it does not (the re-verify
+ *  failure and the changed-tree proof) — so tests assert what an operator will actually see. */
+export const DETAIL_CONFLICT = detailExcerpt(REFUSAL_CONFLICT);
+export const DETAIL_APPLY_FAILED = detailExcerpt(REFUSAL_APPLY_FAILED);
+export const DETAIL_WRONG_HEAD = detailExcerpt(REFUSAL_WRONG_HEAD);
+export const DETAIL_REVERIFY_FAILED = detailExcerpt(REFUSAL_REVERIFY_FAILED);
+export const DETAIL_CHANGED_TREE = detailExcerpt(REFUSAL_CHANGED_TREE);
+
+/** The failure-triage judge's analysis of a deliver refusal (it escalates: a git state, not a worker error). */
+export const DELIVER_TRIAGE_ANALYSIS = 'the engine refused the deliver: a git state, not a worker error';
+
+/** The retry gate the engine opens on the refused deliver unit — `actor.rs` `TriageDecision::Escalate`,
+ *  format string filled. The prompt QUOTES the failure (the 450/750 triage excerpt), so a gate card
+ *  that also renders the lift's `failure` must say it once (F-255-02). */
+export const deliverRetryPrompt = (refusal: string): string =>
+  `Unit 5 failed and triage escalated: ${DELIVER_TRIAGE_ANALYSIS}. Failure output: "${triageExcerpt(refusal)}". ` +
+  'Approve to retry (optionally amend), reject to fail the run, or reassign the unit to a different CLI first.';
+export const deliverRetryGate = (refusal: string): { ord: number; prompt: string } => ({ ord: 5, prompt: deliverRetryPrompt(refusal) });
+/** While that gate is open the unit's `denial_reason` already reads the escalation (the same excerpt). */
+export const deliverEscalationReason = (refusal: string): string =>
+  `triage escalation: ${DELIVER_TRIAGE_ANALYSIS} — ${triageExcerpt(refusal)}`;
+/** A REJECTED deliver unit's `denial_reason`, as the engine FRAMES it — never the bare refusal: the
+ *  triage-Fail path (a human was present; the 150/250 excerpt) … */
+export const deliverRejectedReason = (refusal: string): string =>
+  `Worker FAILED on unit 5 (triage: ${DELIVER_TRIAGE_ANALYSIS}): ${detailExcerpt(refusal)}`;
+/** … and the plain worker-failure path (no human; the 300/500 excerpt). */
+export const deliverWorkerFailedReason = (refusal: string): string => `Worker FAILED on unit 5: ${failureExcerpt(refusal)}`;
+
+function deliverRetry(seq: number, refusal: string): CoreEvent[] {
   return [
-    { type: 'failureTriaged', session: GATE_RUN, ord: 5, seq, ts: 1789082200000, decision: 'escalate', analysis: 'the engine refused the deliver: a git state, not a worker error' },
-    { type: 'awaitingHuman', session: GATE_RUN, ord: 5, seq: seq + 1, ts: 1789082200001, prompt: DELIVER_RETRY_PROMPT, reviewingOrd: 5 },
+    { type: 'failureTriaged', session: GATE_RUN, ord: 5, seq, ts: 1789082200000, decision: 'escalate', analysis: DELIVER_TRIAGE_ANALYSIS },
+    { type: 'awaitingHuman', session: GATE_RUN, ord: 5, seq: seq + 1, ts: 1789082200001, prompt: deliverRetryPrompt(refusal), reviewingOrd: 5 },
   ];
 }
 
@@ -343,13 +404,13 @@ function deliverRetry(seq: number): CoreEvent[] {
  *  unit #5) so the run's earlier folds stay in the log. */
 export const DELIVER_UNCHANGED_TAIL: CoreEvent[] = [...DISPATCH_5, LIFT_UNCHANGED];
 export const DELIVER_LIFTED_TAIL: CoreEvent[] = [...DISPATCH_5, LIFT_LIFTED, DELIVER_REVERIFY_PASS, GATE_DELIVER_PASS];
-export const DELIVER_CONFLICT_TAIL: CoreEvent[] = [...DISPATCH_5, LIFT_CONFLICT, STEP_FAILED_CONFLICT, ...deliverRetry(312)];
+export const DELIVER_CONFLICT_TAIL: CoreEvent[] = [...DISPATCH_5, LIFT_CONFLICT, STEP_FAILED_CONFLICT, ...deliverRetry(312, REFUSAL_CONFLICT)];
 export const DELIVER_SKIPPED_TAIL: CoreEvent[] = [...DISPATCH_5, LIFT_SKIPPED];
-export const DELIVER_FAILED_TAIL: CoreEvent[] = [...DISPATCH_5, LIFT_FAILED, STEP_FAILED_APPLY, ...deliverRetry(312)];
+export const DELIVER_FAILED_TAIL: CoreEvent[] = [...DISPATCH_5, LIFT_FAILED, STEP_FAILED_APPLY, ...deliverRetry(312, REFUSAL_APPLY_FAILED)];
 /** The addendum: refused for a wrong HEAD ref — NO `deliverLiftEvaluated` precedes the failure. */
-export const DELIVER_WRONG_HEAD_TAIL: CoreEvent[] = [...DISPATCH_5, STEP_FAILED_WRONG_HEAD, ...deliverRetry(312)];
-export const DELIVER_REVERIFY_FAILED_TAIL: CoreEvent[] = [...DISPATCH_5, LIFT_LIFTED, DELIVER_REVERIFY_FAIL, STEP_FAILED_REVERIFY, ...deliverRetry(323)];
-export const DELIVER_CHANGED_TREE_TAIL: CoreEvent[] = [...DISPATCH_5, LIFT_LIFTED, DELIVER_REVERIFY_CHANGED_TREE, STEP_FAILED_CHANGED_TREE, ...deliverRetry(323)];
+export const DELIVER_WRONG_HEAD_TAIL: CoreEvent[] = [...DISPATCH_5, STEP_FAILED_WRONG_HEAD, ...deliverRetry(312, REFUSAL_WRONG_HEAD)];
+export const DELIVER_REVERIFY_FAILED_TAIL: CoreEvent[] = [...DISPATCH_5, LIFT_LIFTED, DELIVER_REVERIFY_FAIL, STEP_FAILED_REVERIFY, ...deliverRetry(323, REFUSAL_REVERIFY_FAILED)];
+export const DELIVER_CHANGED_TREE_TAIL: CoreEvent[] = [...DISPATCH_5, LIFT_LIFTED, DELIVER_REVERIFY_CHANGED_TREE, STEP_FAILED_CHANGED_TREE, ...deliverRetry(323, REFUSAL_CHANGED_TREE)];
 
 // ── (4) the run base ─────────────────────────────────────────────────────────────────────────────
 

--- a/tests/gateVerdictModel.test.ts
+++ b/tests/gateVerdictModel.test.ts
@@ -186,7 +186,7 @@ describe('gateVerdict helpers', () => {
   });
 
   it('checkOutcome: exit code, timeout and spawn error in that priority', () => {
-    const base = { name: 'test', argv: [], source: '', exitCode: 0, timedOut: false, spawnError: null, durationMs: 1 };
+    const base = { name: 'test', argv: [], source: '', exitCode: 0, timedOut: false, spawnError: null, durationMs: 1, stdoutTail: null, stderrTail: null };
     expect(checkOutcome(base)).toEqual({ word: 'exit 0', ok: true });
     expect(checkOutcome({ ...base, exitCode: 1 })).toEqual({ word: 'exit 1', ok: false });
     expect(checkOutcome({ ...base, exitCode: null, timedOut: true })).toEqual({ word: 'timed out', ok: false });

--- a/tests/gateVerdictModel.test.ts
+++ b/tests/gateVerdictModel.test.ts
@@ -60,7 +60,13 @@ describe('gateVerdict — which evaluation answers the gate', () => {
       afterTree: TREE_AFTER,
       headMoved: false,
       changed: [{ path: 'src/App.tsx', status: 'M' }],
+      // The recorded frame predates wicked-core#431 (api-types 0.33.0): no `restored` field ⇒ `null`,
+      // never `false` — `false` is the engine SAYING the restore failed (tests/*.wire433.test.*).
+      restored: null,
+      restoreError: null,
     });
+    expect(v!.restore).toBeNull();
+    expect(v!.judgeCli).toBeNull();
     // The judge itself said PASS — the denial is the guard's, and the view keeps both facts.
     expect(v!.agentVerdict).toBe('pass');
   });

--- a/tests/gateVerdictModel.wire433.test.ts
+++ b/tests/gateVerdictModel.wire433.test.ts
@@ -1,0 +1,218 @@
+// wicked-core#431 / api-types 0.33.0 — the pure half of the three new stories on the gate, the
+// deliver ord and the run head (tests/fixtures/wire433.ts): the named judge and the restore state
+// on the verdict view, the deliver lift's newest-attempt fold, and the run base — every field
+// `null`/absent-safe for a daemon that predates the wire.
+
+import { describe, expect, it } from 'vitest';
+import type { CoreEvent } from '../src/api/types.js';
+import { deliverLift, liftIsFailure, liftOutcomeLabel, reverifyChangedTree } from '../src/components/deliverLiftModel.js';
+import { gateVerdict, shortId } from '../src/components/gateVerdictModel.js';
+import { runBase, runBaseLine, runBaseOf } from '../src/components/runBaseModel.js';
+import { G4_EVENTS, G5_EVENTS, G6_EVENTS, GATE_RUN, TREE_BEFORE } from './fixtures/gateEvidence.js';
+import {
+  BASE_AFTER,
+  BASE_BEFORE,
+  DELIVER_CHANGED_TREE_TAIL,
+  DELIVER_CONFLICT_TAIL,
+  DELIVER_FAILED_TAIL,
+  DELIVER_LIFTED_TAIL,
+  DELIVER_REVERIFY_FAILED_TAIL,
+  DELIVER_SKIPPED_TAIL,
+  DELIVER_UNCHANGED_TAIL,
+  DELIVER_WRONG_HEAD_TAIL,
+  DISPATCH_5,
+  G4_SAME_SEAT_EVENTS,
+  G5R_EVENTS,
+  G5R_UNPINNED_EVENTS,
+  G5_RESTORE_FAILED_EVENTS,
+  LIFT_CONFLICT,
+  REFUSAL_CONFLICT,
+  REFUSAL_WRONG_HEAD,
+  RESTORE_FAILED_ERROR,
+  RUN_BASE_AT_TIP,
+  RUN_BASE_FETCH_FAILED,
+  RUN_BASE_LIFTED,
+  RUN_BASE_LOCAL_KEPT,
+  RUN_BASE_NO_REMOTE,
+  SUGGESTION_REF,
+} from './fixtures/wire433.js';
+
+describe('gateVerdict — the judge seat (F-3R2-007)', () => {
+  it('reads judgeCli / judgeDistinct off gateEvaluated', () => {
+    const v = gateVerdict(G5R_EVENTS, 4)!;
+    expect(v.judgeCli).toBe('codex');
+    expect(v.judgeDistinct).toBe(true);
+    const same = gateVerdict(G4_SAME_SEAT_EVENTS, 4)!;
+    expect(same.ord).toBe(3);
+    expect(same.judgeCli).toBe('claude');
+    expect(same.judgeDistinct).toBe(false);
+  });
+
+  it('a frame without the fields (a pre-0.33.0 daemon) or with explicit nulls (no judge ran) yields null — never a guessed seat', () => {
+    expect(gateVerdict(G4_EVENTS, 4)!.judgeCli).toBeNull();
+    expect(gateVerdict(G4_EVENTS, 4)!.judgeDistinct).toBeNull();
+    const v = gateVerdict(G5_RESTORE_FAILED_EVENTS, 4)!;
+    expect(v.judgeCli).toBeNull();
+    expect(v.judgeDistinct).toBeNull();
+    // A non-boolean distinct flag is unknown, not false.
+    const odd: CoreEvent[] = [{ type: 'gateEvaluated', session: GATE_RUN, ord: 1, combined: true, judgeCli: 'pi', judgeDistinct: 'yes' }];
+    expect(gateVerdict(odd, 1)!.judgeDistinct).toBeNull();
+    expect(gateVerdict(odd, 1)!.judgeCli).toBe('pi');
+  });
+});
+
+describe('gateVerdict — the restore state (F-3R2-010)', () => {
+  it('G5 on the #431 engine: restored:true on the mutation, the worktreeRestored record attached with its discarded paths and the pinned ref', () => {
+    const v = gateVerdict(G5R_EVENTS, 4)!;
+    expect(v.outcome).toBe('fail');
+    expect(v.denial!.source).toBe('worktree_guard');
+    expect(v.mutation).toMatchObject({ cli: 'pi', phase: 'verify', restored: true, restoreError: null, changed: [{ path: 'src/App.tsx', status: 'M' }] });
+    expect(v.restore).toEqual({ tree: TREE_BEFORE, head: null, discarded: [{ path: 'src/App.tsx', status: 'M' }], suggestionRef: SUGGESTION_REF });
+  });
+
+  it('a failed pin keeps the record with suggestionRef null', () => {
+    expect(gateVerdict(G5R_UNPINNED_EVENTS, 4)!.restore!.suggestionRef).toBeNull();
+  });
+
+  it('a failed restore: restored:false + restoreError, no restore record', () => {
+    const v = gateVerdict(G5_RESTORE_FAILED_EVENTS, 4)!;
+    expect(v.mutation!.restored).toBe(false);
+    expect(v.mutation!.restoreError).toBe(RESTORE_FAILED_ERROR);
+    expect(v.restore).toBeNull();
+  });
+
+  it('the recorded pre-0.33.0 fold (no restored field, no worktreeRestored) reads restored:null and restore:null', () => {
+    const v = gateVerdict(G5_EVENTS, 4)!;
+    expect(v.mutation!.restored).toBeNull();
+    expect(v.mutation!.restoreError).toBeNull();
+    expect(v.restore).toBeNull();
+  });
+
+  it('the restore record belongs to ONE fold: the retry\'s PASS (G6) inherits neither the mutation nor the restore', () => {
+    const retried = [...G5R_EVENTS, ...G6_EVENTS.slice(G5_EVENTS.length)];
+    const v = gateVerdict(retried, 5)!;
+    expect(v.outcome).toBe('pass');
+    expect(v.mutation).toBeNull();
+    expect(v.restore).toBeNull();
+  });
+});
+
+describe('deliverLift — the deliver ord\'s newest-attempt story (F-3R2-013)', () => {
+  const tail = (t: CoreEvent[]): CoreEvent[] => [...G6_EVENTS, ...t];
+
+  it('unchanged: the base was already the tip; no re-verify, no failure', () => {
+    const v = deliverLift(tail(DELIVER_UNCHANGED_TAIL), 5)!;
+    expect(v).toMatchObject({ ord: 5, attempt: 0, outcome: 'unchanged', baseRef: 'origin/main', baseBefore: BASE_BEFORE, baseAfter: BASE_BEFORE, conflicts: [], note: null, reverify: null, failure: null });
+    expect(liftIsFailure(v)).toBe(false);
+  });
+
+  it('lifted: the re-verify (the deliver ord\'s repoChecksEvaluated) rides the view, forced-install source and all', () => {
+    const v = deliverLift(tail(DELIVER_LIFTED_TAIL), 5)!;
+    expect(v.outcome).toBe('lifted');
+    expect(v.baseAfter).toBe(BASE_AFTER);
+    expect(v.reverify!.passed).toBe(true);
+    expect(v.reverify!.checks.map((c) => c.name)).toEqual(['install', 'typecheck', 'lint', 'test']);
+    expect(v.reverify!.checks[0]!.source).toBe('package-lock.json (forced: lockfile drift)');
+    expect(v.failure).toBeNull();
+    expect(liftIsFailure(v)).toBe(false);
+  });
+
+  it('conflict: the files, and the engine\'s LIFT-CONFLICT refusal verbatim as the failure', () => {
+    const v = deliverLift(tail(DELIVER_CONFLICT_TAIL), 5)!;
+    expect(v.outcome).toBe('conflict');
+    expect(v.conflicts).toEqual(['testid-inventory.json']);
+    expect(v.treeAfter).toBeNull();
+    expect(v.failure).toBe(REFUSAL_CONFLICT);
+    expect(liftIsFailure(v)).toBe(true);
+  });
+
+  it('skipped / failed carry the engine\'s note', () => {
+    expect(deliverLift(tail(DELIVER_SKIPPED_TAIL), 5)).toMatchObject({ outcome: 'skipped', baseRef: null, note: expect.stringContaining('no remote default branch') });
+    const failed = deliverLift(tail(DELIVER_FAILED_TAIL), 5)!;
+    expect(failed.outcome).toBe('failed');
+    expect(failed.failure).toContain('could not be applied cleanly');
+    expect(liftIsFailure(failed)).toBe(true);
+  });
+
+  it('the addendum: a deliver unit refused for a wrong HEAD ref has NO lift frame — the view is the deliver: failure alone (outcome null)', () => {
+    const v = deliverLift(tail(DELIVER_WRONG_HEAD_TAIL), 5)!;
+    expect(v.outcome).toBeNull();
+    expect(v.failure).toBe(REFUSAL_WRONG_HEAD);
+    expect(v.reverify).toBeNull();
+    expect(liftIsFailure(v)).toBe(true);
+    expect(liftOutcomeLabel(v.outcome)).toBe('refused before the lift');
+  });
+
+  it('a failed re-verify and a failed post-check proof both read passed:false — the proof case is recognisable (every check exit 0)', () => {
+    const red = deliverLift(tail(DELIVER_REVERIFY_FAILED_TAIL), 5)!;
+    expect(red.reverify!.passed).toBe(false);
+    expect(red.reverify!.skipped).toEqual(['test']);
+    expect(reverifyChangedTree(red.reverify!)).toBe(false);
+    expect(red.failure).toContain("the repository's own checks FAILED on it");
+    const moved = deliverLift(tail(DELIVER_CHANGED_TREE_TAIL), 5)!;
+    expect(moved.reverify!.passed).toBe(false);
+    expect(moved.reverify!.checks.every((c) => c.exitCode === 0)).toBe(true);
+    expect(reverifyChangedTree(moved.reverify!)).toBe(true);
+    expect(moved.failure).toContain('CHANGED the worktree while running');
+  });
+
+  it('a retry starts a fresh story: the new attempt\'s unitDispatched drops the previous conflict; its own lift then stands', () => {
+    const retry: CoreEvent = { type: 'unitDispatched', session: GATE_RUN, ord: 5, seq: 330, ts: 1, attempt: 1 };
+    expect(deliverLift(tail([...DELIVER_CONFLICT_TAIL, retry]), 5)).toBeNull();
+    const lifted: CoreEvent = { ...LIFT_CONFLICT, seq: 331, attempt: 1, outcome: 'unchanged', baseAfter: BASE_BEFORE, conflicts: [] };
+    const v = deliverLift(tail([...DELIVER_CONFLICT_TAIL, retry, lifted]), 5)!;
+    expect(v.attempt).toBe(1);
+    expect(v.outcome).toBe('unchanged');
+    expect(v.failure).toBeNull();
+  });
+
+  it('scoping: a non-deliver ord sees nothing (its repoChecksEvaluated is the verify floor, not a re-verify); unscoped, only a lift frame starts a story', () => {
+    const log = tail(DELIVER_LIFTED_TAIL);
+    expect(deliverLift(log, 4)).toBeNull(); // ord 4's repoChecksEvaluated is the verify floor — no lift frame precedes it
+    const unscoped = deliverLift(log)!;
+    expect(unscoped.ord).toBe(5);
+    expect(unscoped.reverify!.checks).toHaveLength(4);
+    expect(deliverLift(G6_EVENTS)).toBeNull();
+    // A stepFailed on the deliver ord that is NOT a deliver: refusal (a worker stack trace) does not
+    // start a story on its own — that is the failure banner's business.
+    const worker: CoreEvent = { type: 'stepFailed', session: GATE_RUN, ord: 5, seq: 311, ts: 1, attempt: 0, detail: 'worker exited 1\nTraceback…' };
+    expect(deliverLift([...G6_EVENTS, ...DISPATCH_5, worker], 5)).toBeNull();
+  });
+
+  it('no deliver frames at all (the pre-run deliver gate, or an older daemon) ⇒ null', () => {
+    expect(deliverLift(G6_EVENTS, 5)).toBeNull();
+    expect(deliverLift([], 5)).toBeNull();
+  });
+
+  it('liftOutcomeLabel: every engine token has a word; a newer engine\'s passes through', () => {
+    expect(['unchanged', 'lifted', 'conflict', 'skipped', 'failed'].map(liftOutcomeLabel)).toEqual([
+      'base unchanged', 'lifted onto the current tip', 'LIFT-CONFLICT', 'lift skipped', 'lift failed',
+    ]);
+    expect(liftOutcomeLabel('rebased_by_operator')).toBe('rebased_by_operator');
+  });
+});
+
+describe('runBase — how the run\'s base was chosen (F-3R2-013)', () => {
+  it('the last runBaseResolved in the log, narrowed', () => {
+    expect(runBase([RUN_BASE_LIFTED, ...G4_EVENTS])).toEqual({
+      baseRef: 'origin/main', baseCommit: BASE_AFTER, localHead: BASE_BEFORE, behind: 5, fetched: true, lifted: true, note: null,
+    });
+    expect(runBase(G4_EVENTS)).toBeNull();
+    expect(runBaseOf({ type: 'runBaseResolved', session: GATE_RUN })).toBeNull(); // no commit ⇒ no view
+    expect(runBaseOf({ type: 'runBaseResolved', session: GATE_RUN, baseCommit: BASE_AFTER, behind: -3 })!.behind).toBe(0);
+  });
+
+  it('runBaseLine: the one-line note per posture', () => {
+    expect(runBaseLine(runBaseOf(RUN_BASE_LIFTED)!)).toBe(`origin/main @ ${shortId(BASE_AFTER, 7)} · 5 behind · lifted to the tip`);
+    expect(runBaseLine(runBaseOf(RUN_BASE_AT_TIP)!)).toBe(`origin/main @ ${shortId(BASE_BEFORE, 7)} · at the tip`);
+    expect(runBaseLine(runBaseOf(RUN_BASE_LOCAL_KEPT)!)).toBe(`origin/main @ ${shortId(BASE_BEFORE, 7)} · local HEAD kept`);
+    expect(runBaseLine(runBaseOf(RUN_BASE_NO_REMOTE)!)).toBe(`local HEAD @ ${shortId(BASE_BEFORE, 7)} · no remote default branch resolved`);
+    expect(runBaseLine(runBaseOf(RUN_BASE_FETCH_FAILED)!)).toBe(`origin/main @ ${shortId(BASE_BEFORE, 7)} · local HEAD kept · fetch failed — cached refs`);
+  });
+
+  it('shortId: trees to 10, commits to 7, short ids whole', () => {
+    expect(shortId(TREE_BEFORE)).toBe(TREE_BEFORE.slice(0, 10));
+    expect(shortId(BASE_AFTER, 7)).toBe(BASE_AFTER.slice(0, 7));
+    expect(shortId('abc', 7)).toBe('abc');
+  });
+});

--- a/tests/gateVerdictModel.wire433.test.ts
+++ b/tests/gateVerdictModel.wire433.test.ts
@@ -54,8 +54,9 @@ describe('gateVerdict — the judge seat (F-3R2-007)', () => {
     const v = gateVerdict(G5_RESTORE_FAILED_EVENTS, 4)!;
     expect(v.judgeCli).toBeNull();
     expect(v.judgeDistinct).toBeNull();
-    // A non-boolean distinct flag is unknown, not false.
-    const odd: CoreEvent[] = [{ type: 'gateEvaluated', session: GATE_RUN, ord: 1, combined: true, judgeCli: 'pi', judgeDistinct: 'yes' }];
+    // A non-boolean distinct flag is unknown, not false. A bag on purpose: 0.33.0 declares the field
+    // `boolean | null`, and this probes a frame that violates the declaration.
+    const odd: CoreEvent[] = [{ type: 'gateEvaluated', session: GATE_RUN, ord: 1, combined: true, judgeCli: 'pi', judgeDistinct: 'yes' } as unknown as CoreEvent];
     expect(gateVerdict(odd, 1)!.judgeDistinct).toBeNull();
     expect(gateVerdict(odd, 1)!.judgeCli).toBe('pi');
   });

--- a/tests/gateVerdictModel.wire433.test.ts
+++ b/tests/gateVerdictModel.wire433.test.ts
@@ -5,8 +5,8 @@
 
 import { describe, expect, it } from 'vitest';
 import type { CoreEvent } from '../src/api/types.js';
-import { deliverLift, liftIsFailure, liftOutcomeLabel, reverifyChangedTree } from '../src/components/deliverLiftModel.js';
-import { gateVerdict, shortId } from '../src/components/gateVerdictModel.js';
+import { deliverLift, liftIsFailure, liftOutcomeLabel, reverifyChangedTree, splitElided, textCarriesFailure } from '../src/components/deliverLiftModel.js';
+import { floorOf, gateVerdict, isRestoredRetry, shortId } from '../src/components/gateVerdictModel.js';
 import { runBase, runBaseLine, runBaseOf } from '../src/components/runBaseModel.js';
 import { G4_EVENTS, G5_EVENTS, G6_EVENTS, GATE_RUN, TREE_BEFORE } from './fixtures/gateEvidence.js';
 import {
@@ -16,17 +16,25 @@ import {
   DELIVER_CONFLICT_TAIL,
   DELIVER_FAILED_TAIL,
   DELIVER_LIFTED_TAIL,
+  DELIVER_REVERIFY_FAIL,
   DELIVER_REVERIFY_FAILED_TAIL,
   DELIVER_SKIPPED_TAIL,
   DELIVER_UNCHANGED_TAIL,
   DELIVER_WRONG_HEAD_TAIL,
+  DETAIL_CHANGED_TREE,
+  DETAIL_CONFLICT,
+  DETAIL_REVERIFY_FAILED,
+  DETAIL_WRONG_HEAD,
   DISPATCH_5,
   G4_SAME_SEAT_EVENTS,
   G5R_EVENTS,
   G5R_UNPINNED_EVENTS,
   G5_RESTORE_FAILED_EVENTS,
+  GATE_DENY_RESTORED,
   LIFT_CONFLICT,
+  LINT_STDERR_TAIL,
   REFUSAL_CONFLICT,
+  REFUSAL_REVERIFY_FAILED,
   REFUSAL_WRONG_HEAD,
   RESTORE_FAILED_ERROR,
   RUN_BASE_AT_TIP,
@@ -35,6 +43,11 @@ import {
   RUN_BASE_LOCAL_KEPT,
   RUN_BASE_NO_REMOTE,
   SUGGESTION_REF,
+  boundedExcerpt,
+  deliverEscalationReason,
+  deliverRejectedReason,
+  deliverRetryPrompt,
+  deliverWorkerFailedReason,
 } from './fixtures/wire433.js';
 
 describe('gateVerdict — the judge seat (F-3R2-007)', () => {
@@ -149,7 +162,12 @@ describe('deliverLift — the deliver ord\'s newest-attempt story (F-3R2-013)', 
     expect(red.reverify!.passed).toBe(false);
     expect(red.reverify!.skipped).toEqual(['test']);
     expect(reverifyChangedTree(red.reverify!)).toBe(false);
-    expect(red.failure).toContain("the repository's own checks FAILED on it");
+    // What the wire carries (F-255-04): the 150/250 head+tail of the 532-char refusal — the marker in
+    // the middle, the lockfile-drift sentence (elided) gone; an operator reads the excerpt, not the essay.
+    expect(red.failure).toBe(DETAIL_REVERIFY_FAILED);
+    expect(red.failure).toMatch(/\[… \d+ chars elided …\]/);
+    expect(red.failure!.startsWith('deliver: the tree that would ship')).toBe(true);
+    expect(red.failure).not.toContain('Lockfile drift between the old base and the tip');
     const moved = deliverLift(tail(DELIVER_CHANGED_TREE_TAIL), 5)!;
     expect(moved.reverify!.passed).toBe(false);
     expect(moved.reverify!.checks.every((c) => c.exitCode === 0)).toBe(true);
@@ -215,5 +233,90 @@ describe('runBase — how the run\'s base was chosen (F-3R2-013)', () => {
     expect(shortId(TREE_BEFORE)).toBe(TREE_BEFORE.slice(0, 10));
     expect(shortId(BASE_AFTER, 7)).toBe(BASE_AFTER.slice(0, 7));
     expect(shortId('abc', 7)).toBe('abc');
+  });
+});
+
+describe("the wire's excerpting and framing — modelled, not wished away (F-255-04)", () => {
+  it('boundedExcerpt is actor.rs bounded_excerpt: whole under the cap, head + marker + tail over it (code points, not bytes)', () => {
+    expect(boundedExcerpt('short', 150, 250)).toBe('short');
+    const long = 'a'.repeat(300) + 'é' + 'b'.repeat(299); // 600 code points
+    const out = boundedExcerpt(long, 150, 250);
+    expect(out.startsWith('a'.repeat(150) + '\n[… 200 chars elided …]\n')).toBe(true);
+    expect(out.endsWith('b'.repeat(250))).toBe(true);
+  });
+
+  it('the refusals that fit 400 chars reach the wire whole; the two that do not are elided in the middle', () => {
+    expect(DETAIL_CONFLICT).toBe(REFUSAL_CONFLICT);
+    expect(DETAIL_WRONG_HEAD).toBe(REFUSAL_WRONG_HEAD);
+    for (const d of [DETAIL_REVERIFY_FAILED, DETAIL_CHANGED_TREE]) {
+      expect(d).toMatch(/\[… \d+ chars elided …\]/);
+      expect(d.startsWith('deliver: ')).toBe(true);
+    }
+    expect(splitElided(DETAIL_REVERIFY_FAILED)).toHaveLength(3);
+    expect(splitElided(DETAIL_CONFLICT)).toEqual([DETAIL_CONFLICT]);
+  });
+});
+
+describe('textCarriesFailure — the refusal is said once (F-255-02)', () => {
+  it('the triage-escalate prompt (450/750 excerpt) carries the elided 150/250 detail; an unrelated prompt does not', () => {
+    expect(textCarriesFailure(deliverRetryPrompt(REFUSAL_REVERIFY_FAILED), DETAIL_REVERIFY_FAILED)).toBe(true);
+    expect(textCarriesFailure(deliverRetryPrompt(REFUSAL_CONFLICT), DETAIL_CONFLICT)).toBe(true);
+    expect(textCarriesFailure(deliverRetryPrompt(REFUSAL_CONFLICT), DETAIL_REVERIFY_FAILED)).toBe(false);
+    expect(textCarriesFailure('Prompt unavailable (daemon restarted) — you can still approve or reject.', DETAIL_CONFLICT)).toBe(false);
+  });
+
+  it("a rejected unit's FRAMED denial_reason carries it on both engine paths; so does the open-gate escalation reason", () => {
+    expect(textCarriesFailure(deliverWorkerFailedReason(REFUSAL_CONFLICT), DETAIL_CONFLICT)).toBe(true);
+    expect(textCarriesFailure(deliverRejectedReason(REFUSAL_REVERIFY_FAILED), DETAIL_REVERIFY_FAILED)).toBe(true);
+    expect(textCarriesFailure(deliverEscalationReason(REFUSAL_REVERIFY_FAILED), DETAIL_REVERIFY_FAILED)).toBe(true);
+    // The bare refusal — what no engine path sends as a reason — would carry it too.
+    expect(textCarriesFailure(REFUSAL_REVERIFY_FAILED, DETAIL_REVERIFY_FAILED)).toBe(true);
+  });
+
+  it('nothing to compare is never a match', () => {
+    expect(textCarriesFailure(null, DETAIL_CONFLICT)).toBe(false);
+    expect(textCarriesFailure(undefined, DETAIL_CONFLICT)).toBe(false);
+    expect(textCarriesFailure('anything', null)).toBe(false);
+    expect(textCarriesFailure('anything', '\n[… 12 chars elided …]\n')).toBe(false);
+  });
+});
+
+describe('isRestoredRetry — one predicate for every gate card (F-255-01 / F-255-05)', () => {
+  it("true exactly for this unit's failed worktree-guard denial with the tree restored", () => {
+    expect(isRestoredRetry(gateVerdict(G5R_EVENTS, 4), 4)).toBe(true);
+    expect(isRestoredRetry(gateVerdict(G5R_UNPINNED_EVENTS, 4), 4)).toBe(true); // a failed pin changes nothing here
+  });
+
+  it('false when the restore failed, on the pre-0.33.0 fold, for another ord, with no ord, and with no verdict', () => {
+    expect(isRestoredRetry(gateVerdict(G5_RESTORE_FAILED_EVENTS, 4), 4)).toBe(false);
+    expect(isRestoredRetry(gateVerdict(G5_EVENTS, 4), 4)).toBe(false);
+    expect(isRestoredRetry(gateVerdict(G5R_EVENTS, 4), 5)).toBe(false);
+    expect(isRestoredRetry(gateVerdict(G5R_EVENTS, 4), undefined)).toBe(false);
+    expect(isRestoredRetry(gateVerdict(G5R_EVENTS, 4), null)).toBe(false);
+    expect(isRestoredRetry(null, 4)).toBe(false);
+  });
+
+  it("mirrors the engine's guard: a dual-deny another layer wins (denial.source ≠ worktree_guard) keeps Approve even though the tree was restored", () => {
+    const otherLayerWins: CoreEvent[] = G5R_EVENTS.map((e) =>
+      e.type === 'gateEvaluated' && e.ord === 4
+        ? { ...e, denial: { ...GATE_DENY_RESTORED.denial, source: 'repo_checks', reason: 'repository checks failed in the worktree: lint exited 1' } }
+        : e,
+    );
+    const v = gateVerdict(otherLayerWins, 4)!;
+    expect(v.mutation?.restored).toBe(true);
+    expect(v.denial?.source).toBe('repo_checks');
+    expect(isRestoredRetry(v, 4)).toBe(false);
+  });
+});
+
+describe('floorOf — the stream tails behind a red check (F-255-03)', () => {
+  it('a recorded stderr tail survives narrowing; an empty stream is null, never an empty box', () => {
+    const floor = floorOf(DELIVER_REVERIFY_FAIL);
+    const lint = floor.checks.find((c) => c.name === 'lint')!;
+    expect(lint.stderrTail).toBe(LINT_STDERR_TAIL);
+    expect(lint.stdoutTail).toBeNull();
+    const install = floor.checks.find((c) => c.name === 'install')!;
+    expect(install.stderrTail).toBeNull();
+    expect(install.stdoutTail).toBeNull();
   });
 });

--- a/tests/narrator.wire433.test.ts
+++ b/tests/narrator.wire433.test.ts
@@ -1,0 +1,71 @@
+// wicked-core#431 / api-types 0.33.0 in the FEED (DES-RUN-NARRATOR §4): the run base, the creator
+// tree restored, the deliver lift per outcome, a refused write, and the ONE deliberate ACP reroute
+// the feed speaks (`read_only_requires_wrapped`) — every other acpFallback kind stays silent, as
+// do the frames a pre-0.33.0 daemon never sends.
+
+import { describe, expect, it } from 'vitest';
+import type { CoreEvent } from '../src/api/types.js';
+import { narrate, type NarratorContext } from '../src/components/narrator.js';
+import {
+  BASE_AFTER,
+  BASE_BEFORE,
+  LIFT_CONFLICT,
+  LIFT_FAILED,
+  LIFT_LIFTED,
+  LIFT_SKIPPED,
+  LIFT_UNCHANGED,
+  READ_ONLY_REROUTE,
+  RUN_BASE_LIFTED,
+  RUN_BASE_NO_REMOTE,
+  SUGGESTION_REF,
+  TOOL_DENIED,
+  TOOL_DENIED_KINDLESS,
+  WORKTREE_RESTORED,
+} from './fixtures/wire433.js';
+
+const ctx: NarratorContext = {
+  phaseOf: (ord) => (typeof ord === 'number' ? `phase-${ord}` : 'this phase'),
+};
+
+describe('narrate — the wicked-core#431 frames', () => {
+  const CASES: Array<[CoreEvent, string, string]> = [
+    [RUN_BASE_LIFTED, `Based on origin/main @ ${BASE_AFTER.slice(0, 7)} · 5 behind · lifted to the tip`, 'info'],
+    [RUN_BASE_NO_REMOTE, `Based on local HEAD @ ${BASE_BEFORE.slice(0, 7)} · no remote default branch resolved`, 'info'],
+    [WORKTREE_RESTORED, `Restored the creator's tree for phase-4 — pi's edit (1 path) was discarded, kept at ${SUGGESTION_REF}`, 'gate'],
+    [{ ...WORKTREE_RESTORED, suggestionRef: null, discarded: [] }, "Restored the creator's tree for phase-4 — pi's edit (0 paths) was discarded", 'gate'],
+    [LIFT_UNCHANGED, `Deliver lift: base unchanged — origin/main is still at ${BASE_BEFORE.slice(0, 7)}`, 'info'],
+    [LIFT_LIFTED, `Deliver lift: lifted onto origin/main @ ${BASE_AFTER.slice(0, 7)} — re-running the repository's checks on the lifted tree`, 'work'],
+    [LIFT_CONFLICT, 'Deliver lift: CONFLICT in testid-inventory.json — nothing rebased, nothing pushed', 'fail'],
+    [LIFT_SKIPPED, 'Deliver lift: skipped — no remote default branch resolved (origin/HEAD is unset and origin/main does not exist)', 'info'],
+    [LIFT_FAILED, 'Deliver lift: FAILED — git read-tree -m -u exited 128 after the merge-tree succeeded — nothing pushed', 'fail'],
+    [{ ...LIFT_UNCHANGED, outcome: 'rebased_by_operator', note: 'by hand' }, 'Deliver lift: rebased_by_operator — by hand', 'info'],
+    [TOOL_DENIED, 'Refused a write by claude during phase-4 — edit on src/App.tsx (a read-only phase may not edit)', 'fail'],
+    [TOOL_DENIED_KINDLESS, 'Refused a write by claude during phase-4 — edit (a read-only phase may not edit)', 'fail'],
+    [READ_ONLY_REROUTE, 'pi moved to the wrapped carrier for its read-only turn — the write lock is an argv fact there, not a failure', 'info'],
+  ];
+
+  for (const [event, text, tone] of CASES) {
+    it(`${event.type}${typeof event['outcome'] === 'string' ? `/${event['outcome']}` : ''} → "${text.slice(0, 48)}…" (${tone})`, () => {
+      const line = narrate(event, ctx);
+      expect(line).not.toBeNull();
+      expect(line!.text).toBe(text);
+      expect(line!.tone).toBe(tone);
+      expect(line!.event).toBe(event);
+    });
+  }
+
+  it('every other acpFallback kind stays silent — a transport failure is seat-health\'s story, not a feed line', () => {
+    for (const kind of ['binary_unavailable', 'session_died', 'auth_required', 'governance_requires_wrapped', 'something_newer']) {
+      expect(narrate({ ...READ_ONLY_REROUTE, fallbackKind: kind }, ctx)).toBeNull();
+    }
+  });
+
+  it('a runBaseResolved frame with no commit is not spoken (nothing to base the line on)', () => {
+    expect(narrate({ type: 'runBaseResolved', session: 'r' }, ctx)).toBeNull();
+  });
+
+  it('the deliver lift line carries the deliver ord so the feed anchors it under the deliver unit', () => {
+    expect(narrate(LIFT_CONFLICT, ctx)!.ord).toBe(5);
+    expect(narrate(RUN_BASE_LIFTED, ctx)!.ord).toBeNull(); // session-level: no ord
+  });
+});

--- a/tests/wire433.shapes.test.ts
+++ b/tests/wire433.shapes.test.ts
@@ -1,0 +1,212 @@
+// @vitest-environment node
+// (a pure filesystem + type-pin suite: the suite-wide jsdom env rewrites import.meta.url to an
+// http: origin, and nothing here renders)
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import type {
+  AcpFallbackEvent,
+  DeliverLiftEvaluatedEvent,
+  EvaluatorMutatedWorktreeEvent,
+  EvaluatorToolCallDeniedEvent,
+  GateEvaluatedEvent,
+  RepoChecksEvaluatedEvent,
+  RunBaseResolvedEvent,
+  StepFailedEvent,
+  WorktreeRestoredEvent,
+} from '../src/api/types.js';
+import {
+  DELIVER_REVERIFY_CHANGED_TREE,
+  DELIVER_REVERIFY_FAIL,
+  DELIVER_REVERIFY_PASS,
+  GATE_DELIVER_PASS,
+  GATE_DENY_RESTORED,
+  LIFT_CONFLICT,
+  LIFT_FAILED,
+  LIFT_LIFTED,
+  LIFT_SKIPPED,
+  LIFT_UNCHANGED,
+  MUTATION_RESTORED,
+  READ_ONLY_REROUTE,
+  RUN_BASE_AT_TIP,
+  RUN_BASE_FETCH_FAILED,
+  RUN_BASE_LIFTED,
+  RUN_BASE_LOCAL_KEPT,
+  RUN_BASE_NO_REMOTE,
+  STEP_FAILED_APPLY,
+  STEP_FAILED_CHANGED_TREE,
+  STEP_FAILED_CONFLICT,
+  STEP_FAILED_REVERIFY,
+  STEP_FAILED_WRONG_HEAD,
+  TOOL_DENIED,
+  TOOL_DENIED_KINDLESS,
+  WORKTREE_RESTORED,
+  type Wire,
+} from './fixtures/wire433.js';
+
+/**
+ * wire433.shapes — the fixtures ARE `wicked-crew-api-types` 0.33.0's declared shapes (wicked-core#431 /
+ * wicked-crew#527; F-3R2-013).
+ *
+ * Two pins, one per compiler. COMPILE-TIME: every #431 frame in `fixtures/wire433.ts` is declared
+ * `satisfies` its named type (excess keys fail there), and the `pinned` table below assigns each frame
+ * to that type again (a missing key, a tightened nullability or a token outside a union fails here) —
+ * `tsc --noEmit` covers `tests/`, so either drift is a red `npm run typecheck`. RUN-TIME: this suite
+ * reads the INSTALLED `index.d.ts`, extracts each declaration's key set and each union's tokens, and
+ * diffs the frames against them — "every key present, `null` never absent, nothing the wire does not
+ * declare" is re-derived from the package the lockfile resolved, not from a hand-copied list that
+ * would drift silently on the next pin.
+ */
+
+const PKG_ROOT = new URL('../', import.meta.url);
+const DTS = readFileSync(fileURLToPath(new URL('node_modules/wicked-crew-api-types/index.d.ts', PKG_ROOT)), 'utf8');
+
+/** The body of `export interface X {…}` / `export type X = {…}`, comments stripped. */
+function declBody(name: string): string {
+  const re = new RegExp(`^export (?:interface|type) ${name}(?:<[^>]*>)?\\s*=?\\s*\\{([\\s\\S]*?)^\\}`, 'm');
+  const m = re.exec(DTS);
+  if (m === null) throw new Error(`${name} is not declared in the installed wicked-crew-api-types index.d.ts`);
+  return m[1]!.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+}
+
+/** The property names a declaration lists (one per line, this package's style), sorted. */
+function declaredKeys(name: string): string[] {
+  return [...declBody(name).matchAll(/^\s+([A-Za-z_]\w*)\??:/gm)].map((m) => m[1]!).sort();
+}
+
+/** The `type: '<token>'` discriminant a frame declaration carries. */
+function declaredType(name: string): string {
+  const m = /^\s+type: '([A-Za-z]+)';/m.exec(declBody(name));
+  if (m === null) throw new Error(`${name} declares no \`type\` discriminant`);
+  return m[1]!;
+}
+
+/** The quoted tokens of a string-literal union (`export type X = | 'a' | 'b' | (string & {})`), sorted. */
+function unionTokens(name: string): string[] {
+  const re = new RegExp(`^export type ${name} =([\\s\\S]*?);`, 'm');
+  const m = re.exec(DTS);
+  if (m === null) throw new Error(`${name} is not declared in the installed wicked-crew-api-types index.d.ts`);
+  return [...m[1]!.matchAll(/'([^']+)'/g)].map((x) => x[1]!).sort();
+}
+
+type Frame = { type: string } & Record<string, unknown>;
+const ENVELOPE = new Set(['seq', 'ts']);
+const wireKeys = (frame: Record<string, unknown>): string[] => Object.keys(frame).filter((k) => !ENVELOPE.has(k)).sort();
+
+/** Every #431 frame the fixture ships, by the 0.33.0 declaration it must match. */
+const pinned: Record<string, ReadonlyArray<Frame>> = {
+  GateEvaluatedEvent: [GATE_DENY_RESTORED, GATE_DELIVER_PASS] satisfies Wire<GateEvaluatedEvent>[],
+  EvaluatorMutatedWorktreeEvent: [MUTATION_RESTORED] satisfies Wire<EvaluatorMutatedWorktreeEvent>[],
+  WorktreeRestoredEvent: [WORKTREE_RESTORED] satisfies Wire<WorktreeRestoredEvent>[],
+  DeliverLiftEvaluatedEvent: [LIFT_UNCHANGED, LIFT_LIFTED, LIFT_CONFLICT, LIFT_SKIPPED, LIFT_FAILED] satisfies Wire<DeliverLiftEvaluatedEvent>[],
+  RepoChecksEvaluatedEvent: [DELIVER_REVERIFY_PASS, DELIVER_REVERIFY_FAIL, DELIVER_REVERIFY_CHANGED_TREE] satisfies Wire<RepoChecksEvaluatedEvent>[],
+  StepFailedEvent: [STEP_FAILED_CONFLICT, STEP_FAILED_APPLY, STEP_FAILED_WRONG_HEAD, STEP_FAILED_REVERIFY, STEP_FAILED_CHANGED_TREE] satisfies Wire<StepFailedEvent>[],
+  RunBaseResolvedEvent: [RUN_BASE_LIFTED, RUN_BASE_AT_TIP, RUN_BASE_LOCAL_KEPT, RUN_BASE_NO_REMOTE, RUN_BASE_FETCH_FAILED] satisfies Wire<RunBaseResolvedEvent>[],
+  EvaluatorToolCallDeniedEvent: [TOOL_DENIED, TOOL_DENIED_KINDLESS] satisfies Wire<EvaluatorToolCallDeniedEvent>[],
+  AcpFallbackEvent: [READ_ONLY_REROUTE] satisfies Wire<AcpFallbackEvent>[],
+};
+
+describe('wire433 fixtures — the shapes wicked-crew-api-types 0.33.0 declares', () => {
+  it('the pin is exact (no range) and the installed package is the pinned one', () => {
+    const pkg = JSON.parse(readFileSync(fileURLToPath(new URL('package.json', PKG_ROOT)), 'utf8')) as {
+      devDependencies: Record<string, string>;
+    };
+    const installed = JSON.parse(
+      readFileSync(fileURLToPath(new URL('node_modules/wicked-crew-api-types/package.json', PKG_ROOT)), 'utf8'),
+    ) as { version: string };
+    const pin = pkg.devDependencies['wicked-crew-api-types'];
+    expect(pin).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(installed.version).toBe(pin);
+    // The #431 frames arrived in 0.33.0 — anything older cannot declare what the fixtures satisfy.
+    const [major, minor] = installed.version.split('.').map(Number) as [number, number, number];
+    expect(major > 0 || minor >= 33).toBe(true);
+  });
+
+  for (const [name, frames] of Object.entries(pinned)) {
+    it(`${name}: every frame carries exactly the declared keys, each present (null, never absent)`, () => {
+      const keys = declaredKeys(name);
+      expect(keys.length).toBeGreaterThan(3);
+      const token = declaredType(name);
+      for (const frame of frames) {
+        expect(frame.type).toBe(token);
+        expect(wireKeys(frame)).toEqual(keys);
+        expect(Object.values(frame).some((v) => v === undefined)).toBe(false);
+        expect(typeof frame['seq']).toBe('number');
+        expect(typeof frame['ts']).toBe('number');
+      }
+    });
+  }
+
+  it('nested records match their declarations: RepoCheckRun rows, UnitDenial, WorktreeChangedPath', () => {
+    const runKeys = declaredKeys('RepoCheckRun');
+    expect(runKeys).toContain('source');
+    for (const floor of pinned['RepoChecksEvaluatedEvent']!) {
+      for (const row of floor['checks'] as ReadonlyArray<Record<string, unknown>>) {
+        expect(Object.keys(row).sort()).toEqual(runKeys);
+        expect(Object.values(row).some((v) => v === undefined)).toBe(false);
+      }
+    }
+    expect(Object.keys(GATE_DENY_RESTORED.denial).sort()).toEqual(declaredKeys('UnitDenial'));
+    expect(unionTokens('UnitDenialSource')).toContain(GATE_DENY_RESTORED.denial.source);
+    const pathKeys = declaredKeys('WorktreeChangedPath');
+    for (const row of [...MUTATION_RESTORED.changed, ...WORKTREE_RESTORED.discarded]) {
+      expect(Object.keys(row).sort()).toEqual(pathKeys);
+    }
+  });
+
+  it('the unions declare every token the fixtures use — including the lift `failed` and the read-only reroute', () => {
+    const outcomes = unionTokens('DeliverLiftOutcome');
+    expect(outcomes).toEqual(['conflict', 'failed', 'lifted', 'skipped', 'unchanged']);
+    for (const lift of pinned['DeliverLiftEvaluatedEvent']!) expect(outcomes).toContain(lift['outcome']);
+    const kinds = unionTokens('AcpFallbackKind');
+    expect(kinds).toContain('read_only_requires_wrapped');
+    expect(kinds).toContain('governance_requires_wrapped');
+    expect(kinds).toContain(READ_ONLY_REROUTE.fallbackKind);
+    // `failureKind` is declared `string`; the engine's tokens are its `StepFailureKind` variants.
+    for (const failed of pinned['StepFailedEvent']!) {
+      expect(['workerError', 'environmentRefused', 'substanceRejected']).toContain(failed['failureKind']);
+    }
+  });
+
+  it('the nullabilities the surfaces lean on are the declared ones', () => {
+    const gate = declBody('GateEvaluatedEvent');
+    expect(gate).toMatch(/^\s+judgeCli: string \| null;/m);
+    expect(gate).toMatch(/^\s+judgeDistinct: boolean \| null;/m);
+    const mutation = declBody('EvaluatorMutatedWorktreeEvent');
+    expect(mutation).toMatch(/^\s+restored: boolean;/m);
+    expect(mutation).toMatch(/^\s+restoreError: string \| null;/m);
+    const restored = declBody('WorktreeRestoredEvent');
+    expect(restored).toMatch(/^\s+head: string \| null;/m);
+    expect(restored).toMatch(/^\s+discarded: WorktreeChangedPath\[\];/m);
+    expect(restored).toMatch(/^\s+suggestionRef: string \| null;/m);
+    const lift = declBody('DeliverLiftEvaluatedEvent');
+    for (const k of ['baseRef', 'baseBefore', 'baseAfter', 'treeBefore', 'treeAfter', 'note']) {
+      expect(lift).toMatch(new RegExp(`^\\s+${k}: string \\| null;`, 'm'));
+    }
+    expect(lift).toMatch(/^\s+conflicts: string\[\];/m);
+    const base = declBody('RunBaseResolvedEvent');
+    expect(base).toMatch(/^\s+baseRef: string \| null;/m);
+    expect(base).toMatch(/^\s+baseCommit: string;/m);
+    expect(base).not.toMatch(/^\s+ord\??:/m); // session-level: no ord
+    const denied = declBody('EvaluatorToolCallDeniedEvent');
+    expect(denied).toMatch(/^\s+kind: string \| null;/m);
+    expect(denied).toMatch(/^\s+path: string \| null;/m);
+    // `CoreEvent.kind` widened to `string | null` with this frame — why TOOL_DENIED_KINDLESS is a plain
+    // literal and not a cast.
+    expect(declBody('CoreEvent')).toMatch(/^\s+kind\?: string \| null;/m);
+    expect(declBody('StepFailedEvent')).toMatch(/^\s+failureKind: string;/m);
+    // The evidence union the gate card folds names all five frames.
+    const evidence = unionTokens('GateEvidenceEvent');
+    expect(evidence).toEqual([]); // a type union, not string literals — the members are checked below
+    const evidenceDecl = /^export type GateEvidenceEvent =([\s\S]*?);/m.exec(DTS)![1]!;
+    for (const member of [
+      'EvaluatorMutatedWorktreeEvent',
+      'RepoChecksEvaluatedEvent',
+      'WorktreeRestoredEvent',
+      'DeliverLiftEvaluatedEvent',
+      'EvaluatorToolCallDeniedEvent',
+    ]) {
+      expect(evidenceDecl).toContain(member);
+    }
+  });
+});


### PR DESCRIPTION
Studio consumer follow-through for wicked-core#431 (merged as wicked-core#433) and its wire, `wicked-crew-api-types` **0.33.0** (wicked-crew#527). Studio #250/#252 put the evaluator verdict on the gate card; this PR renders the four new stories the #431 engine tells on the same frames — who judged, what the engine put back, what the deliver lift did, where the run was based — each only when the daemon sends it. An older daemon changes nothing.

## What renders

| Surface | Wire (api-types 0.33.0) | Rendering |
|---|---|---|
| **Gate card** (`GateVerdict` / `gateVerdictModel`) | `gateEvaluated.judgeCli`, `judgeDistinct` | Header gains `· judge: <seat>` (`gate-verdict-judge-seat`, `data-judge-cli`, `data-judge-distinct`). `judgeDistinct: false` adds `gate-verdict-judge-same-seat`: *same seat as the creator — evaluator ≠ creator is not held on this verdict*. Absent fields ⇒ no seat claimed (the recorded pre-0.33.0 corpus still passes its "no seat" assertion). |
| **Denial card** | `evaluatorMutatedWorktree.restored` / `restoreError`, new `worktreeRestored {tree, head, discarded[], suggestionRef}` | `restored: true` ⇒ `gate-verdict-restored`: *the evaluator's edit was discarded and the creator's verified tree restored — discarded: M src/App.tsx (tree …) · the edit is kept at `refs/wicked/suggestions/<run>/<ord>/<attempt>` — read it back with* `git show <ref>` (a `<code>` with `user-select: all`, `gate-verdict-suggestion-hint`); `suggestionRef: null` ⇒ *not pinned*. `restored: false` ⇒ `gate-verdict-restore-failed` with `restoreError`; the denial prose (which then still carries `git read-tree …`) stands. **Approve → "Retry against the restored tree"**, Approve + steer → "Retry + steer", `data-retry-restored="true"` on the card — on the run page's gate card AND the landing inbox's card (`gate-inbox-card`), from one shared predicate `isRestoredRetry` keyed on the evidence frames (`outcome === 'fail'`, the deciding verdict is this unit's, `denial.source === 'worktree_guard'` — the engine's own guard for sending the restored-tree prompt — and `mutation.restored === true`), never on the prompt. The `git show` hint keeps its `user-select: all` `<code>` and gains a real, keyboard-reachable **copy** button (`copy-command`; accessible name `copy git show <ref>`; clipboard write → transient "copied", "copy failed" where the API is unavailable), on the gate card and the timeline's restore detail. |
| **Delivery card** (`RunDelivery`) + **deliver gate** (`SteeringGate` on the deliver ord) + **timeline detail** | new `deliverLiftEvaluated {outcome, baseRef, baseBefore, baseAfter, treeBefore, treeAfter, conflicts[], note}`, the deliver ord's `repoChecksEvaluated`, the deliver unit's `stepFailed.detail` | One shared `DeliverLift` card (`deliver-lift[data-outcome]`) over one pure fold (`deliverLiftModel.deliverLift(events, deliverOrd)`, newest attempt — a `unitDispatched` for the ord starts a fresh story). `unchanged` / `lifted` (base + tree before → after; the re-verify per check as `deliver-lift-floor` / `deliver-lift-check`, incl. `source: "package-lock.json (forced: lockfile drift)"`) / `conflict` (`deliver-lift-conflicts`, *nothing was rebased and nothing was pushed*, `deliver-lift-remedy`) / `skipped` / `failed` (the engine's `note`). The refusal renders as the wire carries it in `deliver-lift-failure` (`stepFailed.detail` is the engine's 150/250 head+tail excerpt; the `[… N chars elided …]` marker renders dimmed as `deliver-lift-failure-elided`; backticked refs as `<code>`) — omitted when the surface already shows it: the deliver gate's prompt (the engine's triage-escalate prompt quotes the 450/750 excerpt after `Failure output:`) or the rejected unit's framed `denial_reason` (`Worker FAILED on unit N …`), matched segment-wise by `textCarriesFailure` so an elided detail still dedupes against the wider text — the refusal reads ONCE on every surface. A non-passing check exposes its `RepoCheckRun.stderrTail` / `stdoutTail` (declared since 0.31.0) as a collapsed `<details>` (`deliver-lift-check-tail`; `gate-verdict-check-tail` on the gate card's floor for parity) — monospace, wraps at phone width, capped with its own scroll, empty streams omitted. |
| **Addendum** (#433 final review) | a deliver unit refused for a wrong HEAD ref emits `stepFailed` (`deliver: the worktree's HEAD is attached to …`) with **no** preceding `deliverLiftEvaluated` | `data-outcome="refused"`, *Deliver lift — refused before the lift*, the `deliver:` text on its own; a `repoChecksEvaluated` attaches only to a lift story already in hand (the engine emits the lift frame before any deliver re-verify), so a verify floor is never mistaken for a re-verify. `passed: false` over all-green rows is explained as *the checks CHANGED the worktree while running* (`deliver-lift-changed-tree`). |
| **Run header / timeline** | new `runBaseResolved {baseRef, baseCommit, localHead, behind, fetched, lifted, note}` | `WhatWhere` gains a `base` row (`run-base`): *origin/main @ f57069d · 5 behind · lifted to the tip* (note on hover; *local HEAD kept* / *no remote default branch resolved* / *fetch failed — cached refs* per posture). `RunTimeline` gains a `based on` head row + `run-base-detail`, and rows/details for `worktreeRestored` (`↺ restored`), `deliverLiftEvaluated` (`lift`, detail = the shared card) and `evaluatorToolCallDenied` (`✗ write refused`). |
| **Narrator / feed** | `evaluatorToolCallDenied`, `acpFallback.fallbackKind: 'read_only_requires_wrapped'`, plus the frames above | *Refused a write by claude during verify — edit on src/App.tsx (a read-only phase may not edit)* (fail); *pi moved to the wrapped carrier for its read-only turn — the write lock is an argv fact there, not a failure* (info; every other `acpFallback` kind stays silent as before); *Based on origin/main @ … · 5 behind · lifted to the tip*; *Restored the creator's tree for verify — pi's edit (1 path) was discarded, kept at refs/…*; *Deliver lift: CONFLICT in testid-inventory.json — nothing rebased, nothing pushed* (and the unchanged / lifted / skipped / failed lines). |

Old prompt-text matches re-checked: the only match on the mutation-gate prompt was `SteeringGate`'s `includes('not pass')` (the coverage-fail classification) — both the pre-0.33.0 *"confirm to retry the phase"* and the new *"… Approve to retry the phase against the restored tree …"* contain "NOT PASS", so it holds; the Approve relabel deliberately does not read the prompt.

Copy rule kept: nothing in the lift card says "pushed" or "PR" — the lift precedes the push; the PR claim stays with the Delivery card's url-gated arms (#122/#125).

## Wire pin (the gate)

`wicked-crew-api-types@0.33.0` is on npm (published with wicked-crew#527). This PR opened as a **draft** against the then-installed 0.32.0 types (every new field is read off `CoreEvent`'s `[k: string]: unknown` index signature and runtime-narrowed, exactly as the F-036/F-039 consumer does, so it typechecks against both). The second commit pins the devDependency **exactly `0.33.0` from the registry** (repo convention; the lockfile resolves it from registry.npmjs.org — the only lockfile entry that moves) and makes the fixtures the declared shapes: every #431 frame in `tests/fixtures/wire433.ts` is declared `satisfies` its 0.33.0 named type (`GateEvaluatedEvent`, `EvaluatorMutatedWorktreeEvent`, `WorktreeRestoredEvent`, `DeliverLiftEvaluatedEvent`, `RepoChecksEvaluatedEvent`, `StepFailedEvent`, `RunBaseResolvedEvent`, `EvaluatorToolCallDeniedEvent`, `AcpFallbackEvent`), and the new `tests/wire433.shapes.test.ts` re-derives the fixture-vs-declaration diff at run time from the *installed* `index.d.ts` — exact key sets and discriminants per frame, the nested `RepoCheckRun` / `UnitDenial` / `WorktreeChangedPath` rows, the `DeliverLiftOutcome` (incl. `failed`) and `AcpFallbackKind` (incl. `read_only_requires_wrapped`) tokens, the nullabilities the surfaces read, `CoreEvent.kind: string | null`, and that the pin is exact and is what is installed. Diffing the published declarations against what the draft assumed surfaced two gaps, both closed in that commit: the `stepFailed` fixtures (TS and the e2e rig) lacked the declared `failureKind` (now `"workerError"` — the token the engine's unrecognized-failure → triage route stamps on a `deliver:` refusal), and the deliberately malformed `judgeDistinct: 'yes'` probe now says it is a bag on purpose (0.33.0 types the field `boolean | null` — the bump's one `tsc` ripple). No rendering code changed for the pin; the two `src/` comments that quoted the pre-0.33.0 mutation-gate prompt drop the literal.

## Tests

- `tests/fixtures/wire433.ts` — synthetic frames in the wire's exact `event_to_json` spelling (camelCase, every key present, `null` never absent), mirroring wicked-crew#527's `wire-contract.test.ts` literals and wicked-core's `to_json` tests; composes with the recorded Phase-3 corpus (`gateEvidence.ts`). Denial prose / refusal texts are the engine's own format strings filled (`worktree_guard::denial_reason`, `deliver_lift.rs`, `actor.rs`). Privacy-scrubbed by construction (no operator text, no host paths, synthetic hex).
- `tests/gateVerdictModel.wire433.test.ts` (model: judge, restore, `deliverLift` per outcome + attempt reset + scoping + the addendum, `runBase` + `runBaseLine`; `isRestoredRetry` incl. the dual-deny case, `textCarriesFailure` against the engine prompt / framed reasons / an elided detail, `boundedExcerpt` vs the engine's semantics, `floorOf` tails), `tests/SteeringGate.wire433.test.tsx` (gate card: seat, same-seat warning, restored / unpinned / restore-failed / legacy fold, Approve relabel incl. "frames not prompt", deliver-lift on a retry gate and the refused-before-the-lift gate, none on the pre-run deliver gate), `tests/RunDelivery.lift.test.tsx` (every outcome on the rail body, dedupe against `denial_reason`, failed re-verify, changed-tree proof, silence without frames), `tests/narrator.wire433.test.ts`, `tests/RunTimeline.wire433.test.tsx`, `tests/WhatWhere.base.test.tsx`. One existing expectation extended (`gateVerdictModel.test.ts` G5: the recorded frame reads `restored: null, restoreError: null`, never `false`).
- `e2e/wire433_test.py` on the loopback fixture (`uxfix_fixture.py`, new switch `wire433`: r-api's gate becomes the restored-tree denial with the NEW prompt and a named judge; r-auth gains a rejected `deliver` unit, `runBaseResolved` and the LIFT-CONFLICT chronology) — a real Chromium drives the gate card, the run head's base row, the feed lines, the timeline rows + lift detail and the rail's Delivery body. 7/7 steps green locally; screenshots under `e2e/shots/wire433/` (gitignored).
- `npm run lint` · `npm run typecheck` · `npm test` (267 files / 2932 tests) · `npm run build` — all green locally; `npm run manifest:testids` regenerated (new static testids: `gate-verdict-judge-seat`, `gate-verdict-judge-same-seat`, `gate-verdict-restored`, `gate-verdict-suggestion-hint`, `gate-verdict-restore-failed`, `deliver-lift*`, `run-base`, `run-base-detail`, `worktree-restored-detail`, `tool-call-denied-detail`).

## Independent review (REVISE @ f0bb8b0 → fixed in the third commit)

- **F-255-01** — the landing inbox's gate card kept "Approve" under the restored-tree block: relabelled from the same shared predicate as the run page (`isRestoredRetry`), `data-retry-restored` on `gate-inbox-card`; tests for the relabel and for a PASS gate staying "Approve".
- **F-255-02** — the deliver retry gate said the refusal twice on a real daemon (the engine's triage-escalate prompt quotes it): the gate card omits the lift block's copy when the prompt carries the detail (`textCarriesFailure`, segment-wise so an elided detail matches the wider excerpt); the fixture prompt is the engine's format string (`deliverRetryPrompt`), and the card is asserted to say it ONCE (a count) on the LIFT-CONFLICT, wrong-HEAD and elided re-verify gates; the daemon-restart fallback prompt still renders the block.
- **F-255-03** — `stderrTail` / `stdoutTail` were rendered nowhere (a studio omission, not a wire gap): collapsed `<details>` per non-passing check on the deliver lift and the gate card's floor.
- **F-255-04** — the fixtures now carry what the wire carries: `boundedExcerpt` mirrors `actor.rs` `bounded_excerpt`; `stepFailed.detail` is the 150/250 excerpt (the re-verify and changed-tree refusals elide — the lockfile-drift sentence is in the elided middle, and the tests say so), the prompt quotes the 450/750 excerpt, `denial_reason` is framed (`deliverRejectedReason`, `deliverWorkerFailedReason`), the e2e rig's r-auth unit uses the framed reason.
- **F-255-05** — the relabel predicate includes the engine's `denial.source === 'worktree_guard'` guard (a dual-deny another layer wins keeps "Approve", as the engine keeps the legacy prompt).
- **F-255-06** — the `git show` hint is keyboard-reachable: a real `<button>` with an accessible name, clipboard write, transient "copied".
- Not taken in this revision (LOW/INFO follow-ups): F-255-07 (timeline `stepFailed` row meta prefers a clipped `deliver:` detail), F-255-08 (name the creator seat from `assigned_cli`), F-255-09 (state `baseAfter` as the base the deliver script refuses past), F-255-10 (pre-existing "before unit #N" subtitle on a post-verdict gate).

## Wire gaps (wished-for, not in 0.33.0 — rendered around, not invented)

- `acpFallback` carries no `ord`: the *read_only_requires_wrapped* feed line can name the seat but not the phase it was rerouted for.
- `gateEvaluated` names the judge (`judgeCli`) but not the creator seat on the same frame; the creator IS on the wire (`unitDistributed.cli` / the unit's `assigned_cli`), so naming it in the same-seat warning is a studio follow-up, not a wire gap — a `creatorCli` on `gateEvaluated` would make it a one-field read.
- The deliver unit's `stepFailed` has no structured refusal kind (lift-conflict / apply-failed / wrong-head / reverify-failed / changed-tree): the card keys "refused before the lift" on the absence of a lift frame and renders the prose verbatim; crew's triage regexes are the only classifier today.
- ~~`deliverLiftEvaluated` does not echo the verified base~~ — not a gap (independent review): on `unchanged` / `lifted` the engine hands the deliver script `baseAfter` as the verified base (`deliver_lift.rs`), so stating *the deliver script refuses to rebase past <baseAfter>* is a studio follow-up.
- `awaitingHuman` for the mutation gate has no structured gate kind; the Approve relabel keys on the evidence frames (fine, and prompt-independent) — a `gateKind` would make it a one-field read.
- `AgentSession.verified_tree` is a store node, not on the run DTO: the Delivery card cannot show "verified tree <id>" beside the tree that shipped.

No studio version bump (the release agent cuts 0.5.6). Merge protocol: wait for CI + the bot window; do not merge from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


