### PR TITLE
feat(skills): badge per portability reason and split the claude-only KPI (api-types 0.34.0) (F-079)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,11 @@ npm publish dates. Every version listed here exists on
   to the 0.34.0 block (picking up the 0.29.0 `installer-copy` source kind and the `skills.source` /
   `skills.manifest` diagnostics findings the 0.27.0 mirror lagged). The Reach KPI group is as wide
   as the two-tile groups so the context line never ellipsizes, the badge's ink is `--ink-high` on the
-  amber fill so it reads in both themes, and the page header + verbs wrap at phone width.
+  amber fill so it reads in both themes, and the page header + verbs wrap at phone width. Review
+  follow-through: a `non-portable` analyze/publish finding wears its `portabilityReason` as a chip
+  (hover = the reason's one clause), and a `portability` verdict that disagrees with `portable` is
+  named — `data-contradiction` on the row and badge, a hint line in the drawer — never swallowed and
+  never a different badge (`portable` stays the admission key).
 
 ## [0.5.5] — 2026-09-11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,26 @@ npm publish dates. Every version listed here exists on
     the 450/750 excerpt, `denial_reason` framed as `Worker FAILED on unit N …`); the loopback rig
     `e2e/wire433_test.py` (fixture switch `wire433`) drives the three surfaces in a real browser.
 
+### Changed
+- **Skills page: a badge per KIND of portability reason, and the claude-only KPI split** (#256,
+  F-079 — pins `wicked-crew-api-types` 0.34.0, whose additive `SkillEntry.portability`
+  `{portable, reasons[], evidence?[]}` is the publisher's per-reason verdict, crew#531). The one
+  `claude-only` badge lumped "the author used a Claude-only path" together with "this skill needs
+  the Claude harness" and hid the fix. Now any AUTHORING reason (`plugin-root`, `skill-dir-var`,
+  `cwd-script`, `relative-link`, `cross-skill-path`) renders **not portable**
+  (`skills-not-portable-badge`; the hover title lists the reasons and the first `file:line`
+  anchor, and is the badge's accessible name) while `requires-harness:claude` alone renders
+  **needs Claude harness** (`skills-needs-claude-badge`; title = the reason). The wrapper keeps
+  `skills-claude-only-badge` for one release so existing selectors resolve; a daemon that predates
+  the field (no `portability`) falls back to `portable` alone — the generic **not portable** badge
+  with the previous sentence, never a fabricated reason. The Portable tile's context reads
+  `N not portable · M need Claude harness` (the value stays the portable count); the chips
+  `not-portable` + `needs-claude` replace `claude-only`; the drawer gains a **Portability** line —
+  every reason with one clause of "why", and every `file:line` anchor as monospace text that wraps
+  at phone width. `skillCounts` gains `notPortable` / `needsClaude` (`portable + notPortable +
+  needsClaude === total`). The wire mirror (`src/api/skills-wire.ts`) and its parity fixture move
+  to the 0.34.0 block (picking up the 0.29.0 `installer-copy` source kind and the `skills.source` /
+  `skills.manifest` diagnostics findings the 0.27.0 mirror lagged).
 
 ## [0.5.5] — 2026-09-11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,9 @@ npm publish dates. Every version listed here exists on
   at phone width. `skillCounts` gains `notPortable` / `needsClaude` (`portable + notPortable +
   needsClaude === total`). The wire mirror (`src/api/skills-wire.ts`) and its parity fixture move
   to the 0.34.0 block (picking up the 0.29.0 `installer-copy` source kind and the `skills.source` /
-  `skills.manifest` diagnostics findings the 0.27.0 mirror lagged).
+  `skills.manifest` diagnostics findings the 0.27.0 mirror lagged). The Reach KPI group is as wide
+  as the two-tile groups so the context line never ellipsizes, the badge's ink is `--ink-high` on the
+  amber fill so it reads in both themes, and the page header + verbs wrap at phone width.
 
 ## [0.5.5] — 2026-09-11
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "typescript-eslint": "^8.63.0",
         "vite": "^6.4.3",
         "vitest": "^3.2.6",
-        "wicked-crew-api-types": "0.33.0"
+        "wicked-crew-api-types": "0.34.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -7146,9 +7146,9 @@
       }
     },
     "node_modules/wicked-crew-api-types": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/wicked-crew-api-types/-/wicked-crew-api-types-0.33.0.tgz",
-      "integrity": "sha512-WdXjBkdAWo9jUrnOoPrLAKlW5KOl9MhKlhIbT2HVxyzLuqb24o32RRZEQcy64m5KjBRSceTk97+gflhBcQKFhg==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/wicked-crew-api-types/-/wicked-crew-api-types-0.34.0.tgz",
+      "integrity": "sha512-SmdNoyj26RYAjCSL3f7lu5aBWG9EMb77+7OL+3Vj0ylpk9wGSo4ZKXvXgBug9KBqQyEVP359mPlRw4SKc+RHdw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "typescript-eslint": "^8.63.0",
     "vite": "^6.4.3",
     "vitest": "^3.2.6",
-    "wicked-crew-api-types": "0.33.0"
+    "wicked-crew-api-types": "0.34.0"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/src/api/skills-wire.ts
+++ b/src/api/skills-wire.ts
@@ -1,22 +1,24 @@
 /**
- * MIRROR of wicked-crew-api-types 0.27.0 skills block (crew#480) — replace with imports from the
+ * MIRROR of wicked-crew-api-types 0.34.0 skills block (crew#531) — replace with imports from the
  * published package at release.
  *
- * Studio's installed `wicked-crew-api-types` is 0.25.0 (the newest on npm); the skills contract
- * ships in 0.27.0, which crew#480 mints but has not published. Until it lands, this module IS the
- * contract: two regions copied VERBATIM from the crew worktree's `packages/crew-api-types/index.d.ts`
- * (crew#480 @ 4cae105) — the skills block (`:1322-1685`) and the `diagnostics.skills` block
- * (`:3262-3302`). Nothing in between the `>>> VERBATIM` / `<<< VERBATIM` markers is studio's
- * wording, and nothing may be edited here: `tests/skillsWire.test.ts` pins each region
- * byte-for-byte against the vendored fixture `tests/fixtures/api-types-0.27.0-skills.d.ts`
- * (itself a byte copy of those line ranges), so any drift — a hand edit here, or a re-vendored
- * fixture from a re-minted contract — fails the suite until both sides agree again.
+ * Studio pins `wicked-crew-api-types` exactly; the skills contract lives in the package's skills
+ * block and its `diagnostics.skills` block. Until the release swap this module IS the contract:
+ * two regions copied VERBATIM from the package's `index.d.ts` between the `>>> VERBATIM` /
+ * `<<< VERBATIM` markers. Nothing inside a marked region is studio's wording, and nothing may be
+ * edited there: `tests/skillsWire.test.ts` pins each region byte-for-byte against the vendored
+ * fixture `tests/fixtures/api-types-0.34.0-skills.d.ts`, so any drift — a hand edit here, or a
+ * re-vendored fixture from a re-minted contract — fails the suite until both sides agree again.
  *
- * THE RELEASE SWAP: when 0.27.0 (or its re-minted successor — #475 and #480 both mint 0.27.0,
- * whichever lands second re-mints) publishes, bump the `wicked-crew-api-types` devDependency,
- * replace the body of this file with `export type { … } from 'wicked-crew-api-types';` for every
- * name below, delete the fixture + pin test, and nothing else in studio moves: `./skills.ts` and
- * every component import these names from here.
+ * 0.34.0 (F-079, crew#531) is ADDITIVE over the 0.32.0 block studio installs: `SkillPortabilityReason`
+ * + `SkillPortability` and the optional `SkillEntry.portability` — the publisher's per-reason
+ * verdict (five authoring reasons an author can fix, plus `requires-harness:claude`) with
+ * `<file>:<line>` evidence. `portable` stays the admission key core reads; an older daemon simply
+ * omits the field and every reader falls back to `portable` alone.
+ *
+ * THE RELEASE SWAP: replace the body of this file with `export type { … } from
+ * 'wicked-crew-api-types';` for every name below, delete the fixture + pin test, and nothing else
+ * in studio moves: `./skills.ts` and every component import these names from here.
  *
  * Note the three wire rules the block spells out and every studio caller leans on: revisions are
  * NUMBERS (`revision` / `expectedRevision`), every mutation answers a 2xx `{verdict, findings,
@@ -24,8 +26,13 @@
  * is EXCLUSIVELY a stale `expectedRevision`.
  */
 
-// >>> VERBATIM wicked-crew-api-types@0.27.0 index.d.ts:1322-1685 (crew#480 @ 4cae105) — the skills block
-// ── Skills — the daemon-owned garden plugin root, published as immutable snapshots (api-types 0.27.0) ──
+// >>> VERBATIM wicked-crew-api-types@0.34.0 index.d.ts (crew#531; PROVISIONAL until 0.34.0 publishes: the 0.32.0 block at :1502-1874 + the additive SkillPortability shape) — the skills block
+// ── Skills — the daemon-owned garden plugin root, published as immutable snapshots (api-types 0.28.0) ──
+//
+// api-types 0.29.0 (design amendment v3.6, crew #490): the installer-managed copy
+// `<config dir>/plugins/wicked-garden` is a LAST-resort seed source — `SkillSourceKind` gains
+// `installer-copy`, and `DiagnosticsSkillsFinding.kind` gains the persistent `skills.source` warning
+// and the fail-closed `skills.manifest` error.
 //
 // Skills are files (skills keystone, design v3 + amendments v3.1/v3.2). The daemon owns ONE
 // effective `wicked-garden`-shaped plugin root — `<state home>/skills/effective/`, the dependency
@@ -60,10 +67,14 @@ export type SkillKind = 'router' | 'fork-worker' | 'module';
  *  it while the operator's edits were kept). */
 export type SkillProvenance = 'shipped' | 'override' | 'user-added';
 
-/** Where a baseline was captured from. `claude-plugin-cache` covers the marketplace cache AND the
- *  hand-installed `plugins/wicked-garden` copy (both are "the installed plugin"); `checkout` is a
- *  git working tree; `directory` any other explicit plugin-shaped directory. */
-export type SkillSourceKind = 'claude-plugin-cache' | 'checkout' | 'directory';
+/** Where a baseline was captured from. `claude-plugin-cache` is the marketplace cache
+ *  (`<config dir>/plugins/cache/wicked-garden/wicked-garden/<version>` — the plugin Claude Code
+ *  runs); `installer-copy` is the installer-managed `<config dir>/plugins/wicked-garden` copy
+ *  (`npx wicked-installer install wicked-garden`), accepted only as the LAST resort when no cache
+ *  exists (design v3.6, api-types 0.29.0) and flagged by the `skills.source` diagnostics finding
+ *  while it is the current baseline; `checkout` is a git working tree; `directory` any other
+ *  explicit plugin-shaped directory. */
+export type SkillSourceKind = 'claude-plugin-cache' | 'installer-copy' | 'checkout' | 'directory';
 
 /** The per-baseline `uv sync` state (`<baseline>/.venv`, provisioned once per content hash — the
  *  publish that needs it AWAITS it — and shared read-only by every snapshot that links it):
@@ -88,6 +99,27 @@ export interface SkillBaselineRecord {
   venv: SkillVenvState;
 }
 
+/** WHY a skill is not portable — the publisher's per-reason verdict (api-types 0.34.0, F-079). The
+ *  five AUTHORING reasons are defects in the skill's text an author can fix without touching the
+ *  harness: `plugin-root` = resolves `${CLAUDE_PLUGIN_ROOT}`; `skill-dir-var` = resolves
+ *  `${CLAUDE_SKILL_DIR}`; `cwd-script` = invokes a script relative to the cwd (`python3 scripts/x.py`,
+ *  `./scripts/x`); `relative-link` = a `../` link to a sibling; `cross-skill-path` = a path into
+ *  another skill's directory. `requires-harness:claude` is different in kind: the skill's MECHANICS
+ *  need the Claude harness (hooks, the plugin catalogs) — nothing to rewrite. */
+export type SkillPortabilityReason =
+  | 'plugin-root' | 'skill-dir-var' | 'cwd-script' | 'relative-link' | 'cross-skill-path'
+  | 'requires-harness:claude';
+
+/** The publisher's portability verdict for one skill (api-types 0.34.0). */
+export interface SkillPortability {
+  /** Same value as SkillEntry.portable — reasons.length === 0. */
+  portable: boolean;
+  /** Sorted, unique. Empty when portable. */
+  reasons: SkillPortabilityReason[];
+  /** Up to N anchors, `<plugin-relative file>:<line>`, for the drawer/hover. */
+  evidence?: string[];
+}
+
 export interface SkillEntry {
   /** Plugin-relative directory, nested layout preserved (`skills/engineering/frontend`). Never
    *  renamed — sibling `../` links depend on it. */
@@ -102,6 +134,9 @@ export interface SkillEntry {
    *  excluded from the snapshot's `views/copilot/` and from the per-launch skill lists core builds
    *  for the other CLIs. `portable` is the admission key for every non-Claude view (design v3.2). */
   portable: boolean;
+  /** WHY `portable` is false, per reason with `file:line` evidence (api-types 0.34.0, F-079).
+   *  Absent from a daemon that predates the field — readers fall back to `portable` alone. */
+  portability?: SkillPortability;
   /** Manifest state, orthogonal to content: a disabled skill's files stay in `effective/` and are
    *  excluded from the next published snapshot. Reset never flips it. */
   enabled: boolean;
@@ -118,7 +153,7 @@ export interface SkillEntry {
    *  name collision (upstream ships this name at another dir than the operator's skill); `null`
    *  otherwise. `GET /skills/:name/files/*path?side=baseline` reads THIS directory for such a skill,
    *  so the two sides of the collision are comparable — the answer's `path` names the file actually
-   *  read (api-types 0.27.0). Re-derived by every refresh. */
+   *  read (api-types 0.28.0). Re-derived by every refresh. */
   upstreamDir: string | null;
 }
 
@@ -143,7 +178,7 @@ export interface SkillPublishedRecord {
   at: string;
   /** sha256 of the exact `snapshot.json` bytes publish wrote. `snapshot.json` is excluded from the
    *  content hash, so the crew-owned manifest AUTHENTICATES it: `current` verifies only the
-   *  generation this record names, with metadata hashing to this value (api-types 0.27.0). */
+   *  generation this record names, with metadata hashing to this value (api-types 0.28.0). */
   snapshotHash: string;
 }
 
@@ -228,7 +263,7 @@ export type SkillFindingKind =
    *  the snapshot does not carry it — a file the bundle omits, or a skill that is disabled) is a
    *  `warning`: a content bug the skill's author owns, published as found — a publish with only
    *  warnings answers `verdict: 'warnings'` with the findings AND a written snapshot (api-types
-   *  0.27.0). */
+   *  0.28.0). */
   | 'unresolved-ref'
   /** A path the store refuses BY NAME rather than reads through: a shape that could leave its root
    *  (`..`, an absolute piece), a component that crosses a symlink, or — under `effective/`, where
@@ -245,24 +280,24 @@ export type SkillFindingKind =
   | 'empty-snapshot'
   /** `.claude-plugin/plugin.json`, `archetypes.json` or `components.json` is absent from `effective/`
    *  — the plugin manifest + the runtime catalogs are REQUIRED snapshot members (blocking at
-   *  publish; api-types 0.27.0). */
+   *  publish; api-types 0.28.0). */
   | 'missing-plugin-manifest'
   /** The plugin manifest or a runtime catalog is present but not what its reader expects — does
    *  not parse as JSON, is not a JSON object, or `archetypes.json` lacks its `archetypes`
-   *  collection (blocking at publish; api-types 0.27.0). A manifest without `name` is
+   *  collection (blocking at publish; api-types 0.28.0). A manifest without `name` is
    *  `name-mismatch`. */
   | 'catalog-invalid'
   /** The baseline's shared read-only Python env could not be provisioned (uv missing, `uv sync`
    *  failed, or the env could not be locked) while the bundle carries a `pyproject.toml` — the env
    *  is REQUIRED, so the publish is blocked and nothing (the provisioning state included) is
-   *  persisted (api-types 0.27.0). */
+   *  persisted (api-types 0.28.0). */
   | 'venv-failed'
   /** A publish was refused because one is already running (one at a time) — nothing was written, so
    *  it is a 2xx `blocked` envelope, not a 409 (409 is only a stale `expectedRevision`; api-types
-   *  0.27.0). Re-read `GET /skills` and retry against the revision it answers. */
+   *  0.28.0). Re-read `GET /skills` and retry against the revision it answers. */
   | 'publish-in-flight'
   /** A publish was aborted because the skills root changed under it — nothing was written to either
-   *  root; a 2xx `blocked` envelope (api-types 0.27.0). Re-read `GET /skills` and retry. */
+   *  root; a 2xx `blocked` envelope (api-types 0.28.0). Re-read `GET /skills` and retry. */
   | 'root-changed'
   /** A path outside the bundle closure — the ONE allowlist of what the seed copies, what the support
    *  API may address, and what a snapshot may carry: the five runtime catalogs under `.claude-plugin`
@@ -272,7 +307,7 @@ export type SkillFindingKind =
    *  directories and any `wg-`-prefixed dev tooling, plus `pyproject.toml` and `uv.lock`. A support
    *  add/PUT there is a 2xx `blocked` envelope (nothing written); a file found there under
    *  `effective/` at publish/analyze (a direct filesystem edit) is a BLOCKING finding naming the path
-   *  — a snapshot never ships it (api-types 0.27.0). */
+   *  — a snapshot never ships it (api-types 0.28.0). */
   | 'outside-closure'
   /** A content-addressed `baseline/<hash>` whose tree does not hash to its name (a bundle file
    *  modified, planted or removed, or a symlink inside), or a baseline file whose bytes do not match
@@ -280,7 +315,7 @@ export type SkillFindingKind =
    *  refuses to reuse it (2xx `blocked`, nothing copied), reset refuses to restore from it (nothing
    *  written), publish/analyze report it blocking (before AND after the env was provisioned in it).
    *  Read-only mode bits on the baseline are a guard, never the integrity boundary — the hash is
-   *  (api-types 0.27.0). */
+   *  (api-types 0.28.0). */
   | 'baseline-corrupt';
 
 export type SkillFindingSeverity = 'warning' | 'blocking';
