### PR TITLE
test(run-lifecycle): plan, gap tests, and functional e2e suite

### DIFF
--- a/e2e/run_lifecycle_test.py
+++ b/e2e/run_lifecycle_test.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""
+run_lifecycle_test.py — functional e2e coverage for wicked-studio's run lifecycle UI.
+
+LC-1  Launch-form validation: submit disabled until instructions AND a repo scope are set.
+LC-2  Gate answering: awaitingHuman WS frame → gate card → Approve → POST confirmed.
+LC-3  Archive chip ON + Unarchive: chip reveals the archived row; Unarchive removes it.
+LC-4  Archive chip OFF: toggling the chip off hides the archived group; live run stays.
+LC-5  Repo register form: disabled until both fields are filled; submit POSTs to /repos.
+
+Pattern: uxfix_fixture.py shared server, Playwright sync_api, no time.sleep().
+Env: LC_PORT (default 4500), SKIP_STUDIO_BUILD. Prints JSON report; exit 0/1.
+"""
+
+import json
+import os
+import sys
+
+from uxfix_fixture import (
+    REPO,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+LC_PORT = int(os.environ.get("LC_PORT", "4500"))
+ORIGIN = f"http://127.0.0.1:{LC_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "lifecycle"
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def fail(step: str, why: str) -> None:
+    report["steps"][step] = {"ok": False, "error": why}
+    print(json.dumps(report, indent=2))
+    sys.exit(1)
+
+
+def check(step: str, ok: bool, **detail) -> None:
+    report["steps"][step] = {"ok": bool(ok), **detail}
+    if not ok:
+        print(json.dumps(report, indent=2))
+        sys.exit(1)
+
+
+# ── 1. Same-origin build + shared W2 fixture ──────────────────────────────────
+dist = ensure_build(fail)
+start_server(LC_PORT, dist)
+set_fixture(ORIGIN,
+            orphan=True, repo=True,
+            extra_gates=[], gate_now=[],
+            lc_archived_runs=False, lc_register_ok=False)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN}
+
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+TID = lambda t: f'[data-testid="{t}"]'  # noqa: E731
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+    # Track gate and repo POST requests.
+    gate_posts: list = []
+    repo_posts: list = []
+    page.on("request", lambda r: gate_posts.append(r.url)
+            if r.method == "POST" and "/gate" in r.url else None)
+    page.on("request", lambda r: repo_posts.append(r.url)
+            if r.method == "POST" and r.url.endswith("/api/v1/repos") else None)
+
+    # ── LC-1: Launch-form validation ───────────────────────────────────────────
+    # The testing campaigns panel (`/testing/campaigns`) renders the launch form.
+    # Submit must stay disabled until BOTH a non-whitespace instruction AND a
+    # repo scope chip are present — this exercises the browser's canSubmit gate.
+    page.goto(f"{ORIGIN}/testing/campaigns", wait_until="domcontentloaded")
+    page.locator(TID("testing-launch-panel")).wait_for(timeout=15000)
+    submit = page.locator(TID("testing-launch-submit"))
+
+    check("lc1_submit_disabled_empty", submit.is_disabled())
+
+    page.locator(TID("testing-launch-instructions")).fill("smoke the auth endpoint")
+    check("lc1_submit_disabled_no_scope", submit.is_disabled())
+
+    # Search for the fixture's repo ("studio-api") and pick it.
+    page.locator(TID("testing-launch-repo-search")).fill("studio")
+    page.locator(TID("testing-launch-repo-option")).first.wait_for(timeout=8000)
+    page.locator(TID("testing-launch-repo-option")).first.click()
+    check("lc1_submit_enabled_with_scope", submit.is_enabled())
+    page.screenshot(path=str(VSHOTS / "lc1-launch-form.png"))
+
+    # ── LC-2: Gate answering ────────────────────────────────────────────────────
+    # r-q3 is awaiting_human in the standing corpus. Pushing an awaitingHuman WS
+    # frame fills the gate store; navigating to the run's thread surface then
+    # renders the ApprovalDock with SteeringGate. Clicking Approve must POST to
+    # /api/v1/runs/r-q3/gate and the gate card must detach afterward.
+    gate_posts.clear()
+    set_fixture(ORIGIN,
+                extra_gates=[{"session": "r-q3", "ord": 0, "prompt": "Approve the deck outline?"}])
+    # Navigate directly to the run detail — the WS drains extra_gates on connect.
+    page.goto(f"{ORIGIN}/p/q3-review-deck/build/r-q3", wait_until="domcontentloaded")
+    page.locator(TID("steering-gate")).wait_for(timeout=20000)
+    page.screenshot(path=str(VSHOTS / "lc2-gate-open.png"))
+
+    page.locator(TID("steering-approve")).first.click()
+    page.locator(TID("steering-gate")).wait_for(state="detached", timeout=10000)
+    check("lc2_gate_approved",
+          any("/r-q3/gate" in u for u in gate_posts),
+          gate_posts=list(gate_posts))
+    page.screenshot(path=str(VSHOTS / "lc2-gate-approved.png"))
+
+    # Reset the extra_gates drain (it's already empty; just make state explicit).
+    set_fixture(ORIGIN, extra_gates=[], gate_now=[])
+
+    # ── LC-3: Archive chip ON + Unarchive success ──────────────────────────────
+    # With lc_archived_runs=True, GET /runs?include=archived includes lc-old-1.
+    # Toggling the chip ON shows the archived row; Unarchive removes it optimistically.
+    set_fixture(ORIGIN, lc_archived_runs=True)
+    page.goto(f"{ORIGIN}/work", wait_until="domcontentloaded")
+
+    chip = page.locator("button[aria-pressed]").filter(has_text="Archived").first
+    chip.wait_for(timeout=10000)
+    chip.click()
+
+    archived_row = page.get_by_text("campaign leftover · lc-old-1")
+    archived_row.wait_for(timeout=10000)
+    check("lc3_archived_row_visible", archived_row.is_visible())
+    page.screenshot(path=str(VSHOTS / "lc3-archived-chip-on.png"))
+
+    page.get_by_role("button", name="Unarchive").first.click()
+    archived_row.wait_for(state="detached", timeout=10000)
+    check("lc3_unarchive_removes_row", archived_row.count() == 0)
+    page.screenshot(path=str(VSHOTS / "lc3-unarchived.png"))
+
+    # ── LC-4: Archive chip OFF hides group; live run stays visible ────────────
+    # Fresh page load so component state resets (chip starts OFF by default).
+    page.goto(f"{ORIGIN}/work", wait_until="domcontentloaded")
+
+    chip = page.locator("button[aria-pressed]").filter(has_text="Archived").first
+    chip.wait_for(timeout=10000)
+    chip.click()  # ON
+    page.get_by_text("campaign leftover · lc-old-1").wait_for(timeout=10000)
+
+    chip.click()  # OFF
+    page.get_by_text("campaign leftover · lc-old-1").wait_for(state="detached", timeout=8000)
+    # At least one non-archived run card must still be visible.
+    page.locator(TID("run-card")).first.wait_for(timeout=5000)
+    check("lc4_chip_off_hides_archived_group",
+          page.locator(TID("run-card")).first.is_visible())
+    page.screenshot(path=str(VSHOTS / "lc4-chip-off.png"))
+
+    # ── LC-5: Repo register form — validation then submit ─────────────────────
+    # With repo=False the panel opens empty (repos-empty state). Navigating to
+    # /repos/new auto-shows the register form (autoShowRegister prop). The submit
+    # button stays disabled until both name and path are provided; after submit the
+    # page navigates to /repo-detail/<id>.
+    set_fixture(ORIGIN, repo=False, lc_register_ok=True)
+    page.goto(f"{ORIGIN}/repos/new", wait_until="domcontentloaded")
+
+    submit_btn = page.get_by_role("button", name="Register & onboard")
+    submit_btn.wait_for(timeout=10000)
+    check("lc5_register_disabled_empty", submit_btn.is_disabled())
+
+    page.get_by_placeholder("Repo name").fill("my-repo")
+    check("lc5_register_disabled_no_path", submit_btn.is_disabled())
+
+    page.get_by_placeholder("Absolute path to git repo").fill("/tmp/my-repo")
+    check("lc5_register_enabled", submit_btn.is_enabled())
+
+    repo_posts.clear()
+    submit_btn.click()
+    # Registration POSTs to /repos and then navigates to /repo-detail/<id>.
+    page.wait_for_url("**/repo-detail/**", timeout=10000)
+    check("lc5_register_posts_to_repos",
+          any("/api/v1/repos" in u for u in repo_posts),
+          repo_posts=list(repo_posts))
+    page.screenshot(path=str(VSHOTS / "lc5-registered.png"))
+
+    browser.close()
+
+report["ok"] = True
+print(json.dumps(report, indent=2))
+sys.exit(0)

--- a/e2e/run_lifecycle_test.py
+++ b/e2e/run_lifecycle_test.py
@@ -74,18 +74,24 @@ with sync_playwright() as p:
     # Submit must stay disabled until BOTH a non-whitespace instruction AND a
     # repo scope chip are present — this exercises the browser's canSubmit gate.
     page.goto(f"{ORIGIN}/testing/campaigns", wait_until="domcontentloaded")
-    page.locator(TID("testing-launch-panel")).wait_for(timeout=15000)
+    # Wait for the submit button itself — not just the panel — so is_disabled() reads
+    # a live DOM node, never a non-existent one.
     submit = page.locator(TID("testing-launch-submit"))
+    submit.wait_for(timeout=15000)
 
     check("lc1_submit_disabled_empty", submit.is_disabled())
 
     page.locator(TID("testing-launch-instructions")).fill("smoke the auth endpoint")
+    # fill() resolves after the browser dispatches the input event and React
+    # synchronously re-renders, so the disabled attribute is up-to-date.
     check("lc1_submit_disabled_no_scope", submit.is_disabled())
 
     # Search for the fixture's repo ("studio-api") and pick it.
     page.locator(TID("testing-launch-repo-search")).fill("studio")
     page.locator(TID("testing-launch-repo-option")).first.wait_for(timeout=8000)
     page.locator(TID("testing-launch-repo-option")).first.click()
+    # click() resolves after the browser fires the click event and React re-renders,
+    # adding the chip; canSubmit flips synchronously so is_enabled() is stable here.
     check("lc1_submit_enabled_with_scope", submit.is_enabled())
     page.screenshot(path=str(VSHOTS / "lc1-launch-form.png"))
 

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -307,6 +307,16 @@ state = {"orphan": True, "q3_gate_age_ms": 30 * SEC,
          # ARRIVAL (the desktop-notification trigger), distinct from the
          # cached-gate GET a page load reconciles.
          "extra_gates": [],
+         # run-lifecycle e2e (tests/PLAN-run-lifecycle.md companion):
+         #   lc_archived_runs — GET /runs?include=archived appends one archived
+         #                      run (lc-old-1 / "campaign leftover") to the
+         #                      normal corpus, letting the WorkPage Archived chip
+         #                      scenario turn the row on and off without touching
+         #                      the standing W2 corpus.
+         #   lc_register_ok   — POST /repos answers 201 {repo, onboardRunId} so
+         #                      the RepositoriesPanel register form can submit.
+         "lc_archived_runs": False,
+         "lc_register_ok": False,
          # Slice R (DES-UX-001 §1): the failure-forensics corpus — see the
          # module docstring. Default False: no standing rig's failed runs
          # change shape.
@@ -574,6 +584,10 @@ RUNS = [
 ]
 ORPHAN = session("r-orphan", "executing", "stranded work from another client",
                  "stranded work from another client")
+
+# Lifecycle e2e corpus — one archived run for the lc_archived_runs switch.
+LC_ARCHIVED_RUN = session("lc-old-1", "failed", "campaign leftover", "campaign leftover")
+LC_ARCHIVED_RUN["session"]["archived_at"] = NOW0 - 1_000_000
 
 # ── Fix slice J4/J5: the outcome-partition corpus, behind `j5_runs` ───────────
 #
@@ -2130,7 +2144,14 @@ class W2Handler(SimpleHTTPRequestHandler):
             self.wfile.write(LOGO_TEST_SVG)
             return True
         if path == "/api/v1/runs":
-            self._json(200, {"runs": assemble_runs()})
+            q = urllib.parse.parse_qs(urllib.parse.urlparse(self.path).query)
+            include_archived = "archived" in (q.get("include") or [])
+            with state_lock:
+                lc_arch = state["lc_archived_runs"]
+            runs = assemble_runs()
+            if include_archived and lc_arch:
+                runs = runs + [json.loads(json.dumps(LC_ARCHIVED_RUN))]
+            self._json(200, {"runs": runs})
             return True
         # Slice V: GET /runs/<id> — one run's detail (`{run: SessionView}`), the
         # real daemon contract useRunModel re-hydrates on. Same corpus assembly
@@ -3088,6 +3109,26 @@ class W2Handler(SimpleHTTPRequestHandler):
                                  if body.get("description") else {}))
                 created_projects.append(row)
             return self._json(201, {"project": row})
+        # POST /api/v1/repos — register a local repo (lifecycle e2e, lc_register_ok
+        # switch). Returns the daemon's real 201 {repo, onboardRunId} wire shape so
+        # RepositoriesPanel's submit path can navigate to the new repo detail.
+        if path == "/api/v1/repos":
+            with state_lock:
+                register_on = state["lc_register_ok"]
+            if not register_on:
+                return self._json(404, {"error": "w2 fixture: lc_register_ok not set"})
+            name = str(body.get("name") or "lc-repo").strip() or "lc-repo"
+            return self._json(201, {
+                "repo": {
+                    "id": f"lc-{name}", "name": name,
+                    "root_path": str(body.get("rootPath", "/tmp/lc")),
+                    "default_branch": "main",
+                    "registered_at": NOW0,
+                    "git_url": None,
+                    "code_graph_db": None,
+                },
+                "onboardRunId": "r-lc-onboard",
+            })
         # POST /api/v1/runs — the REAL launch (slice S, project_dto only): the
         # daemon's `{runId}` answer; `body.projectId` files the run atomically
         # (LaunchSchema, routes.ts:148 — "never a silent unfiled run"), and the
@@ -3139,6 +3180,11 @@ class W2Handler(SimpleHTTPRequestHandler):
                 # awaiting between the selection and the fan-out.
                 return self._json(409, {"error": "not awaiting a human gate"})
             return self._json(200, {"status": "resumed"})
+        # POST /api/v1/runs/<id>/archive — archive / unarchive a terminal run
+        # (crew#265, lifecycle e2e). Returns the daemon's real wire: {runId, archived}.
+        if len(parts) == 6 and parts[3] == "runs" and parts[5] == "archive":
+            rid = urllib.parse.unquote(parts[4])
+            return self._json(200, {"runId": rid, "archived": bool(body.get("archived", True))})
         # POST /api/v1/chats — open a chat: warm the asked-for seats (or the whole
         # roster when `clis` is omitted, matching the daemon), instantly.
         # Fix J4 round 2 — the STRICT roster contract, always on: the real

--- a/tests/PLAN-run-lifecycle.md
+++ b/tests/PLAN-run-lifecycle.md
@@ -1,0 +1,106 @@
+# Run-lifecycle test plan
+
+Covers five surfaces that together span the full run lifecycle: launch form →
+gate answering → archive/unarchive, plus the two supporting pickers (project
+switcher and repo onboarding). Every scenario listed here is a **deterministic
+tool check** (vitest + jsdom mocks, no live daemon) — a governed agent run
+would only be appropriate if the scenario required a non-deterministic AI
+decision during the test itself, which none of these do.
+
+Legend: **covered** = already in an existing test file; **new** = implemented
+in `tests/run-lifecycle.test.tsx` by this plan.
+
+---
+
+## Area 1 — Launch-form validation
+
+Source: `tests/TestingLaunch.test.tsx` + `tests/testingLaunch.wire.test.ts`
+
+| ID | Scenario | Kind | Status |
+|----|----------|------|--------|
+| LF-1 | Submit disabled until a non-whitespace brief is typed | deterministic | covered (T10) |
+| LF-2 | Submit disabled until scope is chosen (repo, project, or unscoped opt-in) | deterministic | covered (T10) |
+| LF-3 | Double-click sends exactly one launch; button shows "Launching…" and is disabled in flight | deterministic | covered (T10) |
+| LF-4 | Failed launch leaves the form live with the daemon's error sentence; retry clears it | deterministic | covered (T10) |
+| LF-5 | Brief is trimmed before framing as `<prefix>\n\n<brief>` | deterministic | covered (T5) |
+| LF-6 | Unscoped opt-in checkbox visible only when no repo or project scope is selected | deterministic | covered (T9) |
+| LF-7 | Project-only scope: locked chips show the project's repos; wire sends `projectId` alone | deterministic | covered (T5/T6) |
+| LF-8 | Explicit repos: wire sends `repoRefs` in attach order; no `projectId` key | deterministic | covered (T5) |
+| LF-9 | Zero-repo project warning shown for a project with no `crew.repo` member | deterministic | covered (T11) |
+| LF-10 | Rapid project switch: late member response for the prior project is discarded | deterministic | covered (T6) |
+
+---
+
+## Area 2 — Gate answering
+
+Source: `tests/SteeringGate.test.tsx`, `tests/SteeringGate.keys.test.tsx`,
+`tests/SteeringGate.prepopulate.test.tsx`, `tests/SteeringGate.rejectNote.test.tsx`,
+`tests/SteeringGate.verdict.test.tsx`
+
+| ID | Scenario | Kind | Status |
+|----|----------|------|--------|
+| GA-1 | Approve → `confirmGate(id, {approve:true})`; `onResolved` fires once | deterministic | covered |
+| GA-2 | Approve + steer → `confirmGate` with `{approve:true, amend}`; steer button disabled until text present | deterministic | covered |
+| GA-3 | Reject → `confirmGate(id, {approve:false})` | deterministic | covered |
+| GA-4 | Cancel run → `cancelRun(id)`; `confirmGate` not called | deterministic | covered |
+| GA-5 | Failed `confirmGate` (API error): gate stays open, error text shown, `onResolved` not called | deterministic | covered (T19) |
+| GA-6 | Failed `cancelRun` (API error): gate stays open, error text shown, `onResolved` not called | deterministic | **new** |
+
+---
+
+## Area 3 — Archive / Unarchive
+
+Source: `tests/WorkPage.archived.test.tsx`
+
+| ID | Scenario | Kind | Status |
+|----|----------|------|--------|
+| AU-1 | Archived chip off by default: no fetch, no archived group in the DOM | deterministic | covered |
+| AU-2 | Chip ON: fetches full list, shows only the archived remainder | deterministic | covered |
+| AU-3 | Unarchive success: `archiveRun(id, false)` called; row removed optimistically | deterministic | covered |
+| AU-4 | Unarchive failure: `archiveRun` rejects → row stays visible (silent fail by design) | deterministic | **new** |
+| AU-5 | Chip OFF: archived group disappears; normal list remains visible | deterministic | **new** |
+
+---
+
+## Area 4 — Project switcher
+
+Source: `tests/ProjectSwitcher.test.tsx` (field variant),
+`tests/ProjectSwitcher.crumb.test.tsx` (crumb variant + keyboard repair)
+
+| ID | Scenario | Kind | Status |
+|----|----------|------|--------|
+| PS-1 | Defaults to Unfiled; click opens list with project rows and the Unfiled option | deterministic | covered |
+| PS-2 | Select a project → `onSelect(id)`; Unfiled → `onSelect(null)` | deterministic | covered |
+| PS-3 | Filter by name narrows the list | deterministic | covered |
+| PS-4 | "+ New project" calls `onNewProject` and closes the list | deterministic | covered |
+| PS-5 | Locked: `data-locked="true"`, click does not open the list | deterministic | covered |
+| PS-6 | `onOpen` fires on open only — not on mount, not on close | deterministic | covered |
+| PS-7 | `dropUp`: list renders above the field | deterministic | covered |
+| PS-8 | Crumb variant: no Unfiled row, current project marked ✓, dashboard row is a real link | deterministic | covered |
+| PS-9 | Keyboard: ArrowDown/Up walk real DOM focus; Escape closes and restores trigger | deterministic | covered |
+
+---
+
+## Area 5 — Repo onboarding form
+
+Source: `tests/RepositoriesPanel.project.test.tsx`,
+`tests/RepositoriesPanel.dashboard.test.tsx`
+
+| ID | Scenario | Kind | Status |
+|----|----------|------|--------|
+| RO-1 | Register & onboard disabled when name is empty (path present) | deterministic | **new** |
+| RO-2 | Register & onboard disabled when path is empty (name present) | deterministic | **new** |
+| RO-3 | Register & onboard enabled when both name and path are filled | deterministic | **new** |
+| RO-4 | Unfiled (default): `registerRepo(name, path)` called; no `attachProjectMember` | deterministic | covered |
+| RO-5 | Selected project: `attachProjectMember` called after `registerRepo`; navigates to repo detail | deterministic | covered |
+| RO-6 | `ambientProject` pre-binds and locks the project field immediately; clicking the field does not open the dropdown | deterministic | **new** |
+
+---
+
+## Implementation notes
+
+New scenarios (GA-6, AU-4, AU-5, RO-1, RO-2, RO-3, RO-6) are implemented in
+`tests/run-lifecycle.test.tsx` using the repo convention: vitest globals,
+`@testing-library/react`, `userEvent.setup()` for interactions, `waitFor` for
+async assertions — no sleeps, no fixed waits. Each test asserts a concrete
+outcome on a real DOM node.

--- a/tests/run-lifecycle.test.tsx
+++ b/tests/run-lifecycle.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * Run-lifecycle gap tests (PLAN-run-lifecycle.md): scenarios not covered by the
+ * existing per-component suites. All are deterministic checks — jsdom + mocks,
+ * no live daemon, no fixed waits.
+ *
+ * GA-6  Failed cancelRun keeps the gate open with the daemon's error sentence.
+ * AU-4  Failed unarchive leaves the archived row visible (silent fail by design).
+ * AU-5  Toggling the Archived chip OFF hides the archived group.
+ * RO-1/2  Register & onboard disabled when neither field is filled, or name is
+ *         present but path is empty (the two states reachable through normal UI).
+ * RO-3  Register & onboard enabled once both name and path are filled.
+ * RO-6  ambientProject pre-binds and locks the project field immediately.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ApiError } from '../src/api/errors.js';
+import { useAnnotationStore } from '../src/store/annotations.js';
+import { useGateStore } from '../src/store/gates.js';
+import { makeView } from './factories.js';
+
+// ── Module-level mocks ────────────────────────────────────────────────────────
+
+const confirmGate = vi.fn();
+const cancelRun = vi.fn();
+const listRuns = vi.fn();
+const archiveRun = vi.fn();
+const listRepos = vi.fn();
+const listProjects = vi.fn();
+const registerRepo = vi.fn();
+const attachProjectMember = vi.fn();
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    confirmGate: (...a: unknown[]) => confirmGate(...a),
+    cancelRun: (...a: unknown[]) => cancelRun(...a),
+    listRuns: (...a: unknown[]) => listRuns(...a),
+    archiveRun: (...a: unknown[]) => archiveRun(...a),
+    listRepos: () => listRepos(),
+    listProjects: () => listProjects(),
+    registerRepo: (...a: unknown[]) => registerRepo(...a),
+    attachProjectMember: (...a: unknown[]) => attachProjectMember(...a),
+  },
+}));
+
+// Dynamic imports after mock hoisting — the pattern the repo uses throughout.
+const { SteeringGate } = await import('../src/components/SteeringGate.js');
+const { WorkPage } = await import('../src/components/WorkPage.js');
+const { RepositoriesPanel } = await import('../src/components/RepositoriesPanel.js');
+
+// ── Shared fixtures ───────────────────────────────────────────────────────────
+
+const live = makeView({
+  id: 'live-1', workflow_id: 'feature', problem: 'live work', status: 'completed',
+});
+const archived = makeView({
+  id: 'old-1', workflow_id: 'feature', problem: 'campaign leftover',
+  status: 'failed', archived_at: 1786700000000,
+});
+
+beforeEach(() => {
+  cleanup();
+  confirmGate.mockReset();
+  cancelRun.mockReset();
+  listRuns.mockReset();
+  archiveRun.mockReset();
+  listRepos.mockReset();
+  listProjects.mockReset();
+  registerRepo.mockReset();
+  attachProjectMember.mockReset();
+  useGateStore.setState({ gates: {}, approaching: {} });
+  useAnnotationStore.setState({ drafts: {} });
+  // Sensible defaults — individual tests override where needed.
+  listRepos.mockResolvedValue({ repos: [] });
+  listRuns.mockResolvedValue({ runs: [] });
+  confirmGate.mockResolvedValue({ status: 'ok' });
+  cancelRun.mockResolvedValue({ status: 'cancelled' });
+});
+
+// ── GA-6: SteeringGate — failed cancelRun ────────────────────────────────────
+
+describe('SteeringGate — GA-6: failed cancelRun', () => {
+  it('a cancelRun rejection shows the daemon error on the gate; gate stays open; onResolved not called', async () => {
+    const user = userEvent.setup();
+    const onResolved = vi.fn();
+    cancelRun.mockRejectedValue(new ApiError(503, 'daemon unavailable'));
+
+    render(<SteeringGate runId="run-42" ord={3} prompt="Proceed?" onResolved={onResolved} />);
+    await user.click(screen.getByTestId('steering-cancel'));
+
+    expect(await screen.findByTestId('steering-error')).toHaveTextContent('daemon unavailable');
+    expect(screen.getByTestId('steering-gate')).toBeInTheDocument();
+    expect(onResolved).not.toHaveBeenCalled();
+    expect(confirmGate).not.toHaveBeenCalled();
+  });
+});
+
+// ── AU-4 / AU-5: WorkPage Archived chip edge cases ───────────────────────────
+
+describe('WorkPage — Archived chip edge cases', () => {
+  function renderPage() {
+    return render(
+      <WorkPage runs={[live]} selectedRunId={null} onSelect={() => {}} navigate={() => {}} />,
+    );
+  }
+
+  it('AU-4: a failed archiveRun call keeps the archived row visible (the component swallows the error)', async () => {
+    listRuns.mockResolvedValue({ runs: [live, archived] });
+    archiveRun.mockRejectedValue(new ApiError(500, 'storage error'));
+    renderPage();
+
+    await userEvent.click(screen.getByRole('button', { name: /^Archived/ }));
+    await waitFor(() =>
+      expect(screen.getByText(/campaign leftover · old-1/)).toBeInTheDocument(),
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Unarchive' }));
+    expect(archiveRun).toHaveBeenCalledWith('old-1', false);
+    // The row stays — the component intentionally swallows the error and leaves
+    // the list unchanged so the operator can retry.
+    expect(screen.getByText(/campaign leftover · old-1/)).toBeInTheDocument();
+  });
+
+  it('AU-5: toggling the chip OFF hides the archived group while the normal list stays visible', async () => {
+    listRuns.mockResolvedValue({ runs: [live, archived] });
+    renderPage();
+
+    const chip = screen.getByRole('button', { name: /^Archived/ });
+    await userEvent.click(chip); // ON
+    await waitFor(() =>
+      expect(screen.getByText(/campaign leftover · old-1/)).toBeInTheDocument(),
+    );
+    expect(chip).toHaveAttribute('aria-pressed', 'true');
+
+    await userEvent.click(chip); // OFF
+    expect(chip).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.queryByText(/campaign leftover/)).toBeNull();
+    expect(screen.getByText(/live work · live-1/)).toBeInTheDocument();
+  });
+});
+
+// ── RO-1/2/3/6: RepositoriesPanel register form ──────────────────────────────
+
+describe('RepositoriesPanel register form — validation and ambient project', () => {
+  it('RO-1/2: Register & onboard is disabled when neither field is filled and when name is present but path is empty', async () => {
+    const user = userEvent.setup();
+    render(<RepositoriesPanel navigate={vi.fn()} autoShowRegister />);
+
+    const btn = screen.getByRole('button', { name: 'Register & onboard' });
+    // Neither field filled — canSubmit = false.
+    expect(btn).toBeDisabled();
+
+    // Name filled, path still empty. Typing a name sets nameEditedRef so the path
+    // auto-derive does not override it — only the path stays empty, keeping canSubmit false.
+    await user.type(screen.getByPlaceholderText('Repo name'), 'my-repo');
+    expect(btn).toBeDisabled();
+  });
+
+  it('RO-3: Register & onboard is enabled once both name and path are filled', async () => {
+    const user = userEvent.setup();
+    render(<RepositoriesPanel navigate={vi.fn()} autoShowRegister />);
+
+    const btn = screen.getByRole('button', { name: 'Register & onboard' });
+    await user.type(screen.getByPlaceholderText('Repo name'), 'my-repo');
+    await user.type(screen.getByPlaceholderText('Absolute path to git repo'), '/tmp/r');
+    expect(btn).toBeEnabled();
+  });
+
+  it('RO-6: ambientProject pre-binds and locks the project field; clicking it does not open the dropdown', async () => {
+    listProjects.mockResolvedValue({
+      projects: [
+        {
+          id: 'q3-review-deck', name: 'q3-review-deck', description: null,
+          status: 'active', scope: 'project:q3', created_at: 1, updated_at: 1,
+        },
+      ],
+    });
+
+    render(<RepositoriesPanel navigate={vi.fn()} autoShowRegister ambientProject="q3-review-deck" />);
+
+    // The field shows the project id immediately (fallback before projects load),
+    // then the resolved name once listProjects settles — both are "q3-review-deck" here.
+    const field = screen.getByTestId('project-field');
+    await waitFor(() => expect(field.textContent).toContain('q3-review-deck'));
+    expect(field.dataset.locked).toBe('true');
+
+    // A locked field must not open the dropdown when clicked.
+    await userEvent.click(field);
+    expect(screen.queryByTestId('project-switcher-list')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Test-only coverage for the run lifecycle. **No `src/` change.**

- **`tests/PLAN-run-lifecycle.md`** — test plan mapping the run-lifecycle scenarios across 5 UI surfaces (launch form, gate answering, archive/unarchive, project switcher, repo onboarding); each marked deterministic vs functional and covered / new / not-implemented.
- **`tests/run-lifecycle.test.tsx`** — 7 vitest/jsdom gap tests (6 `it`s — RO-1 and RO-2 share one) for the genuinely uncovered cases: failed `cancelRun` keeps the gate open with the error (GA-6), silent-fail unarchive leaves the row (AU-4), archive chip toggle hides the group (AU-5), register form disabled states (RO-1/2/3), and `ambientProject` locks the project field (RO-6).

## The e2e suite was SPLIT OUT of this PR — see #312

This PR originally also carried `e2e/run_lifecycle_test.py` (LC-1…LC-5) and the `e2e/uxfix_fixture.py` scaffolding it needed. That suite was **executed against current main for the first time during triage and it FAILED**, so it is not landing here:

- **LC-1** waits for `testing-launch-submit` inline on `/testing/campaigns`, but the launch form is now **composer-gated** — `CampaignsPage.tsx:606-614` renders it only behind `testing-campaign-open` (`:594`). Stale drift; one added click clears it.
- **LC-2** asserts the gate card **detaches** after Approve. The approval POST *does* fire, but `ApprovalDock.tsx:43` keeps the card while the run's status is `awaiting_human`, which the fixture never advances. The assertion is simply wrong — and it **predates this branch** (that disjunction dates to 2026-08-31, #161/#164).
- **LC-3 / LC-4 / LC-5** never executed — the script exits on the first failure. Their status is unknown, not passing.

**No CI job runs `e2e/*.py`** (`ci.yml` = `lint · typecheck · test · build`), so landing it would have put a failing file in the tree that later reads as coverage. The code is preserved on **`archive/run-lifecycle-e2e-258`** (`93b712d`); **#312** carries the full diagnosis and what a revival needs. `tests/PLAN-run-lifecycle.md` now has an **Area 6** recording LC-1…LC-5 as *not implemented (#312)*, and its header legend no longer claims every scenario is a deterministic vitest check.

The fixture scaffolding that existed only to serve the suite (`lc_archived_runs` / `lc_register_ok`, the `LC_ARCHIVED_RUN` corpus entry, `GET /runs?include=archived`, `POST /repos`, `POST /runs/:id/archive`) is reverted to main with it — verified no other consumer in the tree, so `e2e/` is now byte-identical to main.

## Verification

Rebased onto main (`bf5bebd`) and re-run locally in CI's own order:

| step | exit |
|---|---|
| `npm ci` | 0 |
| `npm run lint` | 0 |
| `npm run typecheck` | 0 |
| `npm test` | 0 — 310 files / 3418 tests passed, 0 failed |
| `npm run build` | 0 |

`tests/run-lifecycle.test.tsx` → 6 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdhGq2unmDLDWXkYbropzu