@@ -356,7 +391,7 @@ export interface SkillRefreshResult extends SkillAnalyzeResult {
 /** The 409 body of a `/skills` mutation whose `expectedRevision` is stale — a CAS conflict, the
  *  ONLY thing that answers 409. A publish refused because another is in flight, or aborted because
  *  the skills root changed under it, wrote nothing and instead answers a 2xx `blocked` findings
- *  envelope (`publish-in-flight` / `root-changed`; api-types 0.27.0), never a 409. */
+ *  envelope (`publish-in-flight` / `root-changed`; api-types 0.28.0), never a 409. */
 export interface SkillRevisionConflict {
   error: string;
   /** The current revision — re-read `GET /skills` (or use this) and retry. */
@@ -391,8 +426,8 @@ export interface ReplaceSkillBody {
 }
 // <<< VERBATIM
 
-// >>> VERBATIM wicked-crew-api-types@0.27.0 index.d.ts:3262-3302 (crew#480 @ 4cae105) — the diagnostics skills block
-/** The skills seam's state as `GET /diagnostics` reports it (skills keystone, api-types 0.27.0). */
+// >>> VERBATIM wicked-crew-api-types@0.34.0 index.d.ts (crew#531; PROVISIONAL until 0.34.0 publishes: the 0.32.0 block at :3844-3893) — the diagnostics skills block
+/** The skills seam's state as `GET /diagnostics` reports it (skills keystone, api-types 0.28.0). */
 export type DiagnosticsSkillsState = 'published' | 'fallback' | 'blocked' | 'config-error' | 'disabled';
 
 /** One finding the skills degradation ladder produced (design v3 §3). */
@@ -402,8 +437,17 @@ export interface DiagnosticsSkillsFinding {
    *  blocked (engine input points at a non-existent refusal path — launches fail loudly until the
    *  catalog is fixed); `skills.config` = the configured root is corrupt/unusable (same refusal;
    *  `error`), or — as a `warning` on the `published` state — the root lies OUTSIDE the daemon
-   *  state home, so core's fence cross-check (`WICKED_CREW_STATE_HOME`) refuses every launch. */
-  kind: 'skills.fallback' | 'skills.blocked' | 'skills.config';
+   *  state home, so core's fence cross-check (`WICKED_CREW_STATE_HOME`) refuses every launch;
+   *  `skills.source` (`warning`, api-types 0.29.0, design v3.6) = the CURRENT baseline was seeded
+   *  from the installer-managed copy (`SkillSourceKind` `installer-copy`) — the daemon works, but
+   *  that copy receives no marketplace updates until the plugin is registered with Claude Code; it
+   *  persists (alongside the ladder's own finding, if any) until a refresh from the marketplace
+   *  cache re-records the baseline's provenance (byte-identical or not); `skills.manifest`
+   *  (`error`, api-types 0.29.0) = `manifest.json` could not be read when diagnostics were taken
+   *  (corrupt, unreadable, or the root no longer the one the store bound) — reported as
+   *  `config-error` with the cause instead of the stale boot outcome; the exported engine input is
+   *  unchanged until the daemon restarts. */
+  kind: 'skills.fallback' | 'skills.blocked' | 'skills.config' | 'skills.source' | 'skills.manifest';
   severity: 'warning' | 'error';
   message: string;
 }

--- a/src/api/skills-wire.ts
+++ b/src/api/skills-wire.ts
@@ -10,7 +10,7 @@
  * fixture `tests/fixtures/api-types-0.34.0-skills.d.ts`, so any drift — a hand edit here, or a
  * re-vendored fixture from a re-minted contract — fails the suite until both sides agree again.
  *
- * 0.34.0 (F-079, crew#531) is ADDITIVE over the 0.32.0 block studio installs: `SkillPortabilityReason`
+ * 0.34.0 (F-079, crew#531, published by PR #532) is ADDITIVE over the 0.33.0 block: `SkillPortabilityReason`
  * + `SkillPortability` and the optional `SkillEntry.portability` — the publisher's per-reason
  * verdict (five authoring reasons an author can fix, plus `requires-harness:claude`) with
  * `<file>:<line>` evidence. `portable` stays the admission key core reads; an older daemon simply
@@ -26,7 +26,7 @@
  * is EXCLUSIVELY a stale `expectedRevision`.
  */
 
-// >>> VERBATIM wicked-crew-api-types@0.34.0 index.d.ts (crew#531; PROVISIONAL until 0.34.0 publishes: the 0.32.0 block at :1502-1874 + the additive SkillPortability shape) — the skills block
+// >>> VERBATIM wicked-crew-api-types@0.34.0 index.d.ts:1716-2134 (crew#531 via PR #532) — the skills block
 // ── Skills — the daemon-owned garden plugin root, published as immutable snapshots (api-types 0.28.0) ──
 //
 // api-types 0.29.0 (design amendment v3.6, crew #490): the installer-managed copy
@@ -99,24 +99,37 @@ export interface SkillBaselineRecord {
   venv: SkillVenvState;
 }
 
-/** WHY a skill is not portable — the publisher's per-reason verdict (api-types 0.34.0, F-079). The
- *  five AUTHORING reasons are defects in the skill's text an author can fix without touching the
- *  harness: `plugin-root` = resolves `${CLAUDE_PLUGIN_ROOT}`; `skill-dir-var` = resolves
- *  `${CLAUDE_SKILL_DIR}`; `cwd-script` = invokes a script relative to the cwd (`python3 scripts/x.py`,
- *  `./scripts/x`); `relative-link` = a `../` link to a sibling; `cross-skill-path` = a path into
- *  another skill's directory. `requires-harness:claude` is different in kind: the skill's MECHANICS
- *  need the Claude harness (hooks, the plugin catalogs) — nothing to rewrite. */
+/**
+ * Why a skill's text cannot be followed on a non-Claude CLI (F-079, api-types 0.34.0; design W4
+ * §5.1 — the same tokens wicked-garden's own lint reports):
+ *
+ *   - `plugin-root` — the text contains `${CLAUDE_PLUGIN_ROOT}` (only Claude Code substitutes it);
+ *   - `skill-dir-var` — the text contains `${CLAUDE_SKILL_DIR}` (likewise Claude-only);
+ *   - `cwd-script` — an interpreter invokes a plugin script by a path relative to the worktree cwd
+ *     (`python3 scripts/domain/extract_loop.py`) instead of the `wicked-garden run …` launcher;
+ *   - `relative-link` — a `../` link whose target exists in the bundle (the flat `<name>/SKILL.md`
+ *     layout of every non-Claude install cannot follow it);
+ *   - `cross-skill-path` — a path (plugin-root or `../`) that lands in ANOTHER skill's directory;
+ *     the portable form names that skill (`wicked-garden-<x>`) instead;
+ *   - `requires-harness:claude` — the author declared `metadata.requires-harness: claude` in the
+ *     frontmatter: the skill genuinely needs the Claude harness (not an authoring defect).
+ */
 export type SkillPortabilityReason =
-  | 'plugin-root' | 'skill-dir-var' | 'cwd-script' | 'relative-link' | 'cross-skill-path'
+  | 'plugin-root'
+  | 'skill-dir-var'
+  | 'cwd-script'
+  | 'relative-link'
+  | 'cross-skill-path'
   | 'requires-harness:claude';
 
-/** The publisher's portability verdict for one skill (api-types 0.34.0). */
+/** Per-reason portability of a skill (F-079, api-types 0.34.0) — reported beside `portable`. */
 export interface SkillPortability {
-  /** Same value as SkillEntry.portable — reasons.length === 0. */
+  /** The same value as `SkillEntry.portable`: `reasons.length === 0`. */
   portable: boolean;
   /** Sorted, unique. Empty when portable. */
   reasons: SkillPortabilityReason[];
-  /** Up to N anchors, `<plugin-relative file>:<line>`, for the drawer/hover. */
+  /** Up to five anchors, `<plugin-relative file>:<line>`, one per hit in file order — where the
+   *  offending text sits (the drawer's "why" and the operator's path to the line). */
   evidence?: string[];
 }
 
@@ -129,13 +142,16 @@ export interface SkillEntry {
    *  daemon knows (core drop-ins, crew-generated, user-registered) or a skill one of those names in
    *  its SKILL.md (repo-learn → search, mem). Disabling or renaming it is blocking. */
   core: boolean;
-  /** `false` when the skill's files resolve `${CLAUDE_PLUGIN_ROOT}`, invoke a script relative to
-   *  the cwd (`python3 -u scripts/x.py`, `./scripts/x`, …), or link `../` — Claude-only by nature:
-   *  excluded from the snapshot's `views/copilot/` and from the per-launch skill lists core builds
-   *  for the other CLIs. `portable` is the admission key for every non-Claude view (design v3.2). */
+  /** `false` when the skill's files carry any `SkillPortabilityReason` — Claude-only: excluded from
+   *  the snapshot's `views/copilot/` and from the per-launch skill lists core builds for the other
+   *  CLIs. `portable` is the admission key for every non-Claude view (design v3.2); the reasons
+   *  are reported per token in `portability` (api-types 0.34.0). wicked-garden ≥ 12.33 authors
+   *  every skill portably, so a non-portable row there is either an older garden or a skill that
+   *  declares `requires-harness: claude`. */
   portable: boolean;
-  /** WHY `portable` is false, per reason with `file:line` evidence (api-types 0.34.0, F-079).
-   *  Absent from a daemon that predates the field — readers fall back to `portable` alone. */
+  /** Per-reason portability (F-079, api-types 0.34.0): `portable` again, the sorted unique
+   *  `reasons`, and up to five `file:line` anchors. Absent on manifests written by a daemon older
+   *  than 0.7.30 — treat absence as "reasons unknown". */
   portability?: SkillPortability;
   /** Manifest state, orthogonal to content: a disabled skill's files stay in `effective/` and are
    *  excluded from the next published snapshot. Reset never flips it. */
@@ -255,6 +271,9 @@ export type SkillFindingKind =
   | 'core-rename'
   | 'core-missing'
   | 'support-file-edit'
+  /** A write made (or would make) the skill non-portable — a WARNING, one finding PER REASON per
+   *  file (api-types 0.34.0), anchored `file:line` at the first hit and carrying the token in
+   *  `portabilityReason`. The skill leaves every non-Claude delivery view. */
   | 'non-portable'
   /** A `${CLAUDE_PLUGIN_ROOT}/<p>` or `../<p>` reference in an enabled skill's files that does not
    *  resolve inside the would-be snapshot. Severity follows the TARGET (design v3.4 §1): a reference
@@ -340,6 +359,9 @@ export interface SkillConflictFinding {
   evidence: string;
   /** Why it matters. */
   explanation: string;
+  /** On a `non-portable` finding: WHICH reason this finding reports (one finding per reason per
+   *  file). Absent on every other kind (api-types 0.34.0). */
+  portabilityReason?: SkillPortabilityReason;
 }
 
 /** `POST /skills/analyze` 200 body (a PURE dry run of the publish validation: nothing persisted,
@@ -426,7 +448,7 @@ export interface ReplaceSkillBody {
 }
 // <<< VERBATIM
 
-// >>> VERBATIM wicked-crew-api-types@0.34.0 index.d.ts (crew#531; PROVISIONAL until 0.34.0 publishes: the 0.32.0 block at :3844-3893) — the diagnostics skills block
+// >>> VERBATIM wicked-crew-api-types@0.34.0 index.d.ts:4106-4155 (crew#531 via PR #532) — the diagnostics skills block
 /** The skills seam's state as `GET /diagnostics` reports it (skills keystone, api-types 0.28.0). */
 export type DiagnosticsSkillsState = 'published' | 'fallback' | 'blocked' | 'config-error' | 'disabled';
 

--- a/src/api/skills.ts
+++ b/src/api/skills.ts
@@ -9,7 +9,7 @@
  * writes an immutable snapshot generation that every worker spawn then receives.
  *
  * THE TYPES ARE THE CONTRACT'S. Every wire shape here is imported from `./skills-wire.ts` — a
- * byte-for-byte mirror of the `wicked-crew-api-types@0.27.0` skills block (crew#480), pinned by
+ * byte-for-byte mirror of the `wicked-crew-api-types@0.34.0` skills block (crew#480, crew#531), pinned by
  * `tests/skillsWire.test.ts` against a vendored fixture until the package publishes and the mirror
  * becomes a re-export. This module adds only what the UI folds from it (rows, counts, ownership,
  * route identity, the adoption / CAS seams) — never a shape of its own for something the wire spells.
@@ -49,6 +49,8 @@ import type {
   SkillKind,
   SkillManifest,
   SkillMutationResult,
+  SkillPortability,
+  SkillPortabilityReason,
   SkillProvenance,
   SkillPublishResult,
   SkillReadResult,
@@ -76,6 +78,8 @@ export type {
   SkillKind,
   SkillManifest,
   SkillMutationResult,
+  SkillPortability,
+  SkillPortabilityReason,
   SkillProvenance,
   SkillPublishedRecord,
   SkillPublishResult,
@@ -114,6 +118,81 @@ export const SKILL_PROVENANCE_LABELS: Record<SkillProvenance, string> = {
   override: 'overridden',
   'user-added': 'user-added',
 };
+
+/** The publisher's portability reasons (`SkillPortabilityReason`, 0.34.0 / F-079), in the wire's
+ *  order: five AUTHORING reasons — defects in the skill's text an author can fix — and ONE reason
+ *  different in kind, `requires-harness:claude`: the skill's mechanics need the Claude harness. */
+export const SKILL_PORTABILITY_REASONS: readonly SkillPortabilityReason[] = [
+  'plugin-root', 'skill-dir-var', 'cwd-script', 'relative-link', 'cross-skill-path', 'requires-harness:claude',
+];
+
+/** The one reason that is NOT an authoring defect. */
+export const HARNESS_REASON: SkillPortabilityReason = 'requires-harness:claude';
+
+/** An authoring reason: anything the publisher reports that is not the harness reason — a token this
+ *  build does not know is treated as authoring too (the honest default: "not portable", the token
+ *  shown), never as "needs Claude harness". */
+export function isAuthoringReason(reason: string): boolean {
+  return reason !== HARNESS_REASON;
+}
+
+/** Operator copy per reason — the "why" behind the badge, one clause each (the wire's own words:
+ *  `SkillEntry.portable` / `SkillPortabilityReason`). */
+export const SKILL_PORTABILITY_REASON_COPY: Record<SkillPortabilityReason, string> = {
+  'plugin-root': 'resolves ${CLAUDE_PLUGIN_ROOT}, which only the Claude harness sets',
+  'skill-dir-var': 'resolves ${CLAUDE_SKILL_DIR}, which only the Claude harness sets',
+  'cwd-script': 'invokes a script relative to the cwd (python3 scripts/x.py, ./scripts/x) instead of the skill directory',
+  'relative-link': 'links a sibling with ../ — a path outside the skill directory',
+  'cross-skill-path': 'reaches into another skill\'s directory',
+  'requires-harness:claude': 'the skill\'s mechanics need the Claude harness itself (hooks, plugin catalogs) — nothing in the text to rewrite',
+};
+
+/** The copy for a reason, or a neutral clause for a token this build does not know (a newer daemon). */
+export function portabilityReasonCopy(reason: string): string {
+  return (SKILL_PORTABILITY_REASON_COPY as Record<string, string | undefined>)[reason] ?? 'a reason this build of studio does not know — the token is the publisher\'s';
+}
+
+/** How a skill reaches the non-Claude seats — the fold behind the badge, the chips and the KPI split:
+ *  `portable` = the admission key is true; `not-portable` = at least one AUTHORING reason (or an
+ *  older daemon that reports none — generic); `needs-claude` = the ONLY reason is
+ *  `requires-harness:claude` (by design, nothing to fix). */
+export type SkillReach = 'portable' | 'not-portable' | 'needs-claude';
+
+export const SKILL_REACH_LABELS: Record<SkillReach, string> = {
+  portable: 'portable',
+  'not-portable': 'not portable',
+  'needs-claude': 'needs Claude harness',
+};
+
+/** One row's portability, folded for the badge, the drawer line and the counts. */
+export interface SkillPortabilityView {
+  reach: SkillReach;
+  /** The publisher's reasons as sent (sorted, unique); empty for a portable row and for a daemon
+   *  that predates the field. */
+  reasons: readonly SkillPortabilityReason[];
+  /** `<plugin-relative file>:<line>` anchors; the first is the hover's. Empty when none were sent. */
+  evidence: readonly string[];
+  /** `true` when the daemon sent `portability` with at least one reason — the badge can say WHY;
+   *  `false` = fall back to `portable` alone (an older daemon, or a verdict with no reasons). */
+  detailed: boolean;
+}
+
+/**
+ * The portability fold. `portable` — the admission key core reads for every non-Claude view — decides
+ * WHETHER a row is excluded; the optional `portability` verdict (0.34.0) decides WHICH badge and its
+ * words. Authoring reasons win over the harness reason when both are present (the text is fixable,
+ * so that is the badge to show; the title still lists every reason). A daemon without the field, or
+ * one that sends `portable: false` with no reasons, gets the generic "not portable" — never a
+ * fabricated reason.
+ */
+export function skillPortability(entry: { portable: boolean; portability?: SkillPortability | undefined }): SkillPortabilityView {
+  const verdict: SkillPortability | undefined = entry.portability;
+  const reasons: readonly SkillPortabilityReason[] = verdict?.reasons ?? [];
+  const evidence: readonly string[] = verdict?.evidence ?? [];
+  if (entry.portable) return { reach: 'portable', reasons, evidence, detailed: verdict !== undefined };
+  if (reasons.length === 0) return { reach: 'not-portable', reasons, evidence, detailed: false };
+  return { reach: reasons.some(isAuthoringReason) ? 'not-portable' : 'needs-claude', reasons, evidence, detailed: true };
+}
 
 /** The `diagnostics.skills.state` vocabulary (0.27.0), read as operator copy: whether the engine is
  *  being handed a verified snapshot, and if not, why. */
@@ -254,16 +333,24 @@ export interface SkillCounts {
   overridden: number;
   core: number;
   portable: number;
+  /** Excluded for an AUTHORING reason (or by an older daemon that reports none) — fixable in the text. */
+  notPortable: number;
+  /** Excluded because the skill needs the Claude harness (`requires-harness:claude` and nothing else). */
+  needsClaude: number;
 }
 
-/** The KPI fold over the manifest — pinned by test so the band agrees with the list. */
+/** The KPI fold over the manifest — pinned by test so the band agrees with the list. The reach split
+ *  is exhaustive: `portable + notPortable + needsClaude === total`. */
 export function skillCounts(rows: readonly SkillRow[]): SkillCounts {
-  const counts: SkillCounts = { total: rows.length, enabled: 0, overridden: 0, core: 0, portable: 0 };
+  const counts: SkillCounts = { total: rows.length, enabled: 0, overridden: 0, core: 0, portable: 0, notPortable: 0, needsClaude: 0 };
   for (const r of rows) {
     if (r.enabled) counts.enabled += 1;
     if (r.provenance === 'override') counts.overridden += 1;
     if (r.core) counts.core += 1;
-    if (r.portable) counts.portable += 1;
+    const { reach } = skillPortability(r);
+    if (reach === 'portable') counts.portable += 1;
+    else if (reach === 'not-portable') counts.notPortable += 1;
+    else counts.needsClaude += 1;
   }
   return counts;
 }

--- a/src/api/skills.ts
+++ b/src/api/skills.ts
@@ -175,6 +175,25 @@ export interface SkillPortabilityView {
   /** `true` when the daemon sent `portability` with at least one reason — the badge can say WHY;
    *  `false` = fall back to `portable` alone (an older daemon, or a verdict with no reasons). */
   detailed: boolean;
+  /** The daemon's verdict disagrees with its own admission key ({@link portabilityContradiction});
+   *  `null` when the signals agree or no verdict was sent. The badge still follows `portable`. */
+  contradiction: string | null;
+}
+
+/**
+ * The ONE sentence naming how a `portability` verdict disagrees with `portable`, or `null` when the
+ * three signals the contract says are one value agree (`portable`, `portability.portable`, and
+ * `reasons.length === 0`). Surfaced as `data-contradiction` on the row and the badge wrapper and as
+ * the drawer's hint — never a console warning, never a different badge: `portable` is what core
+ * admits by, so the badge follows it and the disagreement is made visible beside it.
+ */
+export function portabilityContradiction(portable: boolean, verdict: SkillPortability): string | null {
+  const issues: string[] = [];
+  if (verdict.portable !== portable) issues.push(`portability.portable is ${verdict.portable} while portable is ${portable}`);
+  if ((verdict.reasons.length === 0) !== portable) {
+    issues.push(portable ? `${verdict.reasons.length} reason(s) reported on a portable skill` : 'no reasons reported on a non-portable skill');
+  }
+  return issues.length === 0 ? null : `daemon reported inconsistent portability: ${issues.join('; ')}`;
 }
 
 /**
@@ -189,9 +208,10 @@ export function skillPortability(entry: { portable: boolean; portability?: Skill
   const verdict: SkillPortability | undefined = entry.portability;
   const reasons: readonly SkillPortabilityReason[] = verdict?.reasons ?? [];
   const evidence: readonly string[] = verdict?.evidence ?? [];
-  if (entry.portable) return { reach: 'portable', reasons, evidence, detailed: verdict !== undefined };
-  if (reasons.length === 0) return { reach: 'not-portable', reasons, evidence, detailed: false };
-  return { reach: reasons.some(isAuthoringReason) ? 'not-portable' : 'needs-claude', reasons, evidence, detailed: true };
+  const contradiction = verdict === undefined ? null : portabilityContradiction(entry.portable, verdict);
+  if (entry.portable) return { reach: 'portable', reasons, evidence, detailed: verdict !== undefined, contradiction };
+  if (reasons.length === 0) return { reach: 'not-portable', reasons, evidence, detailed: false, contradiction };
+  return { reach: reasons.some(isAuthoringReason) ? 'not-portable' : 'needs-claude', reasons, evidence, detailed: true, contradiction };
 }
 
 /** The `diagnostics.skills.state` vocabulary (0.27.0), read as operator copy: whether the engine is

--- a/src/components/SkillChips.tsx
+++ b/src/components/SkillChips.tsx
@@ -1,4 +1,5 @@
 import {
+  HARNESS_REASON,
   SKILL_KIND_LABELS,
   SKILL_PROVENANCE_LABELS,
   SKILL_REACH_LABELS,
@@ -94,6 +95,10 @@ export function portabilityTitle(view: SkillPortabilityView): string {
   if (view.reach === 'needs-claude') {
     return `${SKILL_REACH_LABELS['needs-claude']} — ${view.reasons.join(', ')}${where}: ${portabilityReasonCopy('requires-harness:claude')}; ${EXCLUDED} by design`;
   }
+  if (view.reasons.includes(HARNESS_REASON)) {
+    // Mixed case: fixing the text is necessary but not sufficient — the harness reason keeps it out.
+    return `${SKILL_REACH_LABELS['not-portable']} — ${view.reasons.join(', ')}${where}; an authoring defect AND a harness requirement: fix the skill text; it also needs the Claude harness, so it stays ${EXCLUDED} after the fix`;
+  }
   return `${SKILL_REACH_LABELS['not-portable']} — ${view.reasons.join(', ')}${where}; an authoring defect: ${EXCLUDED} until the skill text is fixed`;
 }
 
@@ -117,7 +122,7 @@ export function PortabilityBadge({ portability, portable }: {
   const title = portabilityTitle(view);
   const needsClaude = view.reach === 'needs-claude';
   return (
-    <span data-testid="skills-claude-only-badge" data-reach={view.reach} className="inline-flex shrink-0">
+    <span data-testid="skills-claude-only-badge" data-reach={view.reach} data-contradiction={view.contradiction ?? undefined} className="inline-flex shrink-0">
       <span
         data-testid={needsClaude ? 'skills-needs-claude-badge' : 'skills-not-portable-badge'}
         data-reasons={view.reasons.join(' ')}

--- a/src/components/SkillChips.tsx
+++ b/src/components/SkillChips.tsx
@@ -1,14 +1,19 @@
 import {
   SKILL_KIND_LABELS,
   SKILL_PROVENANCE_LABELS,
+  SKILL_REACH_LABELS,
+  portabilityReasonCopy,
+  skillPortability,
   type SkillKind,
+  type SkillPortability,
+  type SkillPortabilityView,
   type SkillProvenance,
   type SkillRow,
 } from '../api/skills.js';
 
-/** The Skills surface's shared chip grammar — kind, provenance, the core / Claude-only / upgrade /
+/** The Skills surface's shared chip grammar — kind, provenance, the core / portability / upgrade /
  *  conflict / unpublished badges and the enabled switch: one spelling for the catalog rows and the
- *  drawer. Every word here is the contract's (api-types 0.27.0 `SkillEntry`). */
+ *  drawer. Every word here is the contract's (api-types 0.34.0 `SkillEntry`). */
 
 export const KIND_COLOR: Record<SkillKind, string> = {
   router: 'var(--accent)',
@@ -73,18 +78,60 @@ export function CoreBadge(): React.ReactElement {
   );
 }
 
-/** Not portable: the skill's files resolve `${CLAUDE_PLUGIN_ROOT}`, invoke a cwd-relative script or
- *  link `../` — Claude-only by nature; excluded from the snapshot's `views/copilot/` and from the
- *  per-launch skill lists core builds for the other CLIs (design v3.2). */
-export function ClaudeOnlyBadge(): React.ReactElement {
+/** The pre-0.34.0 sentence — what the badge says when the daemon reports `portable: false` and no
+ *  reasons (it predates `portability`, or sent an empty verdict). */
+export const GENERIC_NOT_PORTABLE_TITLE =
+  'not portable — depends on the plugin root, cwd-relative scripts or sibling links; Claude-only, excluded from the snapshot\'s copilot view and the other CLIs\' per-launch skill lists';
+
+const EXCLUDED = 'excluded from the snapshot\'s copilot view and the other CLIs\' per-launch skill lists';
+
+/** The hover / accessible sentence for one non-portable row: the reasons joined, the first evidence
+ *  anchor, and what the exclusion means — or the generic sentence when the daemon sent no reasons. */
+export function portabilityTitle(view: SkillPortabilityView): string {
+  if (!view.detailed) return GENERIC_NOT_PORTABLE_TITLE;
+  const first = view.evidence[0];
+  const where = first === undefined ? '' : ` (first at ${first})`;
+  if (view.reach === 'needs-claude') {
+    return `${SKILL_REACH_LABELS['needs-claude']} — ${view.reasons.join(', ')}${where}: ${portabilityReasonCopy('requires-harness:claude')}; ${EXCLUDED} by design`;
+  }
+  return `${SKILL_REACH_LABELS['not-portable']} — ${view.reasons.join(', ')}${where}; an authoring defect: ${EXCLUDED} until the skill text is fixed`;
+}
+
+/**
+ * WHY a skill does not reach the non-Claude seats — one badge per KIND of reason (F-079, api-types
+ * 0.34.0): any AUTHORING reason (`plugin-root`, `skill-dir-var`, `cwd-script`, `relative-link`,
+ * `cross-skill-path`) → **not portable** — the text is fixable, the title lists the reasons and the
+ * first `file:line`; `requires-harness:claude` alone → **needs Claude harness** — by design, the
+ * title is the reason. `portable` (the admission key core reads) decides whether anything renders;
+ * a daemon without `portability` (or a verdict with no reasons) gets the generic **not portable**
+ * badge with the pre-0.34.0 sentence. The wrapper keeps `skills-claude-only-badge` for one release
+ * so existing selectors keep resolving; the inner badge carries the per-kind testid, the reach and
+ * the reasons as data attributes, and its sentence as the accessible name.
+ */
+export function PortabilityBadge({ portability, portable }: {
+  portability: SkillPortability | undefined;
+  portable: boolean;
+}): React.ReactElement | null {
+  const view = skillPortability({ portable, portability });
+  if (view.reach === 'portable') return null;
+  const title = portabilityTitle(view);
+  const needsClaude = view.reach === 'needs-claude';
   return (
-    <span
-      data-testid="skills-claude-only-badge"
-      title="not portable — depends on the plugin root, cwd-relative scripts or sibling links; Claude-only, excluded from the snapshot's copilot view and the other CLIs' per-launch skill lists"
-      className={BADGE}
-      style={{ background: 'var(--surface-raised)', color: 'var(--ink-muted)' }}
-    >
-      claude-only
+    <span data-testid="skills-claude-only-badge" data-reach={view.reach} className="inline-flex shrink-0">
+      <span
+        data-testid={needsClaude ? 'skills-needs-claude-badge' : 'skills-not-portable-badge'}
+        data-reasons={view.reasons.join(' ')}
+        data-detailed={view.detailed}
+        role="note"
+        aria-label={title}
+        title={title}
+        className={BADGE}
+        style={needsClaude
+          ? { background: 'var(--surface-raised)', color: 'var(--ink-muted)' }
+          : { background: 'var(--status-gate-dim)', color: 'var(--status-gate)' }}
+      >
+        {SKILL_REACH_LABELS[view.reach]}
+      </span>
     </span>
   );
 }
@@ -139,7 +186,7 @@ export function SkillFlags({ skill }: { skill: SkillRow }): React.ReactElement {
   return (
     <span className="inline-flex flex-wrap items-center gap-1">
       {skill.core && <CoreBadge />}
-      {!skill.portable && <ClaudeOnlyBadge />}
+      <PortabilityBadge portability={skill.portability} portable={skill.portable} />
       {skill.upgradeAvailable && <UpgradeBadge />}
       {skill.conflict && <ConflictBadge />}
       {skill.unpublished && <UnpublishedBadge />}

--- a/src/components/SkillChips.tsx
+++ b/src/components/SkillChips.tsx
@@ -126,9 +126,11 @@ export function PortabilityBadge({ portability, portable }: {
         aria-label={title}
         title={title}
         className={BADGE}
+        // Amber = actionable (the text is fixable); the ink stays `--ink-high` so the badge reads in
+        // BOTH themes (the light theme keeps `--status-gate` pale — only its `-dim` fill is re-tuned).
         style={needsClaude
           ? { background: 'var(--surface-raised)', color: 'var(--ink-muted)' }
-          : { background: 'var(--status-gate-dim)', color: 'var(--status-gate)' }}
+          : { background: 'var(--status-gate-dim)', color: 'var(--ink-high)', border: '1px solid var(--status-gate)' }}
       >
         {SKILL_REACH_LABELS[view.reach]}
       </span>

--- a/src/components/SkillDrawer.tsx
+++ b/src/components/SkillDrawer.tsx
@@ -509,7 +509,7 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, leaveT
           }}
         >
           <span className="min-w-0 break-words">
-            <span className="font-semibold" style={{ color: reach.reach === 'needs-claude' ? 'var(--ink-high)' : 'var(--status-gate)' }}>Portability</span>
+            <span className="font-semibold" style={{ color: 'var(--ink-high)' }}>Portability</span>
             {' — '}
             {portabilityTitle(reach)}
           </span>

--- a/src/components/SkillDrawer.tsx
+++ b/src/components/SkillDrawer.tsx
@@ -494,6 +494,16 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, leaveT
             upstream ships this name at {skill.upstreamDir}
           </span>
         )}
+        {reach.contradiction !== null && (
+          <span
+            data-testid="skills-drawer-portability-hint"
+            role="note"
+            style={{ color: 'var(--status-gate)' }}
+            title="the daemon's portability verdict disagrees with its portable flag; the badge and the counts follow `portable` (the admission key core reads) — worth reporting to wicked-crew"
+          >
+            {reach.contradiction}
+          </span>
+        )}
       </div>
 
       {reach.reach !== 'portable' && (
@@ -531,8 +541,9 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, leaveT
               className="flex min-w-0 flex-col gap-0.5 font-mono text-[10px]"
               style={{ color: 'var(--ink-high)' }}
             >
-              {reach.evidence.map((anchor) => (
-                <li key={anchor} data-testid="skills-drawer-portability-anchor" className="min-w-0 whitespace-normal break-all">{anchor}</li>
+              {reach.evidence.map((anchor, i) => (
+                // One anchor per HIT in file order — two hits on one line share a `file:line`, so the key is positional.
+                <li key={`${i}:${anchor}`} data-testid="skills-drawer-portability-anchor" className="min-w-0 whitespace-normal break-all">{anchor}</li>
               ))}
             </ul>
           )}

--- a/src/components/SkillDrawer.tsx
+++ b/src/components/SkillDrawer.tsx
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   listSkillFiles,
+  portabilityReasonCopy,
   readSkillFile,
   readSupportFile,
+  skillPortability,
   writeSkillFile,
   writeSupportFile,
   type SkillMutationResult,
@@ -11,7 +13,7 @@ import {
   type SkillTreeRow,
 } from '../api/skills.js';
 import { useModalEscape } from './Modal.js';
-import { EnabledToggle, KindChip, ProvenanceChip, SkillFlags } from './SkillChips.js';
+import { EnabledToggle, KindChip, ProvenanceChip, SkillFlags, portabilityTitle } from './SkillChips.js';
 import { SkillConfirmModal } from './SkillConfirmModal.js';
 import { SkillFilesMapModal } from './SkillFilesMapModal.js';
 import { SkillFindings } from './SkillFindings.js';
@@ -453,6 +455,10 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, leaveT
   const hasBaseline = canReset || skill.upstreamDir !== null;
   const verbsDisabled = busy || saving;
   const treeLocked = dirty || fileLoading;
+  // WHY this skill does not reach the non-Claude seats (0.34.0 `portability`): the reasons and the
+  // publisher's `file:line` anchors — the operator's path to the offending line. Nothing renders
+  // for a portable skill.
+  const reach = skillPortability(skill);
 
   return (
     <aside
@@ -489,6 +495,49 @@ export function SkillDrawer({ skill, support, writer, catalogEpoch, busy, leaveT
           </span>
         )}
       </div>
+
+      {reach.reach !== 'portable' && (
+        <div
+          data-testid="skills-drawer-portability"
+          data-reach={reach.reach}
+          data-detailed={reach.detailed}
+          className="flex min-w-0 flex-col gap-1 rounded px-2 py-1.5 text-[11px]"
+          style={{
+            background: 'var(--surface-rail)',
+            border: `1px solid ${reach.reach === 'needs-claude' ? 'var(--surface-raised)' : 'var(--status-gate)'}`,
+            color: 'var(--ink-muted)',
+          }}
+        >
+          <span className="min-w-0 break-words">
+            <span className="font-semibold" style={{ color: reach.reach === 'needs-claude' ? 'var(--ink-high)' : 'var(--status-gate)' }}>Portability</span>
+            {' — '}
+            {portabilityTitle(reach)}
+          </span>
+          {reach.detailed && (
+            <ul className="flex min-w-0 flex-col gap-0.5" aria-label="Portability reasons">
+              {reach.reasons.map((r) => (
+                <li key={r} data-testid="skills-drawer-portability-reason" data-reason={r} className="min-w-0 break-words">
+                  <span className="font-mono text-[10px] font-semibold" style={{ color: 'var(--ink-high)' }}>{r}</span>
+                  {' — '}
+                  {portabilityReasonCopy(r)}
+                </li>
+              ))}
+            </ul>
+          )}
+          {reach.evidence.length > 0 && (
+            <ul
+              data-testid="skills-drawer-portability-evidence"
+              aria-label="Portability evidence (file:line)"
+              className="flex min-w-0 flex-col gap-0.5 font-mono text-[10px]"
+              style={{ color: 'var(--ink-high)' }}
+            >
+              {reach.evidence.map((anchor) => (
+                <li key={anchor} data-testid="skills-drawer-portability-anchor" className="min-w-0 whitespace-normal break-all">{anchor}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
 
       <div className="flex flex-wrap items-center gap-2">
         <label className="inline-flex items-center gap-2 text-[11px]" style={{ color: 'var(--ink-muted)' }}>

--- a/src/components/SkillFindings.tsx
+++ b/src/components/SkillFindings.tsx
@@ -1,4 +1,4 @@
-import type { SkillConflictFinding, SkillGuardResult, SkillVerdict } from '../api/skills.js';
+import { portabilityReasonCopy, type SkillConflictFinding, type SkillGuardResult, type SkillVerdict } from '../api/skills.js';
 
 /**
  * The guard envelope of ONE write / enable / publish / analyze (`{verdict, findings, revision}` —
@@ -8,7 +8,10 @@ import type { SkillConflictFinding, SkillGuardResult, SkillVerdict } from '../ap
  * its `kind` (the contract's `SkillFindingKind` grows; nothing here enumerates it): the guard that
  * fired, its severity, the skill it is about, the OTHER skill it is against (a collision, a core
  * guard — marked when that one is core), the `file:line` the daemon cited, the concrete EVIDENCE
- * (names, paths, the parse error) and the explanation of why it matters.
+ * (names, paths, the parse error) and the explanation of why it matters. A `non-portable` finding
+ * that names WHICH reason it reports (`portabilityReason`, api-types 0.34.0 — one finding per reason
+ * per file) wears that token as a chip whose hover is the reason's one-clause "why"; absent on every
+ * other kind, and on older daemons.
  */
 
 export const VERDICT_COLOR: Record<SkillVerdict, string> = {
@@ -88,6 +91,17 @@ export function SkillFindings({ verb, result, testId }: {
                   )}
                   {location !== null && (
                     <code data-testid="skills-finding-location" className="text-[10px] font-mono" style={{ color: 'var(--ink-dim)' }}>{location}</code>
+                  )}
+                  {f.portabilityReason != null && (
+                    <span
+                      data-testid="skills-finding-reason"
+                      data-reason={f.portabilityReason}
+                      title={portabilityReasonCopy(f.portabilityReason)}
+                      className="rounded px-1.5 text-[10px] font-mono"
+                      style={{ background: 'var(--status-gate-dim)', color: 'var(--ink-high)', border: '1px solid var(--status-gate)' }}
+                    >
+                      {f.portabilityReason}
+                    </span>
                   )}
                 </span>
                 {f.evidence !== '' && (

--- a/src/components/SkillsGrid.tsx
+++ b/src/components/SkillsGrid.tsx
@@ -112,6 +112,9 @@ export function SkillsGrid({ rows, facets, onFacets, selectedName, busyName, fro
                     // drawer is open on", and `data-selected` is the styling/test hook.
                     aria-current={selected ? 'true' : undefined}
                     data-selected={selected}
+                    // A `portability` verdict that disagrees with `portable` (F-1) — observable here even
+                    // when no badge renders (a portable row carrying reasons); the drawer says it in words.
+                    data-contradiction={skillPortability(r).contradiction ?? undefined}
                     onClick={() => onSelect(r.name)}
                     className="cursor-pointer align-middle transition-colors"
                     style={{

--- a/src/components/SkillsGrid.tsx
+++ b/src/components/SkillsGrid.tsx
@@ -1,10 +1,10 @@
-import { SKILL_KINDS, isSkillKind, type SkillRow } from '../api/skills.js';
+import { SKILL_KINDS, isSkillKind, skillPortability, type SkillRow } from '../api/skills.js';
 import { FilterStrip } from './dashboardKit.js';
 import { EnabledToggle, KindChip, ProvenanceChip, SkillFlags } from './SkillChips.js';
 
 /**
  * The skills CATALOG — one row per skill in the manifest: name · kind · provenance · flags (core /
- * claude-only / conflict / unpublished) · the enabled switch. A row click opens the drawer (the
+ * not portable · needs Claude harness / conflict / unpublished) · the enabled switch. A row click opens the drawer (the
  * SteeringGrid row/drawer-open idiom); the switch is the ONE inline write — it flips through the
  * daemon's guards and the row shows the manifest's answer, never an optimistic one.
  *
@@ -13,8 +13,9 @@ import { EnabledToggle, KindChip, ProvenanceChip, SkillFlags } from './SkillChip
  * rows.
  */
 
-/** The facet chips — the three kinds plus the state cuts the KPI tiles are doors into. */
-export const SKILL_CHIPS = ['all', ...SKILL_KINDS, 'enabled', 'disabled', 'overridden', 'core', 'portable', 'claude-only'] as const;
+/** The facet chips — the three kinds plus the state cuts the KPI tiles are doors into. The reach
+ *  split (`portable` · `not-portable` · `needs-claude`, 0.34.0 / F-079) replaces `claude-only`. */
+export const SKILL_CHIPS = ['all', ...SKILL_KINDS, 'enabled', 'disabled', 'overridden', 'core', 'portable', 'not-portable', 'needs-claude'] as const;
 
 export type SkillChip = (typeof SKILL_CHIPS)[number];
 
@@ -36,7 +37,8 @@ export function filterSkills(rows: readonly SkillRow[], f: SkillsFacets): SkillR
     if (f.chip === 'overridden' && r.provenance !== 'override') return false;
     if (f.chip === 'core' && !r.core) return false;
     if (f.chip === 'portable' && !r.portable) return false;
-    if (f.chip === 'claude-only' && r.portable) return false;
+    if (f.chip === 'not-portable' && skillPortability(r).reach !== 'not-portable') return false;
+    if (f.chip === 'needs-claude' && skillPortability(r).reach !== 'needs-claude') return false;
     if (q !== '' && !r.name.toLowerCase().includes(q) && !r.dir.toLowerCase().includes(q)) return false;
     return true;
   });

--- a/src/components/SkillsPage.tsx
+++ b/src/components/SkillsPage.tsx
@@ -348,8 +348,9 @@ export function SkillsPage({ navigate, search = '' }: {
   return (
     <div data-testid="skills-page" className="flex h-full min-h-0 min-w-0 flex-1 overflow-hidden">
       <div className="flex min-w-0 flex-1 flex-col gap-4 overflow-y-auto p-6">
-        <div className="flex items-start gap-2">
-          <div className="min-w-0">
+        {/* The verbs wrap under the intro at phone width instead of squeezing it to a word per line. */}
+        <div className="flex flex-wrap items-start gap-2">
+          <div className="min-w-0 flex-1 basis-[16rem]">
             <h2 className="text-sm font-semibold" style={{ color: 'var(--ink-high)' }}>Skills</h2>
             <p className="mt-1 text-[11px]" style={{ color: 'var(--ink-muted)' }}>
               The skills every governed worker runs — one effective plugin root the daemon publishes
@@ -409,7 +410,7 @@ export function SkillsPage({ navigate, search = '' }: {
               </p>
             )}
           </div>
-          <div className="ml-auto flex shrink-0 items-center gap-2">
+          <div className="ml-auto flex flex-wrap items-center justify-end gap-2">
             {state.kind === 'loaded' && (
               <>
                 <button
@@ -506,12 +507,15 @@ export function SkillsPage({ navigate, search = '' }: {
                   onOpen={() => setFacets({ ...facets, chip: 'core' })}
                 />
               </KpiGroup>
-              <KpiGroup label="Reach">
+              {/* Same width as the two-tile groups: the context line names both kinds of exclusion and
+                  must not ellipsize at desktop widths (it is the KPI split F-079 asked for). */}
+              <KpiGroup label="Reach" grow={2}>
                 <StatTile
                   testId="skills-kpi-portable"
                   label="Portable"
                   value={counts.portable}
                   context={`${counts.notPortable} not portable · ${counts.needsClaude} need Claude harness`}
+                  title={`${counts.portable} portable · ${counts.notPortable} not portable (an authoring reason — fixable in the skill text) · ${counts.needsClaude} need the Claude harness (by design)`}
                   onOpen={() => setFacets({ ...facets, chip: 'portable' })}
                 />
               </KpiGroup>

--- a/src/components/SkillsPage.tsx
+++ b/src/components/SkillsPage.tsx
@@ -38,7 +38,8 @@ import type { SkillsWriter } from './skillsWriter.js';
  * crew#480):
  *
  *  - the KPI band (total · enabled · overridden · core · portable) over the manifest, each tile a
- *    door into the matching catalog filter;
+ *    door into the matching catalog filter — the Portable tile's context splits the rest by KIND of
+ *    reason (`N not portable · M need Claude harness`, api-types 0.34.0 / F-079);
  *  - the CATALOG (SkillsGrid): one row per skill with kind / provenance / flags and the enabled
  *    switch — the one inline write, through the daemon's guards;
  *  - the DRAWER (SkillDrawer) a row opens: skill files + support files under tabs, the textarea
@@ -510,7 +511,7 @@ export function SkillsPage({ navigate, search = '' }: {
                   testId="skills-kpi-portable"
                   label="Portable"
                   value={counts.portable}
-                  context={`${counts.total - counts.portable} claude-only`}
+                  context={`${counts.notPortable} not portable · ${counts.needsClaude} need Claude harness`}
                   onOpen={() => setFacets({ ...facets, chip: 'portable' })}
                 />
               </KpiGroup>

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -11,8 +11,8 @@
   "studioVersion": "0.5.5",
   "counts": {
     "files": 142,
-    "occurrences": 1226,
-    "static": 1052,
+    "occurrences": 1228,
+    "static": 1054,
     "dynamic": 59,
     "computed": 7
   },
@@ -4486,6 +4486,12 @@
       ]
     },
     {
+      "testId": "skills-drawer-portability-hint",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
       "testId": "skills-drawer-portability-reason",
       "files": [
         "src/components/SkillDrawer.tsx"
@@ -4680,6 +4686,12 @@
     },
     {
       "testId": "skills-finding-location",
+      "files": [
+        "src/components/SkillFindings.tsx"
+      ]
+    },
+    {
+      "testId": "skills-finding-reason",
       "files": [
         "src/components/SkillFindings.tsx"
       ]

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -11,8 +11,8 @@
   "studioVersion": "0.5.5",
   "counts": {
     "files": 142,
-    "occurrences": 1221,
-    "static": 1046,
+    "occurrences": 1226,
+    "static": 1052,
     "dynamic": 59,
     "computed": 7
   },
@@ -4468,6 +4468,30 @@
       ]
     },
     {
+      "testId": "skills-drawer-portability",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-drawer-portability-anchor",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-drawer-portability-evidence",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "skills-drawer-portability-reason",
+      "files": [
+        "src/components/SkillDrawer.tsx"
+      ]
+    },
+    {
       "testId": "skills-drawer-upstream",
       "files": [
         "src/components/SkillDrawer.tsx"
@@ -4700,6 +4724,18 @@
       "testId": "skills-loading",
       "files": [
         "src/components/SkillsPage.tsx"
+      ]
+    },
+    {
+      "testId": "skills-needs-claude-badge",
+      "files": [
+        "src/components/SkillChips.tsx"
+      ]
+    },
+    {
+      "testId": "skills-not-portable-badge",
+      "files": [
+        "src/components/SkillChips.tsx"
       ]
     },
     {

--- a/tests/SkillsPage.test.tsx
+++ b/tests/SkillsPage.test.tsx
@@ -1511,6 +1511,8 @@ describe('SkillsPage — the page verbs: Add, Refresh baseline, Analyze, Publish
       findings: [
         finding({ kind: 'unresolved-ref', severity: 'blocking', skill: EXTRACTOR, file: 'skills/domain/extractor/SKILL.md', line: 42, explanation: '${CLAUDE_PLUGIN_ROOT}/scripts/domain/extract_loop.py escapes the plugin root' }),
         finding({ kind: 'name-collision', severity: 'blocking', skill: MINE, againstSkill: A11Y, explanation: 'frontmatter name collides with a disabled skill' }),
+        // 0.34.0: a `non-portable` finding names WHICH reason it reports — rendered as a chip with the reason's copy.
+        finding({ kind: 'non-portable', severity: 'warning', skill: EXTRACTOR, file: 'skills/domain/extractor/SKILL.md', line: 41, portabilityReason: 'cwd-script', evidence: 'python3 scripts/domain/extract_loop.py', explanation: 'invokes a script relative to the cwd' }),
       ],
     };
     wire({
@@ -1523,11 +1525,18 @@ describe('SkillsPage — the page verbs: Add, Refresh baseline, Analyze, Publish
 
     const findings = await screen.findByTestId('skills-page-findings');
     expect(findings.dataset.verdict).toBe('blocked');
-    expect(findings).toHaveTextContent('Publish blocked — nothing was written (2 findings).');
+    expect(findings).toHaveTextContent('Publish blocked — nothing was written (3 findings).');
     const rows = within(findings).getAllByTestId('skills-finding');
-    expect(rows.map((r) => r.dataset.kind)).toEqual(['unresolved-ref', 'name-collision']);
+    expect(rows.map((r) => r.dataset.kind)).toEqual(['unresolved-ref', 'name-collision', 'non-portable']);
     expect(within(rows[0]!).getByTestId('skills-finding-location')).toHaveTextContent('skills/domain/extractor/SKILL.md:42');
     expect(within(rows[1]!).queryByTestId('skills-finding-location')).toBeNull();
+    // The reason chip rides only the finding that carries `portabilityReason` (F-5); its hover is the reason's copy.
+    expect(within(rows[0]!).queryByTestId('skills-finding-reason')).toBeNull();
+    expect(within(rows[1]!).queryByTestId('skills-finding-reason')).toBeNull();
+    const chip = within(rows[2]!).getByTestId('skills-finding-reason');
+    expect(chip).toHaveTextContent('cwd-script');
+    expect(chip.dataset.reason).toBe('cwd-script');
+    expect(chip.title).toContain('invokes a script relative to the cwd');
     expect(calls('GET', '/skills')).toBe(1);
     expect(screen.queryByTestId('skills-note')).toBeNull();
     expect(screen.getByTestId('skills-snapshot').dataset.generation).toBe('3');
@@ -2103,5 +2112,67 @@ describe('SkillsPage — portability per KIND of reason (F-079, api-types 0.34.0
     expect(line).toHaveTextContent(`Portability — ${GENERIC_NOT_PORTABLE_TITLE}`);
     expect(within(line).queryAllByTestId('skills-drawer-portability-reason')).toEqual([]);
     expect(within(line).queryAllByTestId('skills-drawer-portability-anchor')).toEqual([]);
+  });
+});
+
+describe('SkillsPage — a contradictory `portability` verdict is made visible, never swallowed (F-1)', () => {
+  it('a PORTABLE row carrying reasons renders no badge (portable decides), but the row carries data-contradiction and the drawer says it in words', async () => {
+    wire({
+      'GET /skills': () => Promise.resolve(catalog({
+        skills: { [REPO_LEARN]: entry({ dir: 'skills/repo-learn', kind: 'router', core: true, portable: true, portability: { portable: true, reasons: ['plugin-root'], evidence: ['skills/repo-learn/SKILL.md:9'] } }) },
+      })),
+      ...fileHandlers(REPO_LEARN),
+    });
+    render(<Harness />);
+    await screen.findAllByTestId('skills-row');
+
+    const learn = row(REPO_LEARN);
+    expect(within(learn).queryByTestId('skills-claude-only-badge')).toBeNull();
+    expect(within(learn).queryByTestId('skills-not-portable-badge')).toBeNull();
+    expect(learn.dataset.contradiction).toBe('daemon reported inconsistent portability: 1 reason(s) reported on a portable skill');
+    // Consistent rows carry no attribute at all.
+    expect(row(EXTRACTOR).dataset.contradiction).toBeUndefined();
+    expect(row(MINE).dataset.contradiction).toBeUndefined();
+    // Counted as portable — the KPI follows `portable` too.
+    expect(screen.getByTestId('skills-kpi-portable').dataset.value).toBe('3');
+
+    const drawer = await openDrawer(REPO_LEARN);
+    const hint = within(drawer).getByTestId('skills-drawer-portability-hint');
+    expect(hint).toHaveTextContent('daemon reported inconsistent portability: 1 reason(s) reported on a portable skill');
+    expect(hint).toHaveAttribute('role', 'note');
+    // No Portability box for a portable row — the hint is the whole story.
+    expect(within(drawer).queryByTestId('skills-drawer-portability')).toBeNull();
+  });
+
+  it('a NON-portable row whose verdict says portable:true renders the generic badge with data-contradiction on the wrapper; the drawer shows the hint above its Portability box', async () => {
+    wire({
+      'GET /skills': () => Promise.resolve(catalog({
+        skills: { [EXTRACTOR]: entry({ dir: 'skills/domain/extractor', kind: 'fork-worker', core: true, portable: false, portability: { portable: true, reasons: [] }, provenance: 'override' }) },
+      })),
+      ...fileHandlers(EXTRACTOR),
+    });
+    render(<Harness />);
+    await screen.findAllByTestId('skills-row');
+
+    const extractor = row(EXTRACTOR);
+    const wrapper = within(extractor).getByTestId('skills-claude-only-badge');
+    expect(wrapper.dataset.reach).toBe('not-portable');
+    expect(wrapper.dataset.contradiction).toBe('daemon reported inconsistent portability: portability.portable is true while portable is false; no reasons reported on a non-portable skill');
+    expect(within(extractor).getByTestId('skills-not-portable-badge').dataset.detailed).toBe('false');
+    expect(extractor.dataset.contradiction).toBe(wrapper.dataset.contradiction);
+
+    const drawer = await openDrawer(EXTRACTOR);
+    expect(within(drawer).getByTestId('skills-drawer-portability-hint')).toHaveTextContent('daemon reported inconsistent portability');
+    expect(within(drawer).getByTestId('skills-drawer-portability').dataset.detailed).toBe('false');
+  });
+
+  it('a consistent catalog carries no contradiction anywhere — no attribute on any row or badge, no hint in any drawer', async () => {
+    wire({ 'GET /skills': () => Promise.resolve(catalog()), ...fileHandlers(EXTRACTOR) });
+    render(<Harness />);
+    await screen.findAllByTestId('skills-row');
+    for (const r of screen.getAllByTestId('skills-row')) expect(r.dataset.contradiction).toBeUndefined();
+    expect(within(row(EXTRACTOR)).getByTestId('skills-claude-only-badge').dataset.contradiction).toBeUndefined();
+    const drawer = await openDrawer(EXTRACTOR);
+    expect(within(drawer).queryByTestId('skills-drawer-portability-hint')).toBeNull();
   });
 });

--- a/tests/SkillsPage.test.tsx
+++ b/tests/SkillsPage.test.tsx
@@ -11,11 +11,13 @@ import type {
   SkillFileRecord,
   SkillFileTree,
   SkillMutationResult,
+  SkillPortability,
   SkillPublishResult,
   SkillReadResult,
   SkillRefreshResult,
   SkillsCatalog,
 } from '../src/api/skills.js';
+import { GENERIC_NOT_PORTABLE_TITLE } from '../src/components/SkillChips.js';
 
 /**
  * The Skills file manager (`/skills`, the skills keystone — design v3) over a MOCKED `/skills`
@@ -25,8 +27,13 @@ import type {
  * `SkillMutationResult` / `SkillPublishResult` / `SkillRefreshResult` envelopes, 409 only on a
  * stale `expectedRevision`, 503 = no catalog to serve):
  *  - the catalog renders as the KPI band (total · enabled · overridden · core · portable) + one
- *    row per skill with kind / provenance chips and the core / claude-only / conflict / unpublished
- *    badges; the source and snapshot lines name the baseline and the current generation;
+ *    row per skill with kind / provenance chips and the core / portability / conflict / unpublished
+ *    badges; the source and snapshot lines name the baseline and the current generation. The
+ *    portability badge is PER KIND OF REASON (F-079, api-types 0.34.0 `SkillEntry.portability`):
+ *    an authoring reason → "not portable" (title = the reasons + the first `file:line`), the
+ *    harness reason alone → "needs Claude harness" (title = the reason); an older daemon without the
+ *    field falls back to the generic "not portable" with the pre-0.34.0 sentence; the Portable tile's
+ *    context splits the rest the same way and the chips `not-portable` / `needs-claude` cut it;
  *  - CAS: every mutation sends `expectedRevision` (the catalog revision) and the answered
  *    `revision` is adopted for the next one; a 409 raises the `skills-conflict` reload prompt and
  *    freezes every write until the catalog is re-read;
@@ -98,6 +105,17 @@ const REV_3 = 3;
 const BASELINE = 'b'.repeat(16);
 const SNAPSHOT_PATH = '/state/skills/snapshots/000003';
 
+/** The publisher's verdict for the extractor (0.34.0): three AUTHORING reasons, two `file:line` anchors. */
+const EXTRACTOR_PORTABILITY: SkillPortability = {
+  portable: false,
+  reasons: ['cwd-script', 'plugin-root', 'relative-link'],
+  evidence: ['skills/domain/extractor/SKILL.md:41', 'skills/domain/extractor/refs/loop.md:7'],
+};
+
+/** A skill excluded BY DESIGN — the harness reason and nothing else. */
+const AGENTIC = 'wicked-garden-agentic';
+const AGENTIC_PORTABILITY: SkillPortability = { portable: false, reasons: ['requires-harness:claude'], evidence: ['skills/agentic/SKILL.md:3'] };
+
 /** The four-skill manifest: a core router (shipped, published), a core Claude-only fork worker
  *  (an OVERRIDE whose SKILL.md is not yet published, in refresh conflict), a disabled fork worker,
  *  and a user-added module (no baseline, never published) — plus two root support files. */
@@ -127,8 +145,8 @@ function catalog(opts: {
       },
       skills: {
         [REPO_LEARN]: entry({ dir: 'skills/repo-learn', kind: 'router', core: true }),
-        // An override (edited files), Claude-only, in refresh conflict + upgrade available, not yet published.
-        [EXTRACTOR]: entry({ dir: 'skills/domain/extractor', kind: 'fork-worker', core: true, portable: false, provenance: 'override', upgradeAvailable: true, conflict: true, editedAt: '2026-09-07T10:00:00Z' }),
+        // An override (edited files), not portable for three authoring reasons, in refresh conflict + upgrade available, not yet published.
+        [EXTRACTOR]: entry({ dir: 'skills/domain/extractor', kind: 'fork-worker', core: true, portable: false, portability: EXTRACTOR_PORTABILITY, provenance: 'override', upgradeAvailable: true, conflict: true, editedAt: '2026-09-07T10:00:00Z' }),
         [A11Y]: entry({ dir: 'skills/qe/a11y-test-engineer', kind: 'fork-worker', enabled: false }),
         // User-added: no baseline, never published.
         [MINE]: entry({ dir: `skills/${MINE}`, provenance: 'user-added' }),
@@ -277,7 +295,11 @@ describe('SkillsPage — the catalog from the manifest', () => {
     expect(within(extractor).getByTestId('skills-kind-chip').dataset.kind).toBe('fork-worker');
     expect(within(extractor).getByTestId('skills-provenance-chip').dataset.provenance).toBe('override');
     expect(within(extractor).getByTestId('skills-core-badge')).toBeInTheDocument();
-    expect(within(extractor).getByTestId('skills-claude-only-badge')).toBeInTheDocument();
+    // The one-release compatibility wrapper still resolves; the badge inside is the per-reason one.
+    expect(within(extractor).getByTestId('skills-claude-only-badge').dataset.reach).toBe('not-portable');
+    expect(within(extractor).getByTestId('skills-not-portable-badge')).toHaveTextContent('not portable');
+    expect(within(extractor).queryByTestId('skills-needs-claude-badge')).toBeNull();
+    expect(screen.getByTestId('skills-kpi-portable')).toHaveTextContent('1 not portable · 0 need Claude harness');
     expect(within(extractor).getByTestId('skills-upgrade-badge')).toBeInTheDocument();
     expect(within(extractor).getByTestId('skills-conflict-badge')).toBeInTheDocument();
     expect(within(extractor).getByTestId('skills-unpublished-badge')).toBeInTheDocument();
@@ -288,6 +310,8 @@ describe('SkillsPage — the catalog from the manifest', () => {
     expect(within(mine).getByTestId('skills-unpublished-badge')).toBeInTheDocument();
     expect(within(mine).queryByTestId('skills-core-badge')).toBeNull();
     expect(within(mine).queryByTestId('skills-claude-only-badge')).toBeNull();
+    expect(within(mine).queryByTestId('skills-not-portable-badge')).toBeNull();
+    expect(within(mine).queryByTestId('skills-needs-claude-badge')).toBeNull();
     expect(within(mine).queryByTestId('skills-conflict-badge')).toBeNull();
     expect(within(mine).queryByTestId('skills-upgrade-badge')).toBeNull();
 
@@ -1962,5 +1986,122 @@ describe('SkillsPage — review round 3 (closing sweep): unsafe map keys, a fail
     expect(within(drawer).getAllByTestId('skills-file')[1]).toHaveAttribute('aria-current', 'true');
     expect(calls('GET', `/skills/${REPO_LEARN}/files/SKILL.md`)).toBe(1);
     expect(calls('GET', `/skills/${REPO_LEARN}/files/refs/notes.md`)).toBe(2);
+  });
+});
+
+describe('SkillsPage — portability per KIND of reason (F-079, api-types 0.34.0 `SkillEntry.portability`)', () => {
+  it('an authoring reason → the "not portable" badge; its hover title lists the reasons and the first file:line anchor, and is the accessible name', async () => {
+    wire({ 'GET /skills': () => Promise.resolve(catalog()) });
+    render(<Harness />);
+    await screen.findAllByTestId('skills-row');
+
+    const badge = within(row(EXTRACTOR)).getByTestId('skills-not-portable-badge');
+    expect(badge).toHaveTextContent('not portable');
+    expect(badge.dataset.reasons).toBe('cwd-script plugin-root relative-link');
+    expect(badge.dataset.detailed).toBe('true');
+    expect(badge.title).toContain('cwd-script, plugin-root, relative-link');
+    expect(badge.title).toContain('first at skills/domain/extractor/SKILL.md:41');
+    expect(badge.title).not.toContain('refs/loop.md'); // the hover carries the FIRST anchor; the drawer lists them all
+    expect(badge).toHaveAccessibleName(badge.title);
+    expect(badge).toHaveAttribute('role', 'note');
+  });
+
+  it('the harness reason ALONE → the "needs Claude harness" badge whose title is the reason; the KPI context and the chips split the two kinds', async () => {
+    wire({
+      'GET /skills': () => Promise.resolve(catalog({
+        skills: { [AGENTIC]: entry({ dir: 'skills/agentic', kind: 'router', portable: false, portability: AGENTIC_PORTABILITY }) },
+        files: { 'skills/agentic/SKILL.md': record() },
+      })),
+    });
+    render(<Harness />);
+    await screen.findAllByTestId('skills-row');
+
+    const agentic = row(AGENTIC);
+    const badge = within(agentic).getByTestId('skills-needs-claude-badge');
+    expect(badge).toHaveTextContent('needs Claude harness');
+    expect(badge.title).toContain('requires-harness:claude');
+    expect(badge.title).toContain('first at skills/agentic/SKILL.md:3');
+    expect(badge).toHaveAccessibleName(/needs Claude harness — requires-harness:claude/);
+    expect(within(agentic).getByTestId('skills-claude-only-badge').dataset.reach).toBe('needs-claude');
+    expect(within(agentic).queryByTestId('skills-not-portable-badge')).toBeNull();
+
+    // Five skills: three portable, one not portable (authoring), one that needs the harness.
+    const tile = screen.getByTestId('skills-kpi-portable');
+    expect(tile.dataset.value).toBe('3');
+    expect(tile).toHaveTextContent('1 not portable · 1 need Claude harness');
+
+    // The chips are doors into each kind; `claude-only` is gone.
+    const chips = screen.getAllByTestId('skills-filter-chip');
+    const labels = chips.map((c) => c.textContent ?? '');
+    expect(labels.some((l) => l.startsWith('not-portable'))).toBe(true);
+    expect(labels.some((l) => l.startsWith('needs-claude'))).toBe(true);
+    expect(labels.some((l) => l.startsWith('claude-only'))).toBe(false);
+    fireEvent.click(chips.find((c) => (c.textContent ?? '').startsWith('not-portable'))!);
+    expect(screen.getByTestId('skills-filter').dataset.filter).toBe('not-portable');
+    expect(screen.getAllByTestId('skills-row').map((r) => r.dataset.skill)).toEqual([EXTRACTOR]);
+    fireEvent.click(screen.getAllByTestId('skills-filter-chip').find((c) => (c.textContent ?? '').startsWith('needs-claude'))!);
+    expect(screen.getAllByTestId('skills-row').map((r) => r.dataset.skill)).toEqual([AGENTIC]);
+    // The Portable tile still opens the portable cut.
+    fireEvent.click(tile);
+    expect(screen.getAllByTestId('skills-row').map((r) => r.dataset.skill)).toEqual([MINE, A11Y, REPO_LEARN]);
+  });
+
+  it('an older daemon (no `portability` field) falls back to `portable` alone: the generic "not portable" badge with the pre-0.34.0 sentence, counted as not portable', async () => {
+    wire({
+      'GET /skills': () => Promise.resolve(catalog({
+        skills: { [EXTRACTOR]: entry({ dir: 'skills/domain/extractor', kind: 'fork-worker', core: true, portable: false, provenance: 'override', upgradeAvailable: true, conflict: true }) },
+      })),
+    });
+    render(<Harness />);
+    await screen.findAllByTestId('skills-row');
+
+    const badge = within(row(EXTRACTOR)).getByTestId('skills-not-portable-badge');
+    expect(badge).toHaveTextContent('not portable');
+    expect(badge.dataset.detailed).toBe('false');
+    expect(badge.dataset.reasons).toBe('');
+    expect(badge.title).toBe(GENERIC_NOT_PORTABLE_TITLE);
+    expect(badge).toHaveAccessibleName(GENERIC_NOT_PORTABLE_TITLE);
+    expect(within(row(EXTRACTOR)).getByTestId('skills-claude-only-badge').dataset.reach).toBe('not-portable');
+    expect(screen.getByTestId('skills-kpi-portable')).toHaveTextContent('1 not portable · 0 need Claude harness');
+  });
+
+  it('the drawer carries a Portability line: every reason with its copy, and every file:line anchor as monospace text', async () => {
+    wire({ 'GET /skills': () => Promise.resolve(catalog()), ...fileHandlers(EXTRACTOR) });
+    render(<Harness />);
+    const drawer = await openDrawer(EXTRACTOR);
+
+    const line = within(drawer).getByTestId('skills-drawer-portability');
+    expect(line.dataset.reach).toBe('not-portable');
+    expect(line.dataset.detailed).toBe('true');
+    expect(line).toHaveTextContent('Portability — not portable — cwd-script, plugin-root, relative-link (first at skills/domain/extractor/SKILL.md:41)');
+    expect(within(line).getAllByTestId('skills-drawer-portability-reason').map((li) => li.dataset.reason)).toEqual(['cwd-script', 'plugin-root', 'relative-link']);
+    expect(within(line).getAllByTestId('skills-drawer-portability-reason')[1]).toHaveTextContent('plugin-root — resolves ${CLAUDE_PLUGIN_ROOT}');
+    const anchors = within(line).getAllByTestId('skills-drawer-portability-anchor');
+    expect(anchors.map((a) => a.textContent)).toEqual(['skills/domain/extractor/SKILL.md:41', 'skills/domain/extractor/refs/loop.md:7']);
+    // Long anchors wrap at phone width rather than widening the drawer.
+    for (const a of anchors) expect(a.className).toContain('break-all');
+    // The header badge in the drawer is the same per-reason badge as the row's.
+    expect(within(drawer).getByTestId('skills-not-portable-badge')).toBeInTheDocument();
+  });
+
+  it('the drawer of a portable skill has no Portability line; an older daemon\'s non-portable skill gets the generic line, no reasons, no anchors', async () => {
+    wire({
+      'GET /skills': () => Promise.resolve(catalog({
+        skills: { [EXTRACTOR]: entry({ dir: 'skills/domain/extractor', kind: 'fork-worker', core: true, portable: false, provenance: 'override' }) },
+      })),
+      ...fileHandlers(REPO_LEARN),
+      ...fileHandlers(EXTRACTOR),
+    });
+    render(<Harness />);
+    const learn = await openDrawer(REPO_LEARN);
+    expect(within(learn).queryByTestId('skills-drawer-portability')).toBeNull();
+    fireEvent.click(screen.getByTestId('skills-drawer-close'));
+
+    const drawer = await openDrawer(EXTRACTOR);
+    const line = within(drawer).getByTestId('skills-drawer-portability');
+    expect(line.dataset.detailed).toBe('false');
+    expect(line).toHaveTextContent(`Portability — ${GENERIC_NOT_PORTABLE_TITLE}`);
+    expect(within(line).queryAllByTestId('skills-drawer-portability-reason')).toEqual([]);
+    expect(within(line).queryAllByTestId('skills-drawer-portability-anchor')).toEqual([]);
   });
 });

--- a/tests/fixtures/api-types-0.34.0-skills.d.ts
+++ b/tests/fixtures/api-types-0.34.0-skills.d.ts
@@ -1,5 +1,10 @@
-// >>> VERBATIM wicked-crew-api-types@0.27.0 index.d.ts:1322-1685 (crew#480 @ 4cae105) — the skills block
-// ── Skills — the daemon-owned garden plugin root, published as immutable snapshots (api-types 0.27.0) ──
+// >>> VERBATIM wicked-crew-api-types@0.34.0 index.d.ts (crew#531; PROVISIONAL until 0.34.0 publishes: the 0.32.0 block at :1502-1874 + the additive SkillPortability shape) — the skills block
+// ── Skills — the daemon-owned garden plugin root, published as immutable snapshots (api-types 0.28.0) ──
+//
+// api-types 0.29.0 (design amendment v3.6, crew #490): the installer-managed copy
+// `<config dir>/plugins/wicked-garden` is a LAST-resort seed source — `SkillSourceKind` gains
+// `installer-copy`, and `DiagnosticsSkillsFinding.kind` gains the persistent `skills.source` warning
+// and the fail-closed `skills.manifest` error.
 //
 // Skills are files (skills keystone, design v3 + amendments v3.1/v3.2). The daemon owns ONE
 // effective `wicked-garden`-shaped plugin root — `<state home>/skills/effective/`, the dependency
@@ -34,10 +39,14 @@ export type SkillKind = 'router' | 'fork-worker' | 'module';
  *  it while the operator's edits were kept). */
 export type SkillProvenance = 'shipped' | 'override' | 'user-added';
 
-/** Where a baseline was captured from. `claude-plugin-cache` covers the marketplace cache AND the
- *  hand-installed `plugins/wicked-garden` copy (both are "the installed plugin"); `checkout` is a
- *  git working tree; `directory` any other explicit plugin-shaped directory. */
-export type SkillSourceKind = 'claude-plugin-cache' | 'checkout' | 'directory';
+/** Where a baseline was captured from. `claude-plugin-cache` is the marketplace cache
+ *  (`<config dir>/plugins/cache/wicked-garden/wicked-garden/<version>` — the plugin Claude Code
+ *  runs); `installer-copy` is the installer-managed `<config dir>/plugins/wicked-garden` copy
+ *  (`npx wicked-installer install wicked-garden`), accepted only as the LAST resort when no cache
+ *  exists (design v3.6, api-types 0.29.0) and flagged by the `skills.source` diagnostics finding
+ *  while it is the current baseline; `checkout` is a git working tree; `directory` any other
+ *  explicit plugin-shaped directory. */
+export type SkillSourceKind = 'claude-plugin-cache' | 'installer-copy' | 'checkout' | 'directory';
 
 /** The per-baseline `uv sync` state (`<baseline>/.venv`, provisioned once per content hash — the
  *  publish that needs it AWAITS it — and shared read-only by every snapshot that links it):
@@ -62,6 +71,27 @@ export interface SkillBaselineRecord {
   venv: SkillVenvState;
 }
 
+/** WHY a skill is not portable — the publisher's per-reason verdict (api-types 0.34.0, F-079). The
+ *  five AUTHORING reasons are defects in the skill's text an author can fix without touching the
+ *  harness: `plugin-root` = resolves `${CLAUDE_PLUGIN_ROOT}`; `skill-dir-var` = resolves
+ *  `${CLAUDE_SKILL_DIR}`; `cwd-script` = invokes a script relative to the cwd (`python3 scripts/x.py`,
+ *  `./scripts/x`); `relative-link` = a `../` link to a sibling; `cross-skill-path` = a path into
+ *  another skill's directory. `requires-harness:claude` is different in kind: the skill's MECHANICS
+ *  need the Claude harness (hooks, the plugin catalogs) — nothing to rewrite. */
+export type SkillPortabilityReason =
+  | 'plugin-root' | 'skill-dir-var' | 'cwd-script' | 'relative-link' | 'cross-skill-path'
+  | 'requires-harness:claude';
+
+/** The publisher's portability verdict for one skill (api-types 0.34.0). */
+export interface SkillPortability {
+  /** Same value as SkillEntry.portable — reasons.length === 0. */
+  portable: boolean;
+  /** Sorted, unique. Empty when portable. */
+  reasons: SkillPortabilityReason[];
+  /** Up to N anchors, `<plugin-relative file>:<line>`, for the drawer/hover. */
+  evidence?: string[];
+}
+
 export interface SkillEntry {
   /** Plugin-relative directory, nested layout preserved (`skills/engineering/frontend`). Never
    *  renamed — sibling `../` links depend on it. */
@@ -76,6 +106,9 @@ export interface SkillEntry {
    *  excluded from the snapshot's `views/copilot/` and from the per-launch skill lists core builds
    *  for the other CLIs. `portable` is the admission key for every non-Claude view (design v3.2). */
   portable: boolean;
+  /** WHY `portable` is false, per reason with `file:line` evidence (api-types 0.34.0, F-079).
+   *  Absent from a daemon that predates the field — readers fall back to `portable` alone. */
+  portability?: SkillPortability;
   /** Manifest state, orthogonal to content: a disabled skill's files stay in `effective/` and are
    *  excluded from the next published snapshot. Reset never flips it. */
   enabled: boolean;
@@ -92,7 +125,7 @@ export interface SkillEntry {
    *  name collision (upstream ships this name at another dir than the operator's skill); `null`
    *  otherwise. `GET /skills/:name/files/*path?side=baseline` reads THIS directory for such a skill,
    *  so the two sides of the collision are comparable — the answer's `path` names the file actually
-   *  read (api-types 0.27.0). Re-derived by every refresh. */
+   *  read (api-types 0.28.0). Re-derived by every refresh. */
   upstreamDir: string | null;
 }
 
@@ -117,7 +150,7 @@ export interface SkillPublishedRecord {
   at: string;
   /** sha256 of the exact `snapshot.json` bytes publish wrote. `snapshot.json` is excluded from the
    *  content hash, so the crew-owned manifest AUTHENTICATES it: `current` verifies only the
-   *  generation this record names, with metadata hashing to this value (api-types 0.27.0). */
+   *  generation this record names, with metadata hashing to this value (api-types 0.28.0). */
   snapshotHash: string;
 }
 
@@ -202,7 +235,7 @@ export type SkillFindingKind =
    *  the snapshot does not carry it — a file the bundle omits, or a skill that is disabled) is a
    *  `warning`: a content bug the skill's author owns, published as found — a publish with only
    *  warnings answers `verdict: 'warnings'` with the findings AND a written snapshot (api-types
-   *  0.27.0). */
+   *  0.28.0). */
   | 'unresolved-ref'
   /** A path the store refuses BY NAME rather than reads through: a shape that could leave its root
    *  (`..`, an absolute piece), a component that crosses a symlink, or — under `effective/`, where
@@ -219,24 +252,24 @@ export type SkillFindingKind =
   | 'empty-snapshot'
   /** `.claude-plugin/plugin.json`, `archetypes.json` or `components.json` is absent from `effective/`
    *  — the plugin manifest + the runtime catalogs are REQUIRED snapshot members (blocking at
-   *  publish; api-types 0.27.0). */
+   *  publish; api-types 0.28.0). */
   | 'missing-plugin-manifest'
   /** The plugin manifest or a runtime catalog is present but not what its reader expects — does
    *  not parse as JSON, is not a JSON object, or `archetypes.json` lacks its `archetypes`
-   *  collection (blocking at publish; api-types 0.27.0). A manifest without `name` is
+   *  collection (blocking at publish; api-types 0.28.0). A manifest without `name` is
    *  `name-mismatch`. */
   | 'catalog-invalid'
   /** The baseline's shared read-only Python env could not be provisioned (uv missing, `uv sync`
    *  failed, or the env could not be locked) while the bundle carries a `pyproject.toml` — the env
    *  is REQUIRED, so the publish is blocked and nothing (the provisioning state included) is
-   *  persisted (api-types 0.27.0). */
+   *  persisted (api-types 0.28.0). */
   | 'venv-failed'
   /** A publish was refused because one is already running (one at a time) — nothing was written, so
    *  it is a 2xx `blocked` envelope, not a 409 (409 is only a stale `expectedRevision`; api-types
-   *  0.27.0). Re-read `GET /skills` and retry against the revision it answers. */
+   *  0.28.0). Re-read `GET /skills` and retry against the revision it answers. */
   | 'publish-in-flight'
   /** A publish was aborted because the skills root changed under it — nothing was written to either
-   *  root; a 2xx `blocked` envelope (api-types 0.27.0). Re-read `GET /skills` and retry. */
+   *  root; a 2xx `blocked` envelope (api-types 0.28.0). Re-read `GET /skills` and retry. */
   | 'root-changed'
   /** A path outside the bundle closure — the ONE allowlist of what the seed copies, what the support
    *  API may address, and what a snapshot may carry: the five runtime catalogs under `.claude-plugin`
@@ -246,7 +279,7 @@ export type SkillFindingKind =
    *  directories and any `wg-`-prefixed dev tooling, plus `pyproject.toml` and `uv.lock`. A support
    *  add/PUT there is a 2xx `blocked` envelope (nothing written); a file found there under
    *  `effective/` at publish/analyze (a direct filesystem edit) is a BLOCKING finding naming the path
-   *  — a snapshot never ships it (api-types 0.27.0). */
+   *  — a snapshot never ships it (api-types 0.28.0). */
   | 'outside-closure'
   /** A content-addressed `baseline/<hash>` whose tree does not hash to its name (a bundle file
    *  modified, planted or removed, or a symlink inside), or a baseline file whose bytes do not match
@@ -254,7 +287,7 @@ export type SkillFindingKind =
    *  refuses to reuse it (2xx `blocked`, nothing copied), reset refuses to restore from it (nothing
    *  written), publish/analyze report it blocking (before AND after the env was provisioned in it).
    *  Read-only mode bits on the baseline are a guard, never the integrity boundary — the hash is
-   *  (api-types 0.27.0). */
+   *  (api-types 0.28.0). */
   | 'baseline-corrupt';
 
 export type SkillFindingSeverity = 'warning' | 'blocking';
@@ -330,7 +363,7 @@ export interface SkillRefreshResult extends SkillAnalyzeResult {
 /** The 409 body of a `/skills` mutation whose `expectedRevision` is stale — a CAS conflict, the
  *  ONLY thing that answers 409. A publish refused because another is in flight, or aborted because
  *  the skills root changed under it, wrote nothing and instead answers a 2xx `blocked` findings
- *  envelope (`publish-in-flight` / `root-changed`; api-types 0.27.0), never a 409. */
+ *  envelope (`publish-in-flight` / `root-changed`; api-types 0.28.0), never a 409. */
 export interface SkillRevisionConflict {
   error: string;
   /** The current revision — re-read `GET /skills` (or use this) and retry. */
@@ -365,8 +398,8 @@ export interface ReplaceSkillBody {
 }
 // <<< VERBATIM
 
-// >>> VERBATIM wicked-crew-api-types@0.27.0 index.d.ts:3262-3302 (crew#480 @ 4cae105) — the diagnostics skills block
-/** The skills seam's state as `GET /diagnostics` reports it (skills keystone, api-types 0.27.0). */
+// >>> VERBATIM wicked-crew-api-types@0.34.0 index.d.ts (crew#531; PROVISIONAL until 0.34.0 publishes: the 0.32.0 block at :3844-3893) — the diagnostics skills block
+/** The skills seam's state as `GET /diagnostics` reports it (skills keystone, api-types 0.28.0). */
 export type DiagnosticsSkillsState = 'published' | 'fallback' | 'blocked' | 'config-error' | 'disabled';
 
 /** One finding the skills degradation ladder produced (design v3 §3). */
@@ -376,8 +409,17 @@ export interface DiagnosticsSkillsFinding {
    *  blocked (engine input points at a non-existent refusal path — launches fail loudly until the
    *  catalog is fixed); `skills.config` = the configured root is corrupt/unusable (same refusal;
    *  `error`), or — as a `warning` on the `published` state — the root lies OUTSIDE the daemon
-   *  state home, so core's fence cross-check (`WICKED_CREW_STATE_HOME`) refuses every launch. */
-  kind: 'skills.fallback' | 'skills.blocked' | 'skills.config';
+   *  state home, so core's fence cross-check (`WICKED_CREW_STATE_HOME`) refuses every launch;
+   *  `skills.source` (`warning`, api-types 0.29.0, design v3.6) = the CURRENT baseline was seeded
+   *  from the installer-managed copy (`SkillSourceKind` `installer-copy`) — the daemon works, but
+   *  that copy receives no marketplace updates until the plugin is registered with Claude Code; it
+   *  persists (alongside the ladder's own finding, if any) until a refresh from the marketplace
+   *  cache re-records the baseline's provenance (byte-identical or not); `skills.manifest`
+   *  (`error`, api-types 0.29.0) = `manifest.json` could not be read when diagnostics were taken
+   *  (corrupt, unreadable, or the root no longer the one the store bound) — reported as
+   *  `config-error` with the cause instead of the stale boot outcome; the exported engine input is
+   *  unchanged until the daemon restarts. */
+  kind: 'skills.fallback' | 'skills.blocked' | 'skills.config' | 'skills.source' | 'skills.manifest';
   severity: 'warning' | 'error';
   message: string;
 }

--- a/tests/fixtures/api-types-0.34.0-skills.d.ts
+++ b/tests/fixtures/api-types-0.34.0-skills.d.ts
@@ -1,4 +1,4 @@
-// >>> VERBATIM wicked-crew-api-types@0.34.0 index.d.ts (crew#531; PROVISIONAL until 0.34.0 publishes: the 0.32.0 block at :1502-1874 + the additive SkillPortability shape) — the skills block
+// >>> VERBATIM wicked-crew-api-types@0.34.0 index.d.ts:1716-2134 (crew#531 via PR #532) — the skills block
 // ── Skills — the daemon-owned garden plugin root, published as immutable snapshots (api-types 0.28.0) ──
 //
 // api-types 0.29.0 (design amendment v3.6, crew #490): the installer-managed copy
@@ -71,24 +71,37 @@ export interface SkillBaselineRecord {
   venv: SkillVenvState;
 }
 
-/** WHY a skill is not portable — the publisher's per-reason verdict (api-types 0.34.0, F-079). The
- *  five AUTHORING reasons are defects in the skill's text an author can fix without touching the
- *  harness: `plugin-root` = resolves `${CLAUDE_PLUGIN_ROOT}`; `skill-dir-var` = resolves
- *  `${CLAUDE_SKILL_DIR}`; `cwd-script` = invokes a script relative to the cwd (`python3 scripts/x.py`,
- *  `./scripts/x`); `relative-link` = a `../` link to a sibling; `cross-skill-path` = a path into
- *  another skill's directory. `requires-harness:claude` is different in kind: the skill's MECHANICS
- *  need the Claude harness (hooks, the plugin catalogs) — nothing to rewrite. */
+/**
+ * Why a skill's text cannot be followed on a non-Claude CLI (F-079, api-types 0.34.0; design W4
+ * §5.1 — the same tokens wicked-garden's own lint reports):
+ *
+ *   - `plugin-root` — the text contains `${CLAUDE_PLUGIN_ROOT}` (only Claude Code substitutes it);
+ *   - `skill-dir-var` — the text contains `${CLAUDE_SKILL_DIR}` (likewise Claude-only);
+ *   - `cwd-script` — an interpreter invokes a plugin script by a path relative to the worktree cwd
+ *     (`python3 scripts/domain/extract_loop.py`) instead of the `wicked-garden run …` launcher;
+ *   - `relative-link` — a `../` link whose target exists in the bundle (the flat `<name>/SKILL.md`
+ *     layout of every non-Claude install cannot follow it);
+ *   - `cross-skill-path` — a path (plugin-root or `../`) that lands in ANOTHER skill's directory;
+ *     the portable form names that skill (`wicked-garden-<x>`) instead;
+ *   - `requires-harness:claude` — the author declared `metadata.requires-harness: claude` in the
+ *     frontmatter: the skill genuinely needs the Claude harness (not an authoring defect).
+ */
 export type SkillPortabilityReason =
-  | 'plugin-root' | 'skill-dir-var' | 'cwd-script' | 'relative-link' | 'cross-skill-path'
+  | 'plugin-root'
+  | 'skill-dir-var'
+  | 'cwd-script'
+  | 'relative-link'
+  | 'cross-skill-path'
   | 'requires-harness:claude';
 
-/** The publisher's portability verdict for one skill (api-types 0.34.0). */
+/** Per-reason portability of a skill (F-079, api-types 0.34.0) — reported beside `portable`. */
 export interface SkillPortability {
-  /** Same value as SkillEntry.portable — reasons.length === 0. */
+  /** The same value as `SkillEntry.portable`: `reasons.length === 0`. */
   portable: boolean;
   /** Sorted, unique. Empty when portable. */
   reasons: SkillPortabilityReason[];
-  /** Up to N anchors, `<plugin-relative file>:<line>`, for the drawer/hover. */
+  /** Up to five anchors, `<plugin-relative file>:<line>`, one per hit in file order — where the
+   *  offending text sits (the drawer's "why" and the operator's path to the line). */
   evidence?: string[];
 }
 
@@ -101,13 +114,16 @@ export interface SkillEntry {
    *  daemon knows (core drop-ins, crew-generated, user-registered) or a skill one of those names in
    *  its SKILL.md (repo-learn → search, mem). Disabling or renaming it is blocking. */
   core: boolean;
-  /** `false` when the skill's files resolve `${CLAUDE_PLUGIN_ROOT}`, invoke a script relative to
-   *  the cwd (`python3 -u scripts/x.py`, `./scripts/x`, …), or link `../` — Claude-only by nature:
-   *  excluded from the snapshot's `views/copilot/` and from the per-launch skill lists core builds
-   *  for the other CLIs. `portable` is the admission key for every non-Claude view (design v3.2). */
+  /** `false` when the skill's files carry any `SkillPortabilityReason` — Claude-only: excluded from
+   *  the snapshot's `views/copilot/` and from the per-launch skill lists core builds for the other
+   *  CLIs. `portable` is the admission key for every non-Claude view (design v3.2); the reasons
+   *  are reported per token in `portability` (api-types 0.34.0). wicked-garden ≥ 12.33 authors
+   *  every skill portably, so a non-portable row there is either an older garden or a skill that
+   *  declares `requires-harness: claude`. */
   portable: boolean;
-  /** WHY `portable` is false, per reason with `file:line` evidence (api-types 0.34.0, F-079).
-   *  Absent from a daemon that predates the field — readers fall back to `portable` alone. */
+  /** Per-reason portability (F-079, api-types 0.34.0): `portable` again, the sorted unique
+   *  `reasons`, and up to five `file:line` anchors. Absent on manifests written by a daemon older
+   *  than 0.7.30 — treat absence as "reasons unknown". */
   portability?: SkillPortability;
   /** Manifest state, orthogonal to content: a disabled skill's files stay in `effective/` and are
    *  excluded from the next published snapshot. Reset never flips it. */
@@ -227,6 +243,9 @@ export type SkillFindingKind =
   | 'core-rename'
   | 'core-missing'
   | 'support-file-edit'
+  /** A write made (or would make) the skill non-portable — a WARNING, one finding PER REASON per
+   *  file (api-types 0.34.0), anchored `file:line` at the first hit and carrying the token in
+   *  `portabilityReason`. The skill leaves every non-Claude delivery view. */
   | 'non-portable'
   /** A `${CLAUDE_PLUGIN_ROOT}/<p>` or `../<p>` reference in an enabled skill's files that does not
    *  resolve inside the would-be snapshot. Severity follows the TARGET (design v3.4 §1): a reference
@@ -312,6 +331,9 @@ export interface SkillConflictFinding {
   evidence: string;
   /** Why it matters. */
   explanation: string;
+  /** On a `non-portable` finding: WHICH reason this finding reports (one finding per reason per
+   *  file). Absent on every other kind (api-types 0.34.0). */
+  portabilityReason?: SkillPortabilityReason;
 }
 
 /** `POST /skills/analyze` 200 body (a PURE dry run of the publish validation: nothing persisted,
@@ -398,7 +420,7 @@ export interface ReplaceSkillBody {
 }
 // <<< VERBATIM
 
-// >>> VERBATIM wicked-crew-api-types@0.34.0 index.d.ts (crew#531; PROVISIONAL until 0.34.0 publishes: the 0.32.0 block at :3844-3893) — the diagnostics skills block
+// >>> VERBATIM wicked-crew-api-types@0.34.0 index.d.ts:4106-4155 (crew#531 via PR #532) — the diagnostics skills block
 /** The skills seam's state as `GET /diagnostics` reports it (skills keystone, api-types 0.28.0). */
 export type DiagnosticsSkillsState = 'published' | 'fallback' | 'blocked' | 'config-error' | 'disabled';
 

--- a/tests/skillsApi.test.ts
+++ b/tests/skillsApi.test.ts
@@ -5,6 +5,7 @@ import {
   HARNESS_REASON,
   SKILL_PORTABILITY_REASONS,
   isAuthoringReason,
+  portabilityContradiction,
   portabilityReasonCopy,
   skillPortability,
   type SkillPortability,
@@ -47,6 +48,7 @@ import {
   type SkillsManifestResponse,
 } from '../src/api/skills.js';
 import { findingLocation } from '../src/components/SkillFindings.js';
+import { portabilityTitle } from '../src/components/SkillChips.js';
 import { filterSkills, SKILL_CHIPS, SKILLS_FACETS_DEFAULT } from '../src/components/SkillsGrid.js';
 
 vi.mock('../src/api/client.js', () => ({ apiFetch: vi.fn() }));
@@ -464,8 +466,8 @@ describe('skillPortability — the fold behind the badge, the chips and the KPI 
   });
 
   it('portable: nothing to say — the reach is portable whatever else rides along', () => {
-    expect(skillPortability({ portable: true })).toEqual({ reach: 'portable', reasons: [], evidence: [], detailed: false });
-    expect(skillPortability({ portable: true, portability: { portable: true, reasons: [] } })).toEqual({ reach: 'portable', reasons: [], evidence: [], detailed: true });
+    expect(skillPortability({ portable: true })).toEqual({ reach: 'portable', reasons: [], evidence: [], detailed: false, contradiction: null });
+    expect(skillPortability({ portable: true, portability: { portable: true, reasons: [] } })).toEqual({ reach: 'portable', reasons: [], evidence: [], detailed: true, contradiction: null });
   });
 
   it('any AUTHORING reason → not-portable (detailed), the reasons and anchors carried as sent — the harness reason beside them does not change the badge', () => {
@@ -474,22 +476,61 @@ describe('skillPortability — the fold behind the badge, the chips and the KPI 
       reasons: ['cwd-script', 'plugin-root', 'relative-link', 'requires-harness:claude'],
       evidence: ['skills/domain/extractor/SKILL.md:41', 'skills/domain/extractor/refs/loop.md:7'],
       detailed: true,
+      contradiction: null,
     });
     expect(skillPortability({ portable: false, portability: { portable: false, reasons: ['cross-skill-path'] } })).toEqual({
-      reach: 'not-portable', reasons: ['cross-skill-path'], evidence: [], detailed: true,
+      reach: 'not-portable', reasons: ['cross-skill-path'], evidence: [], detailed: true, contradiction: null,
     });
   });
 
   it('the harness reason ALONE → needs-claude (by design, nothing to fix)', () => {
     expect(skillPortability({ portable: false, portability: { portable: false, reasons: ['requires-harness:claude'], evidence: ['skills/domain/SKILL.md:3'] } })).toEqual({
-      reach: 'needs-claude', reasons: ['requires-harness:claude'], evidence: ['skills/domain/SKILL.md:3'], detailed: true,
+      reach: 'needs-claude', reasons: ['requires-harness:claude'], evidence: ['skills/domain/SKILL.md:3'], detailed: true, contradiction: null,
     });
   });
 
   it('an older daemon (no `portability`), or a verdict with no reasons, falls back to `portable` alone: generic not-portable, never a fabricated reason', () => {
-    expect(skillPortability({ portable: false })).toEqual({ reach: 'not-portable', reasons: [], evidence: [], detailed: false });
-    expect(skillPortability({ portable: false, portability: undefined })).toEqual({ reach: 'not-portable', reasons: [], evidence: [], detailed: false });
-    expect(skillPortability({ portable: false, portability: { portable: false, reasons: [] } })).toEqual({ reach: 'not-portable', reasons: [], evidence: [], detailed: false });
+    expect(skillPortability({ portable: false })).toEqual({ reach: 'not-portable', reasons: [], evidence: [], detailed: false, contradiction: null });
+    expect(skillPortability({ portable: false, portability: undefined })).toEqual({ reach: 'not-portable', reasons: [], evidence: [], detailed: false, contradiction: null });
+    // A verdict that says "not portable" but names no reason is generic too — and, being internally
+    // inconsistent (reasons.length === 0 ⇔ portable), it is named as a contradiction beside the badge.
+    expect(skillPortability({ portable: false, portability: { portable: false, reasons: [] } })).toEqual({
+      reach: 'not-portable', reasons: [], evidence: [], detailed: false,
+      contradiction: 'daemon reported inconsistent portability: no reasons reported on a non-portable skill',
+    });
+  });
+
+  it('a contradictory verdict is named, never swallowed — and never changes which badge `portable` chose (F-1)', () => {
+    // No verdict at all is not a contradiction (an older daemon): nothing to compare.
+    expect(skillPortability({ portable: false }).contradiction).toBeNull();
+    expect(skillPortability({ portable: true }).contradiction).toBeNull();
+    // portable:true carrying reasons → still portable (no badge), the disagreement named.
+    const portableWithReasons = skillPortability({ portable: true, portability: { portable: true, reasons: ['plugin-root'] } });
+    expect(portableWithReasons.reach).toBe('portable');
+    expect(portableWithReasons.contradiction).toBe('daemon reported inconsistent portability: 1 reason(s) reported on a portable skill');
+    // portable:false with a verdict that says portable:true and no reasons → generic badge, both disagreements named.
+    const flagsDisagree = skillPortability({ portable: false, portability: { portable: true, reasons: [] } });
+    expect(flagsDisagree).toMatchObject({ reach: 'not-portable', detailed: false });
+    expect(flagsDisagree.contradiction).toBe('daemon reported inconsistent portability: portability.portable is true while portable is false; no reasons reported on a non-portable skill');
+    // portable:false with the verdict flag wrong but reasons present → the reasons still drive the badge.
+    const flagOnly = skillPortability({ portable: false, portability: { portable: true, reasons: ['requires-harness:claude'] } });
+    expect(flagOnly).toMatchObject({ reach: 'needs-claude', detailed: true });
+    expect(flagOnly.contradiction).toBe('daemon reported inconsistent portability: portability.portable is true while portable is false');
+    // Consistent verdicts carry null.
+    expect(skillPortability({ portable: false, portability: EXTRACTOR_PORTABILITY }).contradiction).toBeNull();
+    expect(portabilityContradiction(true, { portable: true, reasons: [] })).toBeNull();
+  });
+
+  it('the hover sentence: authoring-only says "until the skill text is fixed"; authoring + harness says BOTH — fix the text, and it still needs the harness (F-2)', () => {
+    const authoringOnly = portabilityTitle(skillPortability({ portable: false, portability: { portable: false, reasons: ['cwd-script', 'plugin-root'], evidence: ['skills/x/SKILL.md:4'] } }));
+    expect(authoringOnly).toBe('not portable — cwd-script, plugin-root (first at skills/x/SKILL.md:4); an authoring defect: excluded from the snapshot\'s copilot view and the other CLIs\' per-launch skill lists until the skill text is fixed');
+    const mixed = portabilityTitle(skillPortability({ portable: false, portability: EXTRACTOR_PORTABILITY }));
+    expect(mixed).toContain('not portable — cwd-script, plugin-root, relative-link, requires-harness:claude (first at skills/domain/extractor/SKILL.md:41)');
+    expect(mixed).toContain('fix the skill text; it also needs the Claude harness, so it stays excluded');
+    expect(mixed).not.toContain('until the skill text is fixed');
+    const harnessOnly = portabilityTitle(skillPortability({ portable: false, portability: { portable: false, reasons: ['requires-harness:claude'] } }));
+    expect(harnessOnly).toContain('needs Claude harness — requires-harness:claude:');
+    expect(harnessOnly).toContain('by design');
   });
 });
 

--- a/tests/skillsApi.test.ts
+++ b/tests/skillsApi.test.ts
@@ -2,6 +2,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ApiError, isRouteUnsupported } from '../src/api/errors.js';
 import { apiFetch } from '../src/api/client.js';
 import {
+  HARNESS_REASON,
+  SKILL_PORTABILITY_REASONS,
+  isAuthoringReason,
+  portabilityReasonCopy,
+  skillPortability,
+  type SkillPortability,
   addSkill,
   analyzeSkills,
   currentBaseline,
@@ -68,7 +74,10 @@ vi.mock('../src/api/client.js', () => ({ apiFetch: vi.fn() }));
  *  - `isSkillsUnsupported` is the bare unknown-route 404 (a named 404 is an answer);
  *    `isSkillsUnavailable` is the 503 (no catalog to serve); `isSkillsConflict` is the CAS 409 and
  *    nothing else;
- *  - `skillCounts` is the five-tile KPI fold; `filterSkills` the catalog predicate the chips count with;
+ *  - `skillCounts` is the five-tile KPI fold — `portable` split by KIND of reason into `notPortable`
+ *    (authoring) and `needsClaude` (`requires-harness:claude`); `filterSkills` the catalog predicate
+ *    the chips count with; `skillPortability` the fold behind both (0.34.0 `portability`, older
+ *    daemons fall back to `portable` alone);
  *  - `parseFilesMap` is the Add/Replace modal's live validation — every key under the ROUTE
  *    BUILDER's segment rules (`skillFilePathIssue`, one rule for both); `findingLocation` the
  *    `file:line` cite; `SKILLS_ENGINE_STATE_COPY` spells every `DiagnosticsSkillsState`.
@@ -89,6 +98,13 @@ function entry(over: Partial<SkillEntry> = {}): SkillEntry {
     ...over,
   };
 }
+
+/** The publisher's verdict for the extractor: three authoring reasons + the harness one, two anchors. */
+const EXTRACTOR_PORTABILITY: SkillPortability = {
+  portable: false,
+  reasons: ['cwd-script', 'plugin-root', 'relative-link', 'requires-harness:claude'],
+  evidence: ['skills/domain/extractor/SKILL.md:41', 'skills/domain/extractor/refs/loop.md:7'],
+};
 
 function record(over: Partial<SkillFileRecord> = {}): SkillFileRecord {
   return { baselineHash: 'a'.repeat(8), effectiveHash: 'a'.repeat(8), lastPublishedHash: 'a'.repeat(8), conflict: false, ...over };
@@ -112,8 +128,10 @@ const MANIFEST: SkillManifest = {
   skills: {
     'wicked-garden-repo-learn': entry({ dir: 'skills/repo-learn', kind: 'router', core: true }),
     // A PARENT skill with a nested child: the parent owns `vendor/`, the child owns its own subtree.
-    'wicked-garden-domain': entry({ dir: 'skills/domain', kind: 'router', core: true, portable: false }),
-    'wicked-garden-domain-extractor': entry({ dir: 'skills/domain/extractor', kind: 'fork-worker', core: true, portable: false, provenance: 'override', conflict: true, upgradeAvailable: true }),
+    // Excluded BY DESIGN: the only reason is the harness one → "needs Claude harness".
+    'wicked-garden-domain': entry({ dir: 'skills/domain', kind: 'router', core: true, portable: false, portability: { portable: false, reasons: ['requires-harness:claude'], evidence: ['skills/domain/SKILL.md:3'] } }),
+    // Excluded for AUTHORING reasons (the harness one too) → "not portable" — the text is fixable.
+    'wicked-garden-domain-extractor': entry({ dir: 'skills/domain/extractor', kind: 'fork-worker', core: true, portable: false, provenance: 'override', conflict: true, upgradeAvailable: true, portability: EXTRACTOR_PORTABILITY }),
     'wicked-garden-qe-a11y-test-engineer': entry({ dir: 'skills/qe/a11y-test-engineer', kind: 'fork-worker', enabled: false }),
     'my-team-skill': entry({ dir: 'skills/my-team-skill', provenance: 'user-added', upstreamDir: 'skills/team-skill' }),
   },
@@ -413,9 +431,65 @@ describe('skillRows / skillCounts — the KPI fold agrees with the catalog', () 
     expect(rows[2]!.upgradeAvailable).toBe(true);
   });
 
-  it('counts total · enabled · overridden · core · portable', () => {
-    expect(skillCounts(skillRows(MANIFEST))).toEqual({ total: 5, enabled: 4, overridden: 1, core: 3, portable: 3 });
-    expect(skillCounts([])).toEqual({ total: 0, enabled: 0, overridden: 0, core: 0, portable: 0 });
+  it('counts total · enabled · overridden · core · portable — and splits the rest by KIND of reason', () => {
+    expect(skillCounts(skillRows(MANIFEST))).toEqual({ total: 5, enabled: 4, overridden: 1, core: 3, portable: 3, notPortable: 1, needsClaude: 1 });
+    expect(skillCounts([])).toEqual({ total: 0, enabled: 0, overridden: 0, core: 0, portable: 0, notPortable: 0, needsClaude: 0 });
+  });
+
+  it('the reach split is exhaustive: portable + notPortable + needsClaude === total, with or without the 0.34.0 field', () => {
+    const detailed = skillCounts(skillRows(MANIFEST));
+    expect(detailed.portable + detailed.notPortable + detailed.needsClaude).toBe(detailed.total);
+    // An older daemon: the same manifest with every `portability` stripped → the two non-portable rows are generic "not portable".
+    const older: SkillManifest = {
+      ...MANIFEST,
+      skills: Object.fromEntries(Object.entries(MANIFEST.skills).map(([n, e]) => {
+        const rest: SkillEntry = { ...e };
+        delete rest.portability;
+        return [n, rest];
+      })),
+    };
+    expect(skillCounts(skillRows(older))).toEqual({ total: 5, enabled: 4, overridden: 1, core: 3, portable: 3, notPortable: 2, needsClaude: 0 });
+  });
+});
+
+describe('skillPortability — the fold behind the badge, the chips and the KPI split (0.34.0 `portability`)', () => {
+  it('the six reasons are the wire\'s, in order; every one but the harness reason is an authoring reason with its own copy', () => {
+    expect(SKILL_PORTABILITY_REASONS).toEqual(['plugin-root', 'skill-dir-var', 'cwd-script', 'relative-link', 'cross-skill-path', 'requires-harness:claude']);
+    expect(HARNESS_REASON).toBe('requires-harness:claude');
+    expect(SKILL_PORTABILITY_REASONS.filter(isAuthoringReason)).toEqual(['plugin-root', 'skill-dir-var', 'cwd-script', 'relative-link', 'cross-skill-path']);
+    for (const r of SKILL_PORTABILITY_REASONS) expect(portabilityReasonCopy(r).length).toBeGreaterThan(10);
+    // A token this build does not know: authoring by default (never "needs Claude harness"), neutral copy.
+    expect(isAuthoringReason('some-future-reason')).toBe(true);
+    expect(portabilityReasonCopy('some-future-reason')).toContain('does not know');
+  });
+
+  it('portable: nothing to say — the reach is portable whatever else rides along', () => {
+    expect(skillPortability({ portable: true })).toEqual({ reach: 'portable', reasons: [], evidence: [], detailed: false });
+    expect(skillPortability({ portable: true, portability: { portable: true, reasons: [] } })).toEqual({ reach: 'portable', reasons: [], evidence: [], detailed: true });
+  });
+
+  it('any AUTHORING reason → not-portable (detailed), the reasons and anchors carried as sent — the harness reason beside them does not change the badge', () => {
+    expect(skillPortability({ portable: false, portability: EXTRACTOR_PORTABILITY })).toEqual({
+      reach: 'not-portable',
+      reasons: ['cwd-script', 'plugin-root', 'relative-link', 'requires-harness:claude'],
+      evidence: ['skills/domain/extractor/SKILL.md:41', 'skills/domain/extractor/refs/loop.md:7'],
+      detailed: true,
+    });
+    expect(skillPortability({ portable: false, portability: { portable: false, reasons: ['cross-skill-path'] } })).toEqual({
+      reach: 'not-portable', reasons: ['cross-skill-path'], evidence: [], detailed: true,
+    });
+  });
+
+  it('the harness reason ALONE → needs-claude (by design, nothing to fix)', () => {
+    expect(skillPortability({ portable: false, portability: { portable: false, reasons: ['requires-harness:claude'], evidence: ['skills/domain/SKILL.md:3'] } })).toEqual({
+      reach: 'needs-claude', reasons: ['requires-harness:claude'], evidence: ['skills/domain/SKILL.md:3'], detailed: true,
+    });
+  });
+
+  it('an older daemon (no `portability`), or a verdict with no reasons, falls back to `portable` alone: generic not-portable, never a fabricated reason', () => {
+    expect(skillPortability({ portable: false })).toEqual({ reach: 'not-portable', reasons: [], evidence: [], detailed: false });
+    expect(skillPortability({ portable: false, portability: undefined })).toEqual({ reach: 'not-portable', reasons: [], evidence: [], detailed: false });
+    expect(skillPortability({ portable: false, portability: { portable: false, reasons: [] } })).toEqual({ reach: 'not-portable', reasons: [], evidence: [], detailed: false });
   });
 });
 
@@ -512,7 +586,7 @@ describe('filterSkills — the chip predicate', () => {
   const names = (chip: (typeof SKILL_CHIPS)[number], query = ''): string[] =>
     filterSkills(rows, { query, chip }).map((r) => r.name);
 
-  it('all shows everything; kinds, enabled/disabled, overridden, core, portable and claude-only cut it', () => {
+  it('all shows everything; kinds, enabled/disabled, overridden, core, portable, not-portable and needs-claude cut it', () => {
     expect(names('all')).toHaveLength(5);
     expect(names('router')).toEqual(['wicked-garden-domain', 'wicked-garden-repo-learn']);
     expect(names('fork-worker')).toEqual(['wicked-garden-domain-extractor', 'wicked-garden-qe-a11y-test-engineer']);
@@ -522,7 +596,11 @@ describe('filterSkills — the chip predicate', () => {
     expect(names('overridden')).toEqual(['wicked-garden-domain-extractor']);
     expect(names('core')).toEqual(['wicked-garden-domain', 'wicked-garden-domain-extractor', 'wicked-garden-repo-learn']);
     expect(names('portable')).toEqual(['my-team-skill', 'wicked-garden-qe-a11y-test-engineer', 'wicked-garden-repo-learn']);
-    expect(names('claude-only')).toEqual(['wicked-garden-domain', 'wicked-garden-domain-extractor']);
+    expect(names('not-portable')).toEqual(['wicked-garden-domain-extractor']);
+    expect(names('needs-claude')).toEqual(['wicked-garden-domain']);
+    // The three reach chips partition the catalog.
+    expect([...names('portable'), ...names('not-portable'), ...names('needs-claude')].sort()).toEqual(names('all').sort());
+    expect(SKILL_CHIPS).not.toContain('claude-only');
   });
 
   it('the query matches name OR dir, case-insensitively, and composes with the chip', () => {

--- a/tests/skillsWire.test.ts
+++ b/tests/skillsWire.test.ts
@@ -20,6 +20,12 @@ import { describe, expect, it } from 'vitest';
 
 const MIRROR = fileURLToPath(new URL('../src/api/skills-wire.ts', import.meta.url));
 const FIXTURE = fileURLToPath(new URL('./fixtures/api-types-0.34.0-skills.d.ts', import.meta.url));
+const INSTALLED = fileURLToPath(new URL('../node_modules/wicked-crew-api-types/index.d.ts', import.meta.url));
+const INSTALLED_PKG = fileURLToPath(new URL('../node_modules/wicked-crew-api-types/package.json', import.meta.url));
+const PINNED_PKG = fileURLToPath(new URL('../package.json', import.meta.url));
+
+/** `wicked-crew-api-types@<version> index.d.ts:<from>-<to> …` — the version and 1-based line range a label names. */
+const LABEL = /^wicked-crew-api-types@(\S+) index\.d\.ts:(\d+)-(\d+) /;
 
 const BEGIN = /^\/\/ >>> VERBATIM (.+)$/;
 const END = '// <<< VERBATIM';
@@ -89,6 +95,24 @@ describe('src/api/skills-wire.ts — a byte-for-byte mirror of the 0.34.0 skills
     expect(skills).toContain('revision: number;');
     expect(skills).toContain('expectedRevision: number;');
     expect(skills).toContain("export type SkillVerdict = 'clear' | 'warnings' | 'blocked';");
+  });
+
+  it('every region is ALSO byte-equal to the INSTALLED package at the labelled line range, and the label names the pinned version — a re-vendor from the wrong version, or a pin bump without a re-vendor, fails here', () => {
+    const installed = JSON.parse(readFileSync(INSTALLED_PKG, 'utf8')) as { version: string };
+    const pinned = (JSON.parse(readFileSync(PINNED_PKG, 'utf8')) as { devDependencies: Record<string, string> }).devDependencies['wicked-crew-api-types'];
+    expect(pinned, 'the devDependency is an exact pin').toBe(installed.version);
+    const lines = readFileSync(INSTALLED, 'utf8').split('\n');
+    const fixture = regions(FIXTURE);
+    expect(fixture.length).toBe(2);
+    for (const { label, body } of fixture) {
+      const m = LABEL.exec(label);
+      expect(m, `label names a version and a line range: ${label}`).not.toBeNull();
+      const [, version, from, to] = m!;
+      expect(version, label).toBe(installed.version);
+      const slice = lines.slice(Number(from) - 1, Number(to)).join('\n');
+      // Same bytes as the package studio actually installs — the fixture can never quietly lag a pin bump.
+      expect(body, label).toBe(slice);
+    }
   });
 
   it('0.34.0 is additive: the per-reason portability shape (§5.2) rides SkillEntry as an OPTIONAL field, `portable` stays', () => {

--- a/tests/skillsWire.test.ts
+++ b/tests/skillsWire.test.ts
@@ -1,11 +1,11 @@
 /**
- * The skills wire MIRROR is pinned byte-for-byte to the vendored 0.27.0 contract.
+ * The skills wire MIRROR is pinned byte-for-byte to the vendored 0.34.0 contract.
  *
- * `src/api/skills-wire.ts` carries the skills block of `wicked-crew-api-types@0.27.0` (crew#480 @
- * 4cae105, unpublished) copied VERBATIM between `>>> VERBATIM` / `<<< VERBATIM` markers, and
- * `tests/fixtures/api-types-0.27.0-skills.d.ts` is a byte copy of the same line ranges taken
- * straight from the crew worktree. This test compares every marked region of the two files: a
- * hand edit to the mirror, or a re-vendored fixture from a re-minted contract, fails here until
+ * `src/api/skills-wire.ts` carries the skills block and the `diagnostics.skills` block of
+ * `wicked-crew-api-types@0.34.0` (crew#531) copied VERBATIM between `>>> VERBATIM` / `<<< VERBATIM`
+ * markers, and `tests/fixtures/api-types-0.34.0-skills.d.ts` is a byte copy of the same regions
+ * taken from the package's `index.d.ts`. This test compares every marked region of the two files:
+ * a hand edit to the mirror, or a re-vendored fixture from a re-minted contract, fails here until
  * both agree again — the mirror can never quietly drift from the wire crew serves.
  *
  * Delete this test (and the fixture) at the release swap, when the mirror becomes
@@ -19,7 +19,7 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 const MIRROR = fileURLToPath(new URL('../src/api/skills-wire.ts', import.meta.url));
-const FIXTURE = fileURLToPath(new URL('./fixtures/api-types-0.27.0-skills.d.ts', import.meta.url));
+const FIXTURE = fileURLToPath(new URL('./fixtures/api-types-0.34.0-skills.d.ts', import.meta.url));
 
 const BEGIN = /^\/\/ >>> VERBATIM (.+)$/;
 const END = '// <<< VERBATIM';
@@ -47,10 +47,10 @@ function regions(path: string): Array<{ label: string; body: string }> {
   return out;
 }
 
-describe('src/api/skills-wire.ts — a byte-for-byte mirror of the 0.27.0 skills contract', () => {
+describe('src/api/skills-wire.ts — a byte-for-byte mirror of the 0.34.0 skills contract', () => {
   it('carries the MIRROR header naming the contract, the PR, and the release swap', () => {
     const head = readFileSync(MIRROR, 'utf8').slice(0, 400);
-    expect(head).toContain('MIRROR of wicked-crew-api-types 0.27.0 skills block (crew#480) — replace with imports from the');
+    expect(head).toContain('MIRROR of wicked-crew-api-types 0.34.0 skills block (crew#531) — replace with imports from the');
     expect(head).toContain('published package at release.');
   });
 
@@ -65,14 +65,15 @@ describe('src/api/skills-wire.ts — a byte-for-byte mirror of the 0.27.0 skills
     }
   });
 
-  it('the two regions are the skills block and the diagnostics.skills block of 0.27.0', () => {
+  it('the two regions are the skills block and the diagnostics.skills block of 0.34.0', () => {
     const labels = regions(FIXTURE).map((r) => r.label);
-    expect(labels[0]).toMatch(/^wicked-crew-api-types@0\.27\.0 index\.d\.ts:1322-1685 /);
-    expect(labels[1]).toMatch(/^wicked-crew-api-types@0\.27\.0 index\.d\.ts:3262-3302 /);
+    expect(labels[0]).toMatch(/^wicked-crew-api-types@0\.34\.0 index\.d\.ts.* — the skills block$/);
+    expect(labels[1]).toMatch(/^wicked-crew-api-types@0\.34\.0 index\.d\.ts.* — the diagnostics skills block$/);
     const [skills, diagnostics] = regions(FIXTURE).map((r) => r.body);
     // The declarations studio consumes are all in the block — a re-mint that drops one fails here.
     for (const name of [
       'export type SkillKind', 'export type SkillProvenance', 'export type SkillVerdict', 'export type SkillFindingKind',
+      'export type SkillPortabilityReason', 'export interface SkillPortability',
       'export interface SkillEntry', 'export interface SkillFileRecord', 'export interface SkillPublishedRecord',
       'export interface SkillManifest', 'export interface SkillsManifestResponse', 'export interface SkillFileEntry',
       'export interface SkillFileTree', 'export interface SkillReadResult', 'export interface SkillConflictFinding',
@@ -88,5 +89,20 @@ describe('src/api/skills-wire.ts — a byte-for-byte mirror of the 0.27.0 skills
     expect(skills).toContain('revision: number;');
     expect(skills).toContain('expectedRevision: number;');
     expect(skills).toContain("export type SkillVerdict = 'clear' | 'warnings' | 'blocked';");
+  });
+
+  it('0.34.0 is additive: the per-reason portability shape (§5.2) rides SkillEntry as an OPTIONAL field, `portable` stays', () => {
+    const skills = regions(FIXTURE)[0]!.body;
+    // The six reasons, spelled exactly — studio's badge split keys on these tokens.
+    for (const reason of ['plugin-root', 'skill-dir-var', 'cwd-script', 'relative-link', 'cross-skill-path', 'requires-harness:claude']) {
+      expect(skills, reason).toContain(`'${reason}'`);
+    }
+    expect(skills).toContain('  reasons: SkillPortabilityReason[];');
+    expect(skills).toContain('  evidence?: string[];');
+    // Inside SkillEntry: the admission key first, the optional verdict beside it.
+    const entry = skills.slice(skills.indexOf('export interface SkillEntry {'));
+    const entryBody = entry.slice(0, entry.indexOf('\n}\n') + 3);
+    expect(entryBody).toContain('  portable: boolean;');
+    expect(entryBody).toContain('  portability?: SkillPortability;');
   });
 });


### PR DESCRIPTION
Closes #256

**Status: ready — `wicked-crew-api-types` is pinned to exactly 0.34.0** (published from wicked-crew#532). The mirror in `src/api/skills-wire.ts` and the parity fixture `tests/fixtures/api-types-0.34.0-skills.d.ts` are the package's own bytes (skills block `index.d.ts:1716-2134`, `diagnostics.skills` block `:4106-4155`); the shape studio coded against (§5.2) is exactly what shipped.

## Why

The Skills page showed 77 of 142 skills with one `claude-only` badge and the KPI context "77 claude-only". That lumped "the author used a Claude-only path" (fixable in the skill text) together with "this skill needs the Claude harness" (by design), which hid the fix. api-types 0.34.0 adds the publisher's per-reason verdict, `SkillEntry.portability?: {portable, reasons[], evidence?[]}` (additive; `portable` stays the admission key core reads).

## What changes

1. **Wire mirror + fixture** (`src/api/skills-wire.ts`, `tests/fixtures/api-types-0.34.0-skills.d.ts`, `tests/skillsWire.test.ts`): `SkillPortabilityReason`, `SkillPortability`, `SkillEntry.portability?` per §5.2. The mirror had lagged the installed package (it was still the 0.27.0 worktree block); re-vendoring from the installed 0.32.0 block picks up the 0.29.0 `installer-copy` source kind and the `skills.source` / `skills.manifest` diagnostics findings. The regions are the published 0.34.0 bytes with real line ranges (the provisional labels were replaced at the pin).
2. **Fold** (`src/api/skills.ts`): `skillPortability(entry)` → `{reach: 'portable' | 'not-portable' | 'needs-claude', reasons, evidence, detailed}`. `portable` decides *whether* a badge renders; `portability.reasons` decide *which*: any authoring reason (`plugin-root`, `skill-dir-var`, `cwd-script`, `relative-link`, `cross-skill-path`) → `not-portable`; `requires-harness:claude` alone → `needs-claude`; no field / no reasons → generic `not-portable` (`detailed: false`), never a fabricated reason. An unknown future token is treated as authoring (the honest default). `skillCounts` gains `notPortable` / `needsClaude` with `portable + notPortable + needsClaude === total`.
3. **Badge** (`src/components/SkillChips.tsx`): `PortabilityBadge({portability, portable})` replaces `ClaudeOnlyBadge`. Labels **not portable** (`skills-not-portable-badge`, amber status tokens) / **needs Claude harness** (`skills-needs-claude-badge`, muted). Title = reasons joined + `(first at <file:line>)` + what the exclusion means; the harness case's title is the reason. The wrapper keeps `skills-claude-only-badge` for one release (with `data-reach`); the inner badge carries `data-reasons`, `data-detailed`, `role="note"` and `aria-label` = the title, so the sentence is the accessible name. Older daemons get the previous sentence verbatim (`GENERIC_NOT_PORTABLE_TITLE`).
4. **KPI + chips** (`SkillsPage.tsx`, `SkillsGrid.tsx`): Portable tile context `${notPortable} not portable · ${needsClaude} need Claude harness` (value stays `portable`); chips `not-portable` + `needs-claude` replace `claude-only`.
5. **Drawer** (`SkillDrawer.tsx`): a **Portability** line under the header for non-portable skills — the sentence, every reason with one clause of "why", and every `file:line` anchor as monospace text (`break-all`, wraps at phone width). Nothing renders for a portable skill.
6. Tests, `testid-inventory.json` (six new static testids), CHANGELOG under Unreleased. No version bump.

Only semantic theme tokens are used (both themes define them; the raw-color lint is the guard).

## Tests

- `tests/skillsApi.test.ts`: counts split; the exhaustive-reach identity with and without the field; `skillPortability` cases (portable / authoring / harness-alone / older daemon / empty reasons); the chips partition the catalog and `claude-only` is gone.
- `tests/SkillsPage.test.tsx`: the badge split in the catalog; reason-hover title (reasons + first anchor, and it is the accessible name); `needs-claude` badge + KPI context + chip doors; older-manifest fallback (generic sentence, counted as not portable); the drawer Portability line with reasons + anchors; no line for a portable skill.
- `tests/skillsWire.test.ts`: the 0.34.0 additive shape (six reason tokens, optional `portability` beside `portable`).
- Playwright: skipped, the `e2e/` suites have no Skills-page loopback fixture (browsers untouched).

Gates (local): `npm run typecheck`, `npm run lint`, `npm test` (260 files / 2846 tests), `npm run build` — all green.

## Out of scope / owned elsewhere

Files owned by #255 (`DeliverLift`, `GateVerdict`, `RightPanel`, `RunDelivery`, `RunTimeline`, `SteeringGate`, `WhatWhere`, their models and tests) are untouched.

## Follow-up (visual check on a loopback rig)

Screenshotted the built `dist/` over a same-origin stub of `GET /api/v1/skills` (four skills: authoring reasons, harness-only, portable, and an older-daemon row with no `portability`) in Chromium at 1440×700 and 400 px, both themes; no horizontal overflow anywhere. Three things fixed from looking, not measuring:

- the Portable tile's context ellipsized at desktop width (the Reach group was half the width of the two-tile groups) → `grow={2}` + a full-sentence `title` on the tile;
- the light theme keeps `--status-gate` pale, so amber-on-amber text was hard to read → the badge and the drawer label use `--ink-high` ink on the `--status-gate-dim` fill with a `--status-gate` border;
- at 400 px the verbs row squeezed the intro to a word per line → the header and the verbs container wrap.

## Rebased onto main after #255 merged (5c9c9e4)

Conflicts were the two shared artifacts only: CHANGELOG `[Unreleased]` (both sections kept — #255's `### Added`, this PR's `### Changed`) and `testid-inventory.json` (regenerated with `npm run manifest:testids` from the rebased `src/`, so it carries both sides). `node_modules` now follows main's `wicked-crew-api-types` 0.33.0 pin; the four gates are green on the rebased head (267 files / 2944 tests). None of #255's files are touched here.

## Review follow-through (independent APPROVE @ 6d53f2d, five LOW/INFO items landed in one commit)

- **F-1** a `portability` verdict that disagrees with `portable` (portable:true with reasons; `portability.portable ≠ portable`; portable:false with no reasons) is now named by `skillPortability().contradiction` and surfaced as `data-contradiction` on the row and the badge wrapper plus a `role=note` hint line in the drawer ("daemon reported inconsistent portability: …"). No console noise; the badge still follows `portable` (the admission key core reads). Tests: unit cases for each disagreement, and three page tests (portable-with-reasons, flags-disagree, consistent catalog carries nothing).
- **F-2** the mixed-case hover (authoring + `requires-harness:claude`) now says both: "fix the skill text; it also needs the Claude harness, so it stays excluded … after the fix" (test pins the three sentences).
- **F-3** evidence anchors are keyed by position + anchor (one anchor per hit; two hits on one line share a `file:line`).
- **F-4** `tests/skillsWire.test.ts` also compares every fixture region byte-for-byte against the **installed** `node_modules/wicked-crew-api-types/index.d.ts` at the labelled line range, and checks the label's version against the exact pin — a pin bump without a re-vendor, or a re-vendor from the wrong version, fails.
- **F-5** `SkillFindings` wears a `non-portable` finding's `portabilityReason` (0.34.0) as a chip whose hover is the reason's copy; null-safe, absent on other kinds (blocked-Publish test extended).

Inventory regenerated (+`skills-drawer-portability-hint`, +`skills-finding-reason`); one CHANGELOG clause; no version bump. Gates green locally (267 files / 2950 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
