### PR TITLE
fix(document): per-format export readiness, folded heartbeats, reload restore, a human floor-failure card, a name field before Create (F-4R2-016/-005/-006/-014/-003)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,50 @@ npm publish dates. Every version listed here exists on
 [npm](https://www.npmjs.com/package/wicked-studio?activeTab=versions).
 
 ## [Unreleased]
+### Fixed
+- **Document thread hardening** (phase4-r2 acceptance findings F-4R2-003 / -005 / -006 / -014 / -016).
+  - *Export bar — readiness per format* (F-4R2-016): `ExportMenu` looked up the FIRST ready answer for
+    the version, so an un-consumed HTML download shadowed the PDF that finished after it — the PDF
+    button spun for 120 s while the file already sat in the thread. Each format button now asks for
+    its own (version, format) answer and flips the moment its own reply lands. The bridge's additive
+    layout report (wicked-interactive#219: `layout`, `layout_source`, `page_size`, `pages`) is read
+    null-safely off the export response AND the `export.generated` echo and rendered where present —
+    "PDF ready — 2 pages · A4 portrait" under the row, on the anchor's hover text, and on the thread
+    line; an older bridge that sends none of it changes nothing.
+  - *Heartbeat narration* (F-4R2-005): crew's seams re-emit the current phase's line every ≤15 s, so
+    one draft read as 39 narration rows ("Crew phase 2/3: writing the draft (draft)…" ×16). A repeat
+    of the NEWEST narration now folds into it — one row, a repeat count and a span that ticks live
+    while the thread generates — live and on the restored transcript alike. The same words after
+    another line are a new phase, not a fold. (Keying narration on the unit ord needs the wire: the
+    seams' `status.posted` frames carry no `unit_ord` / `run_id` — recorded as a crew wire gap.)
+  - *Reload mid-run* (F-4R2-006): the composer read `terminal` for up to one heartbeat interval over
+    an executing run, because neither the frames nor the announce history carry a run id. On doc open
+    the thread now reads `GET /runs` once and adopts the run whose declared write root names the doc
+    (`interactive-drafts/<doc>`, `interactive-chats/<doc>-m-…`, `interactive-edits/<doc>-v…`,
+    `interactive-demos/<doc>`): a LIVE run flips the composer to `generating` with one honest line
+    ("Still in progress — a governed run picked this up before the page reloaded…") and an "open run"
+    link on the chip; the run's lifecycle frame ends the live state if the seam's terminal frame
+    never reaches the thread.
+  - *Deliverable-floor failure, for a human* (F-4R2-014): the crew seams' "The crew run answering
+    your ask failed (run …). Reason: [wicked-crew] deliverable floor: … EXPECTED: /abs/path … Inspect
+    it via the crew API (GET …)" line rendered verbatim in the document chat. It is now a card: one
+    sentence derived from the floor's own EXPECTED path ("The revise step produced no file, so this
+    turn did not land — nothing changed in your document"), a link to the run page, a **Retry** that
+    re-sends the same ask as a new message (`doc-actionable-retry[data-kind=resend]`), and the raw
+    dump — absolute paths, issue ids, the API URL — whole behind a collapsed "details" fold. The
+    failure itself is unchanged: the floor did its job.
+  - *Document name before Create* (F-4R2-003): the launch composer shows the id the bridge will mint
+    (its own slug of the quoted name or the brief's first six words), live and editable, so a 409
+    "doc already exists" is preventable; when one still happens the copy names the colliding document
+    with a link ("open it") and offers "use a different name" inline (the next free-looking name in
+    the field), with the daemon's own sentence kept, dimmed.
+  - Tests: `runFailure`, `runBinding`, `docThread.collapse`, `exportReport` unit suites; the
+    `DocumentThread.runFailed` / `DocumentThread.name` component suites; `ExportMenu` gains the
+    two-formats case; the loopback rig `e2e/ux5_document_hardening_test.py` (fixture switches
+    `export_report`, `doc_fail_floor`, `doc_heartbeat_ms`, `doc_bound_run`, `create_409_existing`)
+    drives the export chip, the failure card's Retry, the folded heartbeat, the reload restore and
+    the 409 way-out in a real browser.
+
 ### Added
 - **Reassign to <seat> + retry on a failure-escalation gate** (phase7-r2 acceptance finding
   F-7R2-007, HIGH). At every "Unit N failed and triage escalated" gate the card offered Approve — a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,50 +11,6 @@ npm publish dates. Every version listed here exists on
 [npm](https://www.npmjs.com/package/wicked-studio?activeTab=versions).
 
 ## [Unreleased]
-### Fixed
-- **Document thread hardening** (phase4-r2 acceptance findings F-4R2-003 / -005 / -006 / -014 / -016).
-  - *Export bar — readiness per format* (F-4R2-016): `ExportMenu` looked up the FIRST ready answer for
-    the version, so an un-consumed HTML download shadowed the PDF that finished after it — the PDF
-    button spun for 120 s while the file already sat in the thread. Each format button now asks for
-    its own (version, format) answer and flips the moment its own reply lands. The bridge's additive
-    layout report (wicked-interactive#219: `layout`, `layout_source`, `page_size`, `pages`) is read
-    null-safely off the export response AND the `export.generated` echo and rendered where present —
-    "PDF ready — 2 pages · A4 portrait" under the row, on the anchor's hover text, and on the thread
-    line; an older bridge that sends none of it changes nothing.
-  - *Heartbeat narration* (F-4R2-005): crew's seams re-emit the current phase's line every ≤15 s, so
-    one draft read as 39 narration rows ("Crew phase 2/3: writing the draft (draft)…" ×16). A repeat
-    of the NEWEST narration now folds into it — one row, a repeat count and a span that ticks live
-    while the thread generates — live and on the restored transcript alike. The same words after
-    another line are a new phase, not a fold. (Keying narration on the unit ord needs the wire: the
-    seams' `status.posted` frames carry no `unit_ord` / `run_id` — recorded as a crew wire gap.)
-  - *Reload mid-run* (F-4R2-006): the composer read `terminal` for up to one heartbeat interval over
-    an executing run, because neither the frames nor the announce history carry a run id. On doc open
-    the thread now reads `GET /runs` once and adopts the run whose declared write root names the doc
-    (`interactive-drafts/<doc>`, `interactive-chats/<doc>-m-…`, `interactive-edits/<doc>-v…`,
-    `interactive-demos/<doc>`): a LIVE run flips the composer to `generating` with one honest line
-    ("Still in progress — a governed run picked this up before the page reloaded…") and an "open run"
-    link on the chip; the run's lifecycle frame ends the live state if the seam's terminal frame
-    never reaches the thread.
-  - *Deliverable-floor failure, for a human* (F-4R2-014): the crew seams' "The crew run answering
-    your ask failed (run …). Reason: [wicked-crew] deliverable floor: … EXPECTED: /abs/path … Inspect
-    it via the crew API (GET …)" line rendered verbatim in the document chat. It is now a card: one
-    sentence derived from the floor's own EXPECTED path ("The revise step produced no file, so this
-    turn did not land — nothing changed in your document"), a link to the run page, a **Retry** that
-    re-sends the same ask as a new message (`doc-actionable-retry[data-kind=resend]`), and the raw
-    dump — absolute paths, issue ids, the API URL — whole behind a collapsed "details" fold. The
-    failure itself is unchanged: the floor did its job.
-  - *Document name before Create* (F-4R2-003): the launch composer shows the id the bridge will mint
-    (its own slug of the quoted name or the brief's first six words), live and editable, so a 409
-    "doc already exists" is preventable; when one still happens the copy names the colliding document
-    with a link ("open it") and offers "use a different name" inline (the next free-looking name in
-    the field), with the daemon's own sentence kept, dimmed.
-  - Tests: `runFailure`, `runBinding`, `docThread.collapse`, `exportReport` unit suites; the
-    `DocumentThread.runFailed` / `DocumentThread.name` component suites; `ExportMenu` gains the
-    two-formats case; the loopback rig `e2e/ux5_document_hardening_test.py` (fixture switches
-    `export_report`, `doc_fail_floor`, `doc_heartbeat_ms`, `doc_bound_run`, `create_409_existing`)
-    drives the export chip, the failure card's Retry, the folded heartbeat, the reload restore and
-    the 409 way-out in a real browser.
-
 ### Added
 - **Reassign to <seat> + retry on a failure-escalation gate** (phase7-r2 acceptance finding
   F-7R2-007, HIGH). At every "Unit N failed and triage escalated" gate the card offered Approve — a
@@ -150,6 +106,54 @@ npm publish dates. Every version listed here exists on
   never a different badge (`portable` stays the admission key).
 
 ### Fixed
+- **Document thread hardening** (phase4-r2 acceptance findings F-4R2-003 / -005 / -006 / -014 / -016).
+  - *Export bar — readiness per format* (F-4R2-016): `ExportMenu` looked up the FIRST ready answer for
+    the version, so an un-consumed HTML download shadowed the PDF that finished after it — the PDF
+    button spun for 120 s while the file already sat in the thread. Each format button now asks for
+    its own (version, format) answer and flips the moment its own reply lands. The bridge's additive
+    layout report (wicked-interactive#219: `layout`, `layout_source`, `page_size`, `pages`) is read
+    null-safely off the export response AND the `export.generated` echo and rendered where present —
+    "PDF ready — 2 pages · A4 portrait" under the row, on the anchor's hover text, and on the thread
+    line; an older bridge that sends none of it changes nothing.
+  - *Heartbeat narration* (F-4R2-005): crew's seams re-emit the current phase's line every ≤15 s, so
+    one draft read as 39 narration rows ("Crew phase 2/3: writing the draft (draft)…" ×16). A repeat
+    of the NEWEST narration now folds into it — one row, a repeat count and a span that ticks live
+    while the thread generates — live and on the restored transcript alike. The same words after
+    another line are a new phase, not a fold. (Keying narration on the unit ord needs the wire: the
+    seams' `status.posted` frames carry no `unit_ord` / `run_id` — recorded as a crew wire gap.)
+  - *Reload mid-run* (F-4R2-006): the composer read `terminal` for up to one heartbeat interval over
+    an executing run, because neither the frames nor the announce history carry a run id. On doc open
+    the thread now reads `GET /runs` once and adopts the run whose declared write root names the doc
+    (`interactive-drafts/<doc>`, `interactive-chats/<doc>-m-…`, `interactive-edits/<doc>-v…`,
+    `interactive-demos/<doc>`): a LIVE run flips the composer to `generating` with one honest line
+    ("Still in progress — a governed run picked this up before the page reloaded and is executing
+    now" — or "…is waiting at a gate" for a run parked at a human gate) and an "open run" link on the
+    chip; the run's lifecycle frame ends the live state if the seam's terminal frame never reaches
+    the thread.
+  - *Deliverable-floor failure, for a human* (F-4R2-014): the crew seams' "The crew run answering
+    your ask failed (run …). Reason: [wicked-crew] deliverable floor: … EXPECTED: /abs/path … Inspect
+    it via the crew API (GET …)" line rendered verbatim in the document chat. It is now a card: one
+    sentence derived from the floor's own EXPECTED path ("The revise step produced no file, so this
+    turn did not land — nothing changed in your document"), a link to the run page, a **Retry** on the
+    wire that failed — a chat ask re-posts as a chat ask (`doc-actionable-retry[data-kind=resend]`),
+    an edit batch re-posts as a batch on the same anchors when the thread still holds its items
+    (`data-kind=resend-batch`), and a draft or demo spec — which no message can re-send — gets the way
+    back said instead (`doc-run-failed-wayback`) — and the raw dump — absolute paths, issue ids, the
+    API URL — whole behind a collapsed "details" fold. All four crew seams' sentences parse, the demo
+    seam's "authoring this demo's spec" included. The head send resolves as answered when its run
+    fails (one retry, on the card — never a second "send failed · retry" chip on the bubble). The
+    failure itself is unchanged: the floor did its job.
+  - *Document name before Create* (F-4R2-003): the launch composer shows the id the bridge will mint
+    (its own slug of the quoted name or the brief's first six words), live and editable, so a 409
+    "doc already exists" is preventable; when one still happens the copy names the colliding document
+    with a link ("open it") and offers "use a different name" inline (the next free-looking name in
+    the field), with the daemon's own sentence kept, dimmed.
+  - Tests: `runFailure`, `runBinding`, `docThread.collapse`, `exportReport` unit suites; the
+    `DocumentThread.runFailed` / `DocumentThread.name` component suites; `ExportMenu` gains the
+    two-formats case; the loopback rig `e2e/ux5_document_hardening_test.py` (fixture switches
+    `export_report`, `doc_fail_floor`, `doc_heartbeat_ms`, `doc_bound_run`, `create_409_existing`)
+    drives the export chip, the failure card's Retry, the folded heartbeat, the reload restore and
+    the 409 way-out in a real browser.
 - **Repo readiness honesty + the project graph control** (phase2-r2 acceptance findings F-2R2-003 /
   -004 / -008 / -009).
   - */repos KPIs and card status* (F-2R2-003): "GRAPHS READY 9 of 9 · INDEX GAPS 0" and "graph ready —

--- a/e2e/ux5_document_hardening_test.py
+++ b/e2e/ux5_document_hardening_test.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""
+ux5_document_hardening_test.py — the wave-5 document-thread gate (phase4-r2 re-run
+findings F-4R2-016 / -014 / -005 / -006 / -003), driven in a REAL browser against the
+deterministic loopback fixture (uxfix_fixture.py — no crew daemon, no bridge).
+
+Scenes, one per finding:
+
+  1. F-4R2-016 — the export bar answers PER FORMAT: with the HTML download READY and
+     un-acted, asking for the PDF shows the pending spinner ON the PDF button, then the
+     PDF button becomes its own download while the HTML one stays; the bridge's
+     additive report (interactive#219) reads "PDF ready — 2 pages · A4 portrait" under
+     the row and on the thread line.
+  2. F-4R2-014 — a deliverable-floor failure renders as the human card: one sentence,
+     a link to the run page, the raw dump folded (no absolute path / API URL in the
+     visible copy), and Retry re-posts the SAME ask on the inject wire.
+  3. F-4R2-005 — heartbeats fold: five re-emissions of the current narration are ONE
+     `doc-narration` row with `data-repeats` and a ticking elapsed span.
+  4. F-4R2-006 — a fresh context (no session storage) opening a doc whose run is still
+     executing reads `generating` (not `terminal`) from the run record, with the
+     "open run" link on the chip.
+  5. F-4R2-003 — the name field: derived live from the brief; a 409 on an existing name
+     names the document, links it, and "use a different name" creates `<name>-2`.
+
+Captures (1440x900, dsf 1) into e2e/shots/vision/: ux5-export-per-format.png,
+ux5-run-failed-card.png, ux5-heartbeat-fold.png, ux5-reload-restore.png,
+ux5-name-collision.png.
+
+Prereqs: Python Playwright with a Chromium already installed (this rig never installs
+browsers). Builds dist-sameorigin/ itself unless SKIP_STUDIO_BUILD=1. Env knobs:
+FEEDBACK_PORT (default 4405). Prints a JSON report to stdout; exit 0/1.
+"""
+
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+from uxfix_fixture import (
+    HIDE_GATE_TOASTS,
+    REPO,
+    ensure_build,
+    set_fixture,
+    start_server,
+)
+
+FEEDBACK_PORT = int(os.environ.get("FEEDBACK_PORT", "4405"))
+ORIGIN = f"http://127.0.0.1:{FEEDBACK_PORT}"
+VSHOTS = REPO / "e2e" / "shots" / "vision"
+PID = "scratch"
+
+report: dict = {"ok": False, "steps": {}}
+
+
+def check(step: str, ok: bool, **detail) -> None:
+    report["steps"][step] = {"ok": bool(ok), **detail}
+    if not ok:
+        print(json.dumps(report, indent=2))
+        sys.exit(1)
+
+
+def api_create_doc(name: str, brief: str) -> dict:
+    req = urllib.request.Request(
+        f"{ORIGIN}/api/v1/projects/{PID}/interactive/api/docs", method="POST",
+        data=json.dumps({"name": name, "brief": brief}).encode())
+    req.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(req, timeout=10) as res:
+        return json.loads(res.read())
+
+
+def visible_text(page, selector: str) -> str:
+    """The element's text WITHOUT its <details> children — what a reader sees folded."""
+    return page.evaluate(
+        """(sel) => {
+             const el = document.querySelector(sel);
+             if (!el) return '';
+             return Array.from(el.childNodes)
+               .filter((n) => !(n instanceof HTMLElement && n.tagName === 'DETAILS'))
+               .map((n) => n.textContent).join(' ');
+           }""", selector)
+
+
+def open_panel(page) -> None:
+    page.locator('[data-testid="doc-canvas"]').wait_for(timeout=30000)
+    if page.locator('[data-testid="panel-expand"]').count() > 0:
+        page.locator('[data-testid="panel-expand"]').click()
+    page.locator('[data-testid="chat-export"]').wait_for(timeout=15000)
+
+
+# ── The same-origin build + the shared fixture ────────────────────────────────
+dist = ensure_build(lambda step, why: check(step, False, error=why))
+start_server(FEEDBACK_PORT, dist)
+report["steps"]["fixture_server"] = {"ok": True, "origin": ORIGIN}
+
+from playwright.sync_api import sync_playwright  # noqa: E402 (import after server, harness style)
+
+VSHOTS.mkdir(parents=True, exist_ok=True)
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page = ctx.new_page()
+
+    # ── Scene 1 (F-4R2-016): the export bar answers per format ────────────────
+    set_fixture(ORIGIN, doc_run_ms=0, export_report=True, export_delay_ms=1200)
+    doc1 = api_create_doc("w5-brochure", "a two-page A4 brochure")["name"]
+    page.goto(f"{ORIGIN}/p/{PID}/document/{doc1}", wait_until="domcontentloaded")
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    open_panel(page)
+    page.locator('[data-testid="export-format"][data-format="html"]').click()
+    page.locator('[data-testid="export-ready"][data-format="html"]').wait_for(timeout=15000)
+    # The HTML download is left UN-ACTED; now the PDF.
+    page.locator('[data-testid="export-format"][data-format="pdf"]').click()
+    pending = page.evaluate(
+        """() => {
+             const pend = document.querySelector('[data-testid="export-pending"]');
+             return { pending: !!pend, onPdf: !!pend && !!pend.closest('[data-format="pdf"]') };
+           }""")
+    check("pdf_pending_on_the_pdf_button", pending["pending"] and pending["onPdf"], **pending)
+    page.locator('[data-testid="export-ready"][data-format="pdf"]').wait_for(timeout=15000)
+    landed = page.evaluate(
+        """() => ({
+             ready: Array.from(document.querySelectorAll('[data-testid="export-ready"]')).map((a) => a.getAttribute('data-format')),
+             pending: !!document.querySelector('[data-testid="export-pending"]'),
+             buttons: Array.from(document.querySelectorAll('[data-testid="export-format"]')).map((b) => b.getAttribute('data-format')),
+             pdfPages: document.querySelector('[data-testid="export-ready"][data-format="pdf"]')?.getAttribute('data-pages'),
+             report: document.querySelector('[data-testid="export-report"][data-format="pdf"]')?.textContent,
+             threadLine: Array.from(document.querySelectorAll('[data-testid="doc-agent"]')).map((m) => m.textContent).find((t) => t.includes('PDF export ready')),
+           })""")
+    check("pdf_chip_flips_while_html_stays",
+          landed["ready"] == ["html", "pdf"] and not landed["pending"] and landed["buttons"] == ["pptx"],
+          **landed)
+    check("pdf_report_rendered",
+          landed["pdfPages"] == "2"
+          and "PDF ready — 2 pages · A4 portrait" in (landed["report"] or "")
+          and "· 2 pages · A4 portrait" in (landed["threadLine"] or ""),
+          **landed)
+    page.screenshot(path=str(VSHOTS / "ux5-export-per-format.png"))
+    set_fixture(ORIGIN, export_delay_ms=0)
+
+    # ── Scene 2 (F-4R2-014): the deliverable-floor failure, for a human ───────
+    set_fixture(ORIGIN, doc_fail_floor=True)
+    injects: list = []
+    page.on("request", lambda r: injects.append(r.post_data or "")
+            if r.method == "POST" and r.url.endswith("/interactive/api/events")
+            and "chat.posted" in (r.post_data or "") else None)
+    ask = "Design change only — replace the violet accent with a deep teal."
+    page.locator('[data-testid="doc-composer"]').fill(ask)
+    page.keyboard.press("Enter")
+    page.locator('[data-testid="doc-run-failed"]').wait_for(timeout=15000)
+    card = page.evaluate(
+        """() => {
+             const c = document.querySelector('[data-testid="doc-run-failed"]');
+             const d = c.querySelector('[data-testid="doc-run-failed-details"]');
+             return {
+               runId: c.getAttribute('data-run-id'),
+               summary: c.querySelector('[data-testid="doc-run-failed-summary"]')?.textContent,
+               href: c.querySelector('[data-testid="doc-run-failed-run"]')?.getAttribute('href'),
+               detailsOpen: d ? d.open : null,
+               raw: c.querySelector('[data-testid="doc-run-failed-raw"]')?.textContent || '',
+               retryKind: c.querySelector('[data-testid="doc-actionable-retry"]')?.getAttribute('data-kind'),
+               composer: document.querySelector('[data-testid="thread"]')?.getAttribute('data-composer-state'),
+             };
+           }""")
+    shown = visible_text(page, '[data-testid="doc-run-failed"]')
+    check("run_failed_card_human_copy",
+          card["summary"] == "The revise step produced no file, so this turn did not land — nothing changed in your document."
+          and card["href"] == f"/runs/{card['runId']}/timeline"
+          and card["detailsOpen"] is False
+          and "/w5/state" in card["raw"]
+          and "/w5/state" not in shown and "GET /api/v1/runs" not in shown
+          and card["retryKind"] == "resend"
+          and card["composer"] == "terminal",
+          **{k: v for k, v in card.items() if k != "raw"}, visible=shown[:200])
+    page.screenshot(path=str(VSHOTS / "ux5-run-failed-card.png"))
+    before = len(injects)
+    page.locator('[data-testid="doc-run-failed"] [data-testid="doc-actionable-retry"]').first.click()
+    page.wait_for_function(
+        """(n) => document.querySelectorAll('[data-testid="doc-message"]').length >= n""", arg=2, timeout=10000)
+    time.sleep(0.5)
+    resent = [b for b in injects[before:] if ask in b]
+    check("retry_resends_the_same_ask", len(resent) == 1, injects_after=len(injects) - before)
+    set_fixture(ORIGIN, doc_fail_floor=False)
+
+    # ── Scene 3 (F-4R2-005): heartbeats fold into one row ─────────────────────
+    set_fixture(ORIGIN, doc_run_ms=9000, doc_heartbeat_ms=1200)
+    page.goto(f"{ORIGIN}/p/{PID}/document", wait_until="domcontentloaded")
+    page.locator('[data-testid="thread"][data-composer-state="idle"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.locator('[data-testid="doc-subject"][data-subject-status="ready"]').wait_for(timeout=15000)
+    page.locator('[data-testid="doc-composer"]').fill("a deck for the quarterly business review")
+    page.keyboard.press("Enter")
+    page.locator('[data-testid="thread"][data-composer-state="generating"]').wait_for(timeout=15000)
+    page.wait_for_function(
+        """() => {
+             const rows = Array.from(document.querySelectorAll('[data-testid="doc-narration"]'));
+             const planning = rows.filter((r) => r.textContent.includes('Planning the deck'));
+             return planning.length === 1 && Number(planning[0].getAttribute('data-repeats')) >= 3;
+           }""", timeout=15000)
+    fold = page.evaluate(
+        """() => {
+             const rows = Array.from(document.querySelectorAll('[data-testid="doc-narration"]'));
+             const planning = rows.filter((r) => r.textContent.includes('Planning the deck'));
+             return {
+               planningRows: planning.length,
+               repeats: planning[0]?.getAttribute('data-repeats'),
+               elapsed: planning[0]?.querySelector('[data-testid="doc-narration-elapsed"]')?.textContent,
+             };
+           }""")
+    check("heartbeats_fold_into_one_row",
+          fold["planningRows"] == 1 and int(fold["repeats"] or 0) >= 3 and "for " in (fold["elapsed"] or ""), **fold)
+    page.screenshot(path=str(VSHOTS / "ux5-heartbeat-fold.png"))
+    page.locator('[data-testid="thread"][data-composer-state="terminal"]').wait_for(timeout=20000)
+    set_fixture(ORIGIN, doc_run_ms=0, doc_heartbeat_ms=0)
+
+    # ── Scene 4 (F-4R2-006): a fresh context restores generating from the run ──
+    set_fixture(ORIGIN, doc_run_ms=60000)
+    doc4 = api_create_doc("w5-reload", "a brief whose run is still executing")["name"]
+    set_fixture(ORIGIN, doc_bound_run={"pid": PID, "doc": doc4})
+    fresh = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)
+    page4 = fresh.new_page()
+    t0 = time.monotonic()
+    page4.goto(f"{ORIGIN}/p/{PID}/document/{doc4}", wait_until="domcontentloaded")
+    page4.add_style_tag(content=HIDE_GATE_TOASTS)
+    page4.locator('[data-testid="doc-canvas"]').wait_for(timeout=30000)
+    if page4.locator('[data-testid="panel-expand"]').count() > 0:
+        page4.locator('[data-testid="panel-expand"]').click()
+    page4.locator('[data-testid="thread"][data-composer-state="generating"]').wait_for(timeout=8000)
+    restored = page4.evaluate(
+        """() => ({
+             state: document.querySelector('[data-testid="thread"]')?.getAttribute('data-composer-state'),
+             chip: document.querySelector('[data-testid="steering-chip"]')?.textContent,
+             runHref: document.querySelector('[data-testid="doc-bound-run"]')?.getAttribute('href'),
+             runStatus: document.querySelector('[data-testid="doc-bound-run"]')?.getAttribute('data-run-status'),
+             narration: Array.from(document.querySelectorAll('[data-testid="doc-narration"]')).map((r) => r.textContent),
+           })""")
+    check("reload_restores_generating_from_the_run_record",
+          restored["state"] == "generating"
+          and "steering the live document run" in (restored["chip"] or "")
+          and restored["runHref"] == "/runs/r-doc-bound/timeline"
+          and restored["runStatus"] == "executing"
+          and any("Still in progress" in n for n in restored["narration"]),
+          seconds=round(time.monotonic() - t0, 1), **restored)
+    page4.screenshot(path=str(VSHOTS / "ux5-reload-restore.png"))
+    fresh.close()
+    set_fixture(ORIGIN, doc_bound_run=None, doc_run_ms=0)
+
+    # ── Scene 5 (F-4R2-003): the name field and the 409 way out ───────────────
+    set_fixture(ORIGIN, create_409_existing=True)
+    page.goto(f"{ORIGIN}/p/{PID}/document", wait_until="domcontentloaded")
+    page.locator('[data-testid="thread"][data-composer-state="idle"]').wait_for(timeout=30000)
+    page.add_style_tag(content=HIDE_GATE_TOASTS)
+    page.locator('[data-testid="doc-subject"][data-subject-status="ready"]').wait_for(timeout=15000)
+    brief = "Create a high-end, salesy product brochure for Wicked Studio — two pages, A4."
+    page.locator('[data-testid="doc-composer"]').fill(brief)
+    derived = page.locator('[data-testid="doc-name"]').input_value()
+    check("name_derived_from_the_brief", derived == "create-a-high-end-salesy-product-brochure", derived=derived)
+    # Point the name at the doc scene 1 created — the collision the finding hit.
+    page.locator('[data-testid="doc-name"]').fill(doc1)
+    page.locator('[data-testid="doc-composer"]').click()
+    page.keyboard.press("Enter")
+    page.locator('[data-testid="doc-composer-error"][data-status="409"]').wait_for(timeout=15000)
+    collision = page.evaluate(
+        """() => {
+             const e = document.querySelector('[data-testid="doc-composer-error"]');
+             return {
+               text: e.textContent,
+               collides: e.getAttribute('data-collides-with'),
+               openHref: e.querySelector('[data-testid="doc-composer-open-existing"]')?.getAttribute('href'),
+               brief: document.querySelector('[data-testid="doc-composer"]')?.value,
+             };
+           }""")
+    check("collision_names_the_doc_and_links_it",
+          collision["collides"] == doc1
+          and f"A document named “{doc1}” already exists" in collision["text"]
+          and collision["openHref"] == f"/p/{PID}/document/{doc1}"
+          and collision["brief"] == brief,
+          **collision)
+    page.screenshot(path=str(VSHOTS / "ux5-name-collision.png"))
+    page.locator('[data-testid="doc-composer-rename"]').click()
+    renamed = page.locator('[data-testid="doc-name"]').input_value()
+    check("use_a_different_name_fills_the_next_name", renamed == f"{doc1}-2", renamed=renamed)
+    page.locator('[data-testid="doc-composer"]').click()
+    page.keyboard.press("Enter")
+    page.wait_for_url(f"**/p/{PID}/document/{doc1}-2", timeout=15000)
+    check("renamed_create_lands", True, url=page.url)
+    set_fixture(ORIGIN, create_409_existing=False)
+
+    browser.close()
+
+report["ok"] = True
+print(json.dumps(report, indent=2))

--- a/e2e/ux5_document_hardening_test.py
+++ b/e2e/ux5_document_hardening_test.py
@@ -216,7 +216,12 @@ with sync_playwright() as p:
     set_fixture(ORIGIN, doc_run_ms=0, doc_heartbeat_ms=0)
 
     # ── Scene 4 (F-4R2-006): a fresh context restores generating from the run ──
-    set_fixture(ORIGIN, doc_run_ms=60000)
+    # The finding's condition is a run the thread has NOT heard: the doc is created with an
+    # instant (silent) run — v1 lands at create time, nothing narrates afterwards — while the
+    # runs wire says an executing run is bound to it. A narrating run (doc_run_ms > 0) would
+    # flip the thread to generating over WS BEFORE `GET /runs` answers, and `adoptRun` then —
+    # correctly — adds no second "Still in progress" line (review F1: the rig, not the product).
+    set_fixture(ORIGIN, doc_run_ms=0)
     doc4 = api_create_doc("w5-reload", "a brief whose run is still executing")["name"]
     set_fixture(ORIGIN, doc_bound_run={"pid": PID, "doc": doc4})
     fresh = browser.new_context(viewport={"width": 1440, "height": 900}, device_scale_factor=1)

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -242,6 +242,23 @@ state = {"orphan": True, "q3_gate_age_ms": 30 * SEC,
          "no_runs": False, "usage_ws": False, "long_prompt": False,
          "extra_narration": [], "demo": False,
          "repo": False, "metrics_ws": False,
+         # Wave 5 (phase4-r2 findings, e2e/ux5_document_hardening_test.py), all default-off so
+         # no standing rig's wires change:
+         #   export_report       — a PDF export's response AND its export.generated echo carry
+         #                         interactive#219's additive report (layout / layout_source /
+         #                         page_size / pages) — the F-4R2-016 rendering case.
+         #   doc_fail_floor      — a chat.posted ask is answered by crew's REAL run-failure
+         #                         line (status.posted state:"error", the deliverable-floor
+         #                         dump verbatim, scrubbed paths) — the F-4R2-014 card.
+         #   doc_heartbeat_ms    — the create path re-emits its current narration every N ms
+         #                         until the landing (crew's ≤15 s heartbeat) — F-4R2-005.
+         #   doc_bound_run       — {"pid","doc"}: ONE executing run whose declared write root
+         #                         is `<state>/interactive-drafts/<doc>` rides GET /runs, filed
+         #                         into pid — the run record F-4R2-006's reload restores from.
+         #   create_409_existing — POST /api/docs answers the bridge's real 409 "doc already
+         #                         exists" for a name already created this lifetime — F-4R2-003.
+         "export_report": False, "doc_fail_floor": False, "doc_heartbeat_ms": 0,
+         "doc_bound_run": None, "create_409_existing": False,
          # Slice P (DES-FEEDBACK-003 §10.2 fixture additions, switch-gated so
          # no standing rig's board grows rows it never asserted):
          #   chat_runs — 2 chat runs ride GET /runs: one 'chat'-stamped live
@@ -1841,6 +1858,18 @@ def assemble_runs() -> list:
         # join BOTH wires (list + detail) so the DTO echo decorates identically.
         if project_dto_on and not state["no_runs"]:
             runs = runs + [UNFILED_RUN] + launched_runs
+        # Wave 5 (F-4R2-006): the doc's bound run — the shape crew's draft seam launches
+        # (`extraWriteRoots: [runDir]`, runDir = <draftDir>/<docId>), filed into its project.
+        bound = state["doc_bound_run"]
+        if bound and not state["no_runs"]:
+            bound_run = session("r-doc-bound", "executing",
+                                f"Draft the document {bound['doc']} from its brief",
+                                "draft the document")
+            bound_run["session"]["workflow_id"] = "interactive-draft"
+            bound_run["session"]["extra_write_roots"] = [
+                f"/w5/state/interactive-drafts/{bound['doc']}"]
+            bound_run["session"]["project_id"] = bound["pid"]
+            runs = runs + [bound_run]
     if viewer_on or repo_refs_on or forensics_on or provenance_on or project_dto_on \
             or chronicle_on or nerve_on or gate_now or guidance or wire433_on:
         runs = json.loads(json.dumps(runs))
@@ -2044,14 +2073,28 @@ doc_sched_lock = threading.Lock()
 doc_next_free: dict = {}  # (pid, doc) -> unix seconds when the agent frees up
 
 
-def schedule_doc_run(pid: str, doc: str, delay_s: float, fixed_version: int | None = None) -> None:
+def schedule_doc_run(pid: str, doc: str, delay_s: float, fixed_version: int | None = None,
+                     heartbeat_message: str | None = None) -> None:
     """Land one version after `delay_s` of FIFO-queued work. `fixed_version`
     re-announces an existing manifest version (the create path, whose v1 is
-    committed at POST time); None appends head+1 (a steer send's own landing)."""
+    committed at POST time); None appends head+1 (a steer send's own landing).
+    Wave 5 (F-4R2-005): with `doc_heartbeat_ms` > 0 and a `heartbeat_message`,
+    the CURRENT narration is re-emitted every that-many ms until the landing —
+    crew's ≤15 s heartbeat, which pre-fix rendered as one identical row each."""
     with doc_sched_lock:
         start = max(time.time(), doc_next_free.get((pid, doc), 0.0))
         fire_at = start + delay_s
         doc_next_free[(pid, doc)] = fire_at
+    with state_lock:
+        heartbeat_ms = int(state["doc_heartbeat_ms"])
+    if heartbeat_message is not None and heartbeat_ms > 0:
+        def beat() -> None:
+            while time.time() + heartbeat_ms / 1000.0 < fire_at:
+                time.sleep(heartbeat_ms / 1000.0)
+                queue_interactive("wicked.interactive.status.posted", {
+                    "project_id": pid, "document_id": doc, "state": "working",
+                    "message": heartbeat_message})
+        threading.Thread(target=beat, daemon=True).start()
 
     def land() -> None:
         if fixed_version is None:
@@ -2923,6 +2966,16 @@ class W2Handler(SimpleHTTPRequestHandler):
                                           "start crew, or create the doc without a project"})
                 return True
             doc = slug(str(body.get("name") or "doc"))
+            # Wave 5 (F-4R2-003): the bridge's real collision — server.js answers
+            # 409 {error: "doc already exists"} for a name that is already a doc.
+            with state_lock:
+                collide = bool(state["create_409_existing"])
+            if collide:
+                with docs_lock:
+                    exists = doc in docs_created.get(pid, {})
+                if exists:
+                    self._json(409, {"error": "doc already exists"})
+                    return True
             # Slice T (§8.4.1 probe 1): the REAL bridge DROPS source_message_id —
             # no `meta.sourceMessageId` ever reaches the manifest (the interactive.ts
             # claim was aspirational). The client's anchor is client-side; the
@@ -2955,17 +3008,19 @@ class W2Handler(SimpleHTTPRequestHandler):
                 # J3 no-answerer shape: the ack is real, the bus never speaks.
                 self._json(201, {"name": doc, "head": head0, "generating": True, "project_id": pid})
                 return True
+            planning = "Planning the deck — outline first, then the slides."
             queue_interactive("wicked.interactive.status.posted", {
                 "project_id": pid, "document_id": doc, "state": "working",
-                "message": "Planning the deck — outline first, then the slides."})
+                "message": planning})
             if v0_mirror:
                 # The answerer lands the FIRST DRAFT as v1 (head 0 → 1), exactly
                 # the real materializeDraft → version.created "generated" path.
-                schedule_doc_run(pid, doc, run_ms / 1000.0)
+                schedule_doc_run(pid, doc, run_ms / 1000.0, heartbeat_message=planning)
             elif run_ms > 0:
                 # Slice T: v1 is committed now but LANDS (the frame) after the
                 # run — long enough for the rig to witness thread-generating.
-                schedule_doc_run(pid, doc, run_ms / 1000.0, fixed_version=1)
+                schedule_doc_run(pid, doc, run_ms / 1000.0, fixed_version=1,
+                                 heartbeat_message=planning)
             else:
                 queue_interactive("wicked.interactive.version.created", {
                     "project_id": pid, "document_id": doc,
@@ -3023,6 +3078,13 @@ class W2Handler(SimpleHTTPRequestHandler):
             download = f"/d/{doc}/api/export/file/{urllib.parse.quote(file)}"
             result = {"format": fmt, "path": f"/docs/{doc}/exports/{file}",
                       "file": file, "download": download}
+            # Wave 5 (F-4R2-016 / interactive#219): the additive layout report, on the
+            # response and the echo alike — an A4 two-pager, as the acceptance brochure was.
+            with state_lock:
+                report_on = bool(state["export_report"])
+            if report_on and fmt == "pdf":
+                result.update({"layout": "document", "layout_source": "author @page",
+                               "page_size": "A4 portrait", "pages": 2})
             # The bridge announces the artifact on the bus too (export.generated);
             # the client deduplicates the echo on `href` (docThread.ts EXPORTED).
             queue_interactive("wicked.interactive.export.generated", {
@@ -3207,6 +3269,36 @@ class W2Handler(SimpleHTTPRequestHandler):
                 if silent_doc:
                     # J3 no-answerer shape: 200 {ok}, landed durably — and then
                     # NOTHING answers it (no status frame, no landing, ever).
+                    self._json(200, {"ok": True, "event_id": "evt-fixture",
+                                     "correlation_id": "c-fixture"})
+                    return True
+                with state_lock:
+                    fail_floor = bool(state["doc_fail_floor"])
+                if fail_floor:
+                    # Wave 5 (F-4R2-014): crew's chat seam picks the ask up, then its
+                    # governed run trips the deterministic deliverable floor — the REAL
+                    # run-failure line (chat-events.ts), state:"error", paths scrubbed.
+                    run_id = "37f020cc-e42c-48aa-b3ec-aa18ec6f9f63"
+                    expected = f"/w5/state/interactive-chats/{doc}-m-dmsg-7/revised.html"
+                    queue_interactive("wicked.interactive.status.posted", {
+                        "project_id": pid, "document_id": doc, "state": "working",
+                        "message": "A governed crew picked up your ask — revising the document…"})
+
+                    def fail() -> None:
+                        queue_interactive("wicked.interactive.status.posted", {
+                            "project_id": pid, "document_id": doc, "state": "error",
+                            "message": (
+                                f"The crew run answering your ask failed (run {run_id}). Reason: "
+                                "[wicked-crew] deliverable floor: this phase declared 1 artifact(s); "
+                                "this run launched at 2026-09-11T10:32:54.984Z. "
+                                f"[wicked-crew] EXPECTED: {expected} [wicked-crew] FOUND: (nothing) "
+                                f"[wicked-crew] MISSING: {expected} (does not exist) "
+                                "[wicked-crew] DELIVERABLE FLOOR FAILED — the run reported done without "
+                                "producing the artifact(s) it was launched to produce. A prose reply is "
+                                "not a deliverable (crew#311), and a prior run's leftover file is not "
+                                f"this run's. Inspect it via the crew API (GET /api/v1/runs/{run_id}), "
+                                "then resend the message.")})
+                    threading.Timer(0.4, fail).start()
                     self._json(200, {"ok": True, "event_id": "evt-fixture",
                                      "correlation_id": "c-fixture"})
                     return True

--- a/src/api/interactive.ts
+++ b/src/api/interactive.ts
@@ -91,7 +91,8 @@ export interface ExportResult {
    * (`exportReportOf`). `page_size` is measured from the produced PDF (`A4 portrait`,
    * `16:9 (960 × 540 pt)`); `layout_source` says why that layout was chosen.
    */
-  layout?: 'document' | 'deck' | string;
+  /** `'document'` | `'deck'` today; typed open because a newer bridge may name another layout. */
+  layout?: string;
   layout_source?: string;
   page_size?: string;
   pages?: number;

--- a/src/api/interactive.ts
+++ b/src/api/interactive.ts
@@ -85,6 +85,16 @@ export interface ExportResult {
   path: string;
   file: string;
   download: string;
+  /**
+   * The additive layout report (wicked-interactive #219): what the export actually printed.
+   * Every field is optional — an older bridge sends none — and read null-safely
+   * (`exportReportOf`). `page_size` is measured from the produced PDF (`A4 portrait`,
+   * `16:9 (960 × 540 pt)`); `layout_source` says why that layout was chosen.
+   */
+  layout?: 'document' | 'deck' | string;
+  layout_source?: string;
+  page_size?: string;
+  pages?: number;
 }
 
 /**

--- a/src/components/DocumentCanvas.tsx
+++ b/src/components/DocumentCanvas.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { getConversation, getVersions, interactiveDocUrl, listDocs } from '../api/interactive.js';
+import { restoreDocRun } from '../interactive/runBinding.js';
 import { readAnchors, readExports, readSendStates } from '../interactive/threadStopgap.js';
 import { useDocsCache } from '../store/docsCache.js';
 import { anyModalOpen, useLayerStore } from '../store/layers.js';
@@ -615,7 +616,12 @@ export function DocumentCanvas({
         if (!cancelled) {
           useDocThreadStore.getState().hydrate(key, [], [], readSendStates(key), readExports(key));
         }
-      });
+      })
+      // F-4R2-006: the transcript cannot say whether a run is STILL executing (its frames carry
+      // no run id, the announce history no state) — the runs wire can. One read per doc open,
+      // after the hydrate has had its say, so a reload mid-run restores `generating` from the
+      // run record instead of reading `terminal` until the next heartbeat.
+      .finally(() => { if (!cancelled) void restoreDocRun(projectId, docId); });
     return () => { cancelled = true; };
   }, [projectId, docId]);
 

--- a/src/components/DocumentThread.tsx
+++ b/src/components/DocumentThread.tsx
@@ -9,12 +9,14 @@ import { DemoWizard } from './DemoWizard.js';
 import { DocSubjectPicker, NO_GROUNDING_NARRATION, type DocFormat, type SubjectStatus } from './DocSubjectPicker.js';
 import { recordFromThread } from '../interactive/demoWire.js';
 import { runExport } from '../interactive/exportWire.js';
-import { retryBatchInject } from '../interactive/feedbackBatch.js';
+import { retryBatchInject, submitFeedbackBatch } from '../interactive/feedbackBatch.js';
+import { seamRetry, seamWayBack } from '../interactive/runFailure.js';
 import { scrollToWid } from '../interactive/widScroller.js';
 import { scrollStripToVersion } from './threadAnchor.js';
 import { modePath, runTimelinePath, versionPath, type Navigate } from '../hooks/useRoute.js';
 import {
-  GENERATING_SILENCE_BUDGET_MS, LIVE_RUN, nextMsgId, threadKey, useDocThreadStore, type DocMsg, type GenState,
+  GENERATING_SILENCE_BUDGET_MS, LIVE_RUN, nextMsgId, threadKey, useDocThreadStore,
+  type DocMsg, type FeedbackItem, type GenState,
 } from '../store/docThread.js';
 
 // Document mode's half of the ONE conversation (DES-MERGE-001 §2, §6.3 slice 10).
@@ -156,20 +158,28 @@ function NarrationRow({ msg, live }: { msg: Extract<DocMsg, { kind: 'narration' 
  * F-4R2-014: the crew run-failure line, for a human. The failure stands — the deliverable floor
  * did its job — but the customer reads ONE sentence (what did not happen, and that nothing in
  * the document changed), a link to the run page instead of a quoted GET, and a Retry that
- * re-sends the same ask. The raw dump (absolute paths, issue ids, the API URL) stays whole
+ * re-sends the same ask ON THE WIRE THAT FAILED (review F3): a chat ask re-posts as a chat ask;
+ * an edit batch re-posts as a batch when the thread still holds its items; a draft or a demo
+ * spec cannot be re-sent as a message, so the card says the way back instead of offering a
+ * Retry that would fail again. The raw dump (absolute paths, issue ids, the API URL) stays whole
  * behind a collapsed "details" — moved, never paraphrased away.
  */
 function RunFailedCard({
-  msg, retryText, busy, onResend, navigate,
+  msg, retry, busy, onResend, onResendBatch, navigate,
 }: {
   msg: Extract<DocMsg, { kind: 'run-failed' }>;
   /** The ask this run was answering (the nearest user message above), or null when unknown. */
-  retryText: string | null;
+  retry: { text: string; items: FeedbackItem[] | null } | null;
   busy: boolean;
   onResend: (text: string) => void;
+  onResendBatch: (items: FeedbackItem[]) => void;
   navigate: Navigate | undefined;
 }): React.ReactElement {
   const runPath = runTimelinePath(msg.runId);
+  const mode = seamRetry(msg.seam);
+  const canResendAsk = mode === 'ask' && retry !== null;
+  const canResendBatch = mode === 'batch' && retry !== null && retry.items !== null && retry.items.length > 0;
+  const wayBack = canResendAsk || canResendBatch ? null : seamWayBack(msg.seam);
   return (
     <div
       data-testid="doc-run-failed"
@@ -191,14 +201,14 @@ function RunFailedCard({
         >
           open the run
         </a>
-        {retryText !== null && (
+        {canResendAsk && (
           <button
             type="button"
             data-testid="doc-actionable-retry"
             data-kind="resend"
             disabled={busy}
             title="Send the same ask again — a new governed run answers it"
-            onClick={() => onResend(retryText)}
+            onClick={() => onResend(retry.text)}
             className="rounded-lg px-2.5 py-1 text-xs font-medium disabled:opacity-40"
             style={{ background: S.danger, color: 'var(--surface-base)', border: 'none',
                      cursor: 'pointer', fontFamily: 'var(--font-sans)' }}
@@ -206,7 +216,27 @@ function RunFailedCard({
             {busy ? 'Sending…' : 'Retry — send the same ask again'}
           </button>
         )}
+        {canResendBatch && (
+          <button
+            type="button"
+            data-testid="doc-actionable-retry"
+            data-kind="resend-batch"
+            disabled={busy}
+            title="Send the same feedback again, on the same anchors — a new governed run answers it"
+            onClick={() => onResendBatch(retry.items ?? [])}
+            className="rounded-lg px-2.5 py-1 text-xs font-medium disabled:opacity-40"
+            style={{ background: S.danger, color: 'var(--surface-base)', border: 'none',
+                     cursor: 'pointer', fontFamily: 'var(--font-sans)' }}
+          >
+            {busy ? 'Sending…' : `Retry — send the same feedback again (${retry.items?.length ?? 0} place${(retry.items?.length ?? 0) === 1 ? '' : 's'})`}
+          </button>
+        )}
       </div>
+      {wayBack !== null && (
+        <p data-testid="doc-run-failed-wayback" data-seam={msg.seam} className="text-xs" style={{ color: S.muted, margin: 0, fontFamily: 'var(--font-sans)' }}>
+          {wayBack}
+        </p>
+      )}
       <details data-testid="doc-run-failed-details" className="text-[11px] font-mono" style={{ color: S.muted }}>
         <summary style={{ cursor: 'pointer' }}>details — the run's own report</summary>
         <pre
@@ -222,7 +252,7 @@ function RunFailedCard({
 }
 
 function Bubble({
-  msg, projectId, docId, onShowVersion, sendState, onRetrySend, live = false, retryText = null, onResend, navigate, busy = false,
+  msg, projectId, docId, onShowVersion, sendState, onRetrySend, live = false, retry = null, onResend, onResendBatch, navigate, busy = false,
 }: {
   msg: DocMsg; projectId: string; docId: string | null;
   /** The tag's cross-link (DES-UXFIX-001 §2.6 rule 2): show this version on the strip. */
@@ -233,9 +263,10 @@ function Bubble({
   onRetrySend?: (msg: Extract<DocMsg, { kind: 'user' }>) => void;
   /** F-4R2-005: this narration is the thread's newest line while it generates — its span ticks. */
   live?: boolean;
-  /** F-4R2-014: the ask a failed run was answering, for the card's Retry. */
-  retryText?: string | null;
+  /** F-4R2-014: the ask a failed run was answering (text + batch items when it was a batch), for the card's Retry. */
+  retry?: { text: string; items: FeedbackItem[] | null } | null;
   onResend?: (text: string) => void;
+  onResendBatch?: (items: FeedbackItem[]) => void;
   navigate?: Navigate | undefined;
   busy?: boolean;
 }): React.ReactElement | null {
@@ -386,9 +417,10 @@ function Bubble({
     return (
       <RunFailedCard
         msg={msg}
-        retryText={retryText}
+        retry={retry}
         busy={busy}
         onResend={(text) => onResend?.(text)}
+        onResendBatch={(items) => onResendBatch?.(items)}
         navigate={navigate}
       />
     );
@@ -971,6 +1003,26 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
     }
   }
 
+  /**
+   * F-4R2-014's Retry for an EDIT-seam failure (review F3): the same feedback again, on the
+   * same anchors, over the batch wire it originally rode (`feedback.submitted` + the inject) —
+   * never re-posted as plain chat, which would lose the anchors. The batch is feedback ON the
+   * head version, read at retry time.
+   */
+  async function resendBatch(items: FeedbackItem[]): Promise<void> {
+    if (docId === null || key === null || busy || items.length === 0) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const { head } = await getVersions(projectId, docId);
+      await submitFeedbackBatch({ projectId, docId, version: head, items });
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
   /** F-4R2-003: the next free-looking name — `brochure` → `brochure-2`, `brochure-2` → `brochure-3`. */
   function nextName(name: string): string {
     const m = /^(.*)-(\d+)$/.exec(name);
@@ -1022,11 +1074,12 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
   // the run executing (F-4R2-006). Before either the chip says what is actually
   // known: the send is out, nothing has spoken yet.
   const heardSignal = lastSignal > 0 || boundLive;
-  /** F-4R2-014: the ask a failed run was answering — the nearest user message above its card. */
-  const retryTextFor = (index: number): string | null => {
+  /** F-4R2-014: the ask a failed run was answering — the nearest user message above its card,
+   *  with its batch items when it was a feedback batch (the edit seam's retry needs them). */
+  const retryFor = (index: number): { text: string; items: FeedbackItem[] | null } | null => {
     for (let i = index - 1; i >= 0; i -= 1) {
       const m = messages[i];
-      if (m?.kind === 'user') return m.text;
+      if (m?.kind === 'user') return { text: m.text, items: m.items ?? null };
     }
     return null;
   };
@@ -1116,8 +1169,9 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
                   sendState={sendStateOf(m)}
                   onRetrySend={(msg) => void retrySend(msg)}
                   live={i === newestIndex && state === 'generating'}
-                  retryText={m.kind === 'run-failed' ? retryTextFor(i) : null}
+                  retry={m.kind === 'run-failed' ? retryFor(i) : null}
                   onResend={(askText) => void resendAsk(askText)}
+                  onResendBatch={(items) => void resendBatch(items)}
                   navigate={navigate}
                   busy={busy}
                 />

--- a/src/components/DocumentThread.tsx
+++ b/src/components/DocumentThread.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
+import { apiStatus } from '../api/errors.js';
 import { createDoc, docBinding, getVersions, injectDocMessage, interactiveUrl, postEvent, postFork } from '../api/interactive.js';
 import { parseCreateAsk } from '../interactive/createAsk.js';
 import { docSlug } from '../interactive/docSlug.js';
+import { useRunEventStore } from '../store/events.js';
 import { ComposerContext } from './ComposerContext.js';
 import { DemoWizard } from './DemoWizard.js';
 import { DocSubjectPicker, NO_GROUNDING_NARRATION, type DocFormat, type SubjectStatus } from './DocSubjectPicker.js';
@@ -10,8 +12,10 @@ import { runExport } from '../interactive/exportWire.js';
 import { retryBatchInject } from '../interactive/feedbackBatch.js';
 import { scrollToWid } from '../interactive/widScroller.js';
 import { scrollStripToVersion } from './threadAnchor.js';
-import { modePath, versionPath, type Navigate } from '../hooks/useRoute.js';
-import { GENERATING_SILENCE_BUDGET_MS, nextMsgId, threadKey, useDocThreadStore, type DocMsg, type GenState } from '../store/docThread.js';
+import { modePath, runTimelinePath, versionPath, type Navigate } from '../hooks/useRoute.js';
+import {
+  GENERATING_SILENCE_BUDGET_MS, LIVE_RUN, nextMsgId, threadKey, useDocThreadStore, type DocMsg, type GenState,
+} from '../store/docThread.js';
 
 // Document mode's half of the ONE conversation (DES-MERGE-001 §2, §6.3 slice 10).
 //
@@ -102,8 +106,123 @@ export function growComposer(el: HTMLTextAreaElement): void {
   el.style.overflowY = fit > max ? 'auto' : 'hidden';
 }
 
+/** A span in words: `48s`, `2m 15s`, `1h 04m`. */
+export function fmtSpan(ms: number): string {
+  const s = Math.max(0, Math.floor(ms / 1000));
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ${String(s % 60).padStart(2, '0')}s`;
+  return `${Math.floor(m / 60)}h ${String(m % 60).padStart(2, '0')}m`;
+}
+
+/**
+ * F-4R2-005: one narration row, with the heartbeats it absorbed. Crew re-emits the current
+ * phase's line every ≤15 s; the store folds each repeat into the newest row (`repeats`,
+ * `firstAt`/`lastAt`), and this row shows the phase ONCE with how long it has held — a live
+ * counter while it is the newest line of a generating thread, the recorded span otherwise.
+ */
+function NarrationRow({ msg, live }: { msg: Extract<DocMsg, { kind: 'narration' }>; live: boolean }): React.ReactElement {
+  const repeats = msg.repeats ?? 0;
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!live || repeats === 0 || msg.firstAt === undefined) return;
+    const timer = setInterval(() => setNow(Date.now()), 1000);
+    return () => { clearInterval(timer); };
+  }, [live, repeats, msg.firstAt]);
+  const span = msg.firstAt === undefined
+    ? null
+    : live ? now - msg.firstAt : (msg.lastAt ?? msg.firstAt) - msg.firstAt;
+  return (
+    // Narration is data: the mono, body ink (§2.8); the dot is the run-emerald.
+    <div className="flex items-start gap-2 text-xs font-mono" data-testid="doc-narration" data-repeats={repeats} style={{ color: S.body }}>
+      <span className="mt-1.5 w-1.5 h-1.5 rounded-full shrink-0" style={{ background: S.live }} />
+      <span>
+        {msg.text}
+        {repeats > 0 && span !== null && (
+          <span
+            data-testid="doc-narration-elapsed"
+            title={`the crew has reported this ${repeats + 1} times — the phase has held for ${fmtSpan(span)}`}
+            style={{ color: S.faint, marginLeft: '6px' }}
+          >
+            · {live ? 'for ' : ''}{fmtSpan(span)}{live ? '' : ` · ×${repeats + 1}`}
+          </span>
+        )}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * F-4R2-014: the crew run-failure line, for a human. The failure stands — the deliverable floor
+ * did its job — but the customer reads ONE sentence (what did not happen, and that nothing in
+ * the document changed), a link to the run page instead of a quoted GET, and a Retry that
+ * re-sends the same ask. The raw dump (absolute paths, issue ids, the API URL) stays whole
+ * behind a collapsed "details" — moved, never paraphrased away.
+ */
+function RunFailedCard({
+  msg, retryText, busy, onResend, navigate,
+}: {
+  msg: Extract<DocMsg, { kind: 'run-failed' }>;
+  /** The ask this run was answering (the nearest user message above), or null when unknown. */
+  retryText: string | null;
+  busy: boolean;
+  onResend: (text: string) => void;
+  navigate: Navigate | undefined;
+}): React.ReactElement {
+  const runPath = runTimelinePath(msg.runId);
+  return (
+    <div
+      data-testid="doc-run-failed"
+      data-run-id={msg.runId}
+      data-cancelled={msg.cancelled}
+      className="self-start max-w-[90%] rounded-xl px-3.5 py-3 flex flex-col gap-2"
+      style={{ background: 'var(--status-fail-dim)', border: '1px solid var(--status-fail-dim)' }}
+    >
+      <p data-testid="doc-run-failed-summary" className="text-sm leading-relaxed" style={{ color: S.ink, margin: 0, fontFamily: 'var(--font-sans)' }}>
+        {msg.summary}
+      </p>
+      <div className="flex flex-wrap items-center gap-2">
+        <a
+          data-testid="doc-run-failed-run"
+          href={runPath}
+          onClick={(e) => { if (navigate !== undefined) { e.preventDefault(); navigate(runPath); } }}
+          className="text-xs font-mono underline"
+          style={{ color: S.accent }}
+        >
+          open the run
+        </a>
+        {retryText !== null && (
+          <button
+            type="button"
+            data-testid="doc-actionable-retry"
+            data-kind="resend"
+            disabled={busy}
+            title="Send the same ask again — a new governed run answers it"
+            onClick={() => onResend(retryText)}
+            className="rounded-lg px-2.5 py-1 text-xs font-medium disabled:opacity-40"
+            style={{ background: S.danger, color: 'var(--surface-base)', border: 'none',
+                     cursor: 'pointer', fontFamily: 'var(--font-sans)' }}
+          >
+            {busy ? 'Sending…' : 'Retry — send the same ask again'}
+          </button>
+        )}
+      </div>
+      <details data-testid="doc-run-failed-details" className="text-[11px] font-mono" style={{ color: S.muted }}>
+        <summary style={{ cursor: 'pointer' }}>details — the run's own report</summary>
+        <pre
+          data-testid="doc-run-failed-raw"
+          className="mt-1 whitespace-pre-wrap"
+          style={{ margin: 0, fontSize: '10px', color: S.muted, overflowWrap: 'anywhere' }}
+        >
+          {msg.text}
+        </pre>
+      </details>
+    </div>
+  );
+}
+
 function Bubble({
-  msg, projectId, docId, onShowVersion, sendState, onRetrySend,
+  msg, projectId, docId, onShowVersion, sendState, onRetrySend, live = false, retryText = null, onResend, navigate, busy = false,
 }: {
   msg: DocMsg; projectId: string; docId: string | null;
   /** The tag's cross-link (DES-UXFIX-001 §2.6 rule 2): show this version on the strip. */
@@ -112,6 +231,13 @@ function Bubble({
   sendState?: SendState | undefined;
   /** Re-arm a refused send — §6.1's "visible failure with a retry". */
   onRetrySend?: (msg: Extract<DocMsg, { kind: 'user' }>) => void;
+  /** F-4R2-005: this narration is the thread's newest line while it generates — its span ticks. */
+  live?: boolean;
+  /** F-4R2-014: the ask a failed run was answering, for the card's Retry. */
+  retryText?: string | null;
+  onResend?: (text: string) => void;
+  navigate?: Navigate | undefined;
+  busy?: boolean;
 }): React.ReactElement | null {
   if (msg.kind === 'user') {
     return (
@@ -254,12 +380,17 @@ function Bubble({
     );
   }
   if (msg.kind === 'narration') {
-    // Narration is data: the mono, body ink (§2.8); the dot is the run-emerald.
+    return <NarrationRow msg={msg} live={live} />;
+  }
+  if (msg.kind === 'run-failed') {
     return (
-      <div className="flex items-start gap-2 text-xs font-mono" data-testid="doc-narration" style={{ color: S.body }}>
-        <span className="mt-1.5 w-1.5 h-1.5 rounded-full shrink-0" style={{ background: S.live }} />
-        <span>{msg.text}</span>
-      </div>
+      <RunFailedCard
+        msg={msg}
+        retryText={retryText}
+        busy={busy}
+        onResend={(text) => onResend?.(text)}
+        navigate={navigate}
+      />
     );
   }
   if (msg.kind === 'divider') {
@@ -531,6 +662,32 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
   const [text, setText] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // F-4R2-003: the document's NAME, shown before Create — derived from the brief (the bridge's
+  // own slug of the quoted name or the first six words) until the operator edits it. A 409
+  // "already exists" is then preventable, and when it still happens the collision names the
+  // document (with a link) and offers a different name inline.
+  const [nameDraft, setNameDraft] = useState('');
+  const [nameEdited, setNameEdited] = useState(false);
+  const [collision, setCollision] = useState<{ name: string; wire: string } | null>(null);
+  const nameEl = useRef<HTMLInputElement>(null);
+  // F-4R2-006: the governed run this thread is bound to (the runs wire's record, adopted on doc
+  // open) — the chip links it, and its lifecycle frames end the live state if the seam's own
+  // terminal frame never reaches this thread.
+  const boundRun = useDocThreadStore((s) => (key === null ? undefined : s.boundRun[key]));
+  const boundLive = boundRun !== undefined && LIVE_RUN.has(boundRun.status);
+  const boundEnded = useRunEventStore((s) => {
+    if (boundRun === undefined) return null;
+    const ended = (s.byRun[boundRun.runId] ?? []).find((e) =>
+      e.type === 'sessionCompleted' || e.type === 'sessionFailed' || e.type === 'runCancelled');
+    return ended === undefined ? null : ended.type;
+  });
+  useEffect(() => {
+    if (key === null || boundRun === undefined || boundEnded === null || !boundLive) return;
+    useDocThreadStore.getState().markRunEnded(
+      key,
+      boundEnded === 'sessionCompleted' ? 'completed' : boundEnded === 'sessionFailed' ? 'failed' : 'cancelled',
+    );
+  }, [key, boundRun, boundEnded, boundLive]);
   // F-046 (studio half): what the next document is ABOUT (the project's repos, sent as
   // `repo_refs` — crew validates them and grounds the run on THOSE, never the first member) and
   // its format (`style`; '' lets crew infer it from the brief's format words).
@@ -549,8 +706,16 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
     setRepoRefs([]);
     setFormat('');
     setNoGrounding(false);
+    setNameDraft('');
+    setNameEdited(false);
+    setCollision(null);
   }, [projectId, docId, mode]);
   const launching = docId === null || key === null;
+  /** The launch composer's parse of the ask — a quoted name (§7.3) or null. */
+  const parsedAsk = launching && mode !== 'video' ? parseCreateAsk(text) : null;
+  /** The id the bridge WILL mint for this brief — what the name field shows until edited. */
+  const derivedName = text.trim() === '' ? '' : docSlug(parsedAsk?.name ?? docName(text));
+  const shownName = nameEdited ? nameDraft : derivedName;
   /** The launch composer refuses to send while the repositories are unknown, except by explicit choice. */
   const subjectBlocks = launching && (subjectStatus === 'loading' || (subjectStatus === 'error' && !noGrounding));
   /** The thread line a no-grounding create leaves — only when discovery FAILED and the user chose to go on. */
@@ -601,6 +766,7 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
     const msgId = nextMsgId();
     setBusy(true);
     setError(null);
+    setCollision(null);
     try {
       // 1 — LAUNCH, the demo path (§4.5): the ask names the demo, and the wizard collects
       // the steps it is made of, in order. Nothing is created until the wizard submits.
@@ -621,7 +787,9 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
         // create lands in the catch below — the visible composer error,
         // never a silent close (the loud-502 contract, §8.4.1 probe 3).
         const parsed = parseCreateAsk(body);
-        const name = parsed?.name ?? docName(body);
+        // F-4R2-003: an edited name field wins; otherwise the derivation the field showed.
+        const typedName = nameEdited ? nameDraft.trim() : '';
+        const name = typedName !== '' ? typedName : (parsed?.name ?? docName(body));
         // F-045: claim the doc for THIS project the moment the create is sent (codex on #241) —
         // the bridge emits doc.created before it answers, so crew's first frames can arrive before
         // the response, let alone before the thread mounts; a pending binding files them here and
@@ -642,6 +810,14 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
           });
         } catch (e) {
           releasePending();
+          // F-4R2-003: a name collision is NAMED — which document, with a way out — never only
+          // the daemon's sentence. Matched on the status (the typed field), with the wire's
+          // words as the fallback for a refusal that arrived untyped.
+          const wire = e instanceof Error ? e.message : String(e);
+          if (apiStatus(e) === 409 || /\b409\b|already exists/i.test(wire)) {
+            setCollision({ name: expectedId, wire });
+            return;
+          }
           throw e;
         }
         if (created.name !== expectedId) {
@@ -657,6 +833,8 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
         setRepoRefs([]); // the picks were for THIS document — the next launch starts clean
         setFormat('');
         setNoGrounding(false);
+        setNameDraft('');
+        setNameEdited(false);
         navigate(versionPath(projectId, created.name, null));
         return;
       }
@@ -770,6 +948,44 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
     }
   }
 
+  /**
+   * F-4R2-014's Retry: send the SAME ask again as a new message — the plain continue wire
+   * (`chat.posted`), enqueued at the tail like any send, failing visibly like any send. A
+   * new governed run answers it; the failed card above stays as the record of the first.
+   */
+  async function resendAsk(askText: string): Promise<void> {
+    if (docId === null || key === null || busy) return;
+    const store = useDocThreadStore.getState();
+    const msgId = nextMsgId();
+    setBusy(true);
+    try {
+      store.addUserMsg(key, msgId, askText);
+      store.setGenState(key, 'generating');
+      try {
+        await injectDocMessage(projectId, docId, askText, msgId);
+      } catch {
+        failVisibly(msgId);
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  /** F-4R2-003: the next free-looking name — `brochure` → `brochure-2`, `brochure-2` → `brochure-3`. */
+  function nextName(name: string): string {
+    const m = /^(.*)-(\d+)$/.exec(name);
+    return m !== null ? `${m[1]}-${Number(m[2]) + 1}` : `${name}-2`;
+  }
+
+  /** F-4R2-003's way out of a collision: a different name, in the field, focused. */
+  function useDifferentName(): void {
+    if (collision === null) return;
+    setNameEdited(true);
+    setNameDraft(nextName(collision.name));
+    setCollision(null);
+    nameEl.current?.focus();
+  }
+
   /** Where a user message sits in its §6.1 lifecycle (see `SendState`). */
   function sendStateOf(msg: DocMsg): SendState | undefined {
     if (msg.kind !== 'user') return undefined;
@@ -802,9 +1018,19 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
     : placeholder;
   // Honesty for the working chip (VIDEO-FB: "steering the live demo run" showed
   // with nothing running anywhere): claiming a LIVE run requires having heard
-  // one — any interactive frame for this thread. Before the first signal the
-  // chip says what is actually known: the send is out, nothing has spoken yet.
-  const heardSignal = lastSignal > 0;
+  // one — any interactive frame for this thread, or the runs wire's own record of
+  // the run executing (F-4R2-006). Before either the chip says what is actually
+  // known: the send is out, nothing has spoken yet.
+  const heardSignal = lastSignal > 0 || boundLive;
+  /** F-4R2-014: the ask a failed run was answering — the nearest user message above its card. */
+  const retryTextFor = (index: number): string | null => {
+    for (let i = index - 1; i >= 0; i -= 1) {
+      const m = messages[i];
+      if (m?.kind === 'user') return m.text;
+    }
+    return null;
+  };
+  const newestIndex = messages.length - 1;
 
   return (
     <div
@@ -869,7 +1095,7 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
               : `Ask for a change and it lands as a new version. Everything the agent says about this ${noun} appears here.`}
           </p>
         )}
-        {messages.map((m) =>
+        {messages.map((m, i) =>
           m.kind === 'gate'
             ? (docId !== null && key !== null && (
                 <GateCard
@@ -889,6 +1115,11 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
                   onShowVersion={showVersion}
                   sendState={sendStateOf(m)}
                   onRetrySend={(msg) => void retrySend(msg)}
+                  live={i === newestIndex && state === 'generating'}
+                  retryText={m.kind === 'run-failed' ? retryTextFor(i) : null}
+                  onResend={(askText) => void resendAsk(askText)}
+                  navigate={navigate}
+                  busy={busy}
                 />
               ),
         )}
@@ -937,6 +1168,20 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
             {heardSignal
               ? `steering the live ${noun} run`
               : `sent — waiting for the ${noun} service to pick this up`}
+            {/* F-4R2-006: the run the runs wire bound this thread to — one click to its page. */}
+            {boundRun !== undefined && (
+              <a
+                data-testid="doc-bound-run"
+                data-run-id={boundRun.runId}
+                data-run-status={boundRun.status}
+                href={runTimelinePath(boundRun.runId)}
+                onClick={(e) => { e.preventDefault(); navigate(runTimelinePath(boundRun.runId)); }}
+                className="underline"
+                style={{ color: S.live }}
+              >
+                open run
+              </a>
+            )}
           </span>
         )}
         {/* §6.1 (J3): past the honesty budget the composer must not claim a live
@@ -954,20 +1199,54 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
         {/* §7.3 (slice X2): the parse, SHOWN before submit — a quoted name in a
             create ask becomes the doc's name, the rest stays the brief. Renders
             only on the launch composer (no doc yet) when a quoted name parses. */}
-        {(docId === null || key === null) && mode !== 'video' && (() => {
-          const parsed = parseCreateAsk(text);
-          if (parsed === null) return null;
-          return (
-            <p
-              data-testid="create-parse"
-              className="text-[10px] font-mono"
-              style={{ color: 'var(--ink-dim)', margin: 0 }}
-            >
-              will create <span style={{ color: 'var(--ink-muted)' }}>“{parsed.name}”</span>
-              {' '}— brief: {parsed.brief}
-            </p>
-          );
-        })()}
+        {parsedAsk !== null && (
+          <p
+            data-testid="create-parse"
+            className="text-[10px] font-mono"
+            style={{ color: 'var(--ink-dim)', margin: 0 }}
+          >
+            will create <span style={{ color: 'var(--ink-muted)' }}>“{parsedAsk.name}”</span>
+            {' '}— brief: {parsedAsk.brief}
+          </p>
+        )}
+        {/* F-4R2-003: the document's NAME, before Create — the id the bridge will mint (derived
+            from the brief, live) until the operator edits it. Visible on the launch composer
+            only; a demo's name rides the wizard. */}
+        {launching && mode !== 'video' && (
+          <label
+            data-testid="doc-name-row"
+            data-derived={!nameEdited}
+            className="flex items-center gap-2 text-[10px] font-mono"
+            style={{ color: 'var(--ink-dim)' }}
+          >
+            <span>name</span>
+            <input
+              ref={nameEl}
+              data-testid="doc-name"
+              value={shownName}
+              placeholder="derived from your brief"
+              spellCheck={false}
+              onChange={(e) => { setNameEdited(true); setNameDraft(e.target.value); setCollision(null); }}
+              title={nameEdited
+                ? 'the name this document is created under'
+                : 'derived from your brief — edit to choose your own; the bridge slugifies it'}
+              className="flex-1 min-w-0 bg-transparent outline-none text-[10px] font-mono"
+              style={{ color: 'var(--ink-muted)', border: `1px solid ${S.border}`,
+                       borderRadius: 'var(--radius-sm)', padding: '1px 6px' }}
+            />
+            {nameEdited && (
+              <button
+                type="button"
+                data-testid="doc-name-reset"
+                onClick={() => { setNameEdited(false); setNameDraft(''); setCollision(null); }}
+                className="underline"
+                style={{ background: 'transparent', border: 'none', color: 'var(--ink-dim)', cursor: 'pointer', padding: 0 }}
+              >
+                use the derived name
+              </button>
+            )}
+          </label>
+        )}
         {/* F-046: on the LAUNCH composer, what the document (or demo) is about — the project's
             repositories as toggles (sent as repo_refs; a demo's spec is grounded on the app's own
             source the same way) — and, for a document, its format (the bridge's styles). */}
@@ -1034,6 +1313,40 @@ export function DocumentThread({ projectId, docId, selectedVersion, navigate, mo
         {error !== null && (
           <p data-testid="doc-composer-error" className="text-[11px] font-mono" style={{ color: S.danger, margin: 0 }}>
             {error} — nothing was sent; edit and try again.
+          </p>
+        )}
+        {/* F-4R2-003: a name collision names the document (linked) and offers the way out
+            inline; the daemon's own sentence stays, dimmed — carried whole, never paraphrased. */}
+        {collision !== null && (
+          <p
+            data-testid="doc-composer-error"
+            data-status="409"
+            data-collides-with={collision.name}
+            className="text-[11px] font-mono"
+            style={{ color: S.danger, margin: 0 }}
+          >
+            A document named “{collision.name}” already exists —{' '}
+            <a
+              data-testid="doc-composer-open-existing"
+              href={versionPath(projectId, collision.name, null)}
+              onClick={(e) => { e.preventDefault(); navigate(versionPath(projectId, collision.name, null)); }}
+              className="underline"
+              style={{ color: S.danger }}
+            >
+              open it
+            </a>
+            {' '}or{' '}
+            <button
+              type="button"
+              data-testid="doc-composer-rename"
+              onClick={useDifferentName}
+              className="underline"
+              style={{ background: 'transparent', border: 'none', color: S.danger, cursor: 'pointer', padding: 0, font: 'inherit' }}
+            >
+              use a different name
+            </button>
+            . Nothing was created.{' '}
+            <span style={{ color: S.faint }}>({collision.wire})</span>
           </p>
         )}
       </div>

--- a/src/components/ExportMenu.tsx
+++ b/src/components/ExportMenu.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { interactiveUrl } from '../api/interactive.js';
 import type { ExportFormat } from '../api/interactive.js';
+import { describeExportReport, exportReportTitle } from '../interactive/exportReport.js';
 import { EXPORT_FORMATS, runExport } from '../interactive/exportWire.js';
 import { exportKey, NO_ANSWERS, useExportAnswers } from '../store/exportAnswers.js';
 import type { ExportAnswer } from '../store/exportAnswers.js';
@@ -85,7 +86,15 @@ export function ExportMenu({
   const answers = useExportAnswers((s) => s.answers[key] ?? NO_ANSWERS);
 
   const pending = answers.find((a) => a.state === 'pending');
-  const readyHere = answers.find((a) => a.state === 'ready' && a.version === version);
+  // F-4R2-016: readiness is PER FORMAT. The first-ready-answer lookup this replaced let an
+  // un-consumed HTML answer shadow the PDF that finished after it — the PDF button never
+  // became its download while the file already sat in the thread. Each button asks for its
+  // own (version, format) answer, so every finished format flips independently.
+  const readyHere = (format: ExportFormat): Extract<ExportAnswer, { state: 'ready' }> | undefined =>
+    answers.find((a): a is Extract<ExportAnswer, { state: 'ready' }> =>
+      a.state === 'ready' && a.version === version && a.format === format);
+  const readyHereAll = answers.filter((a): a is Extract<ExportAnswer, { state: 'ready' }> =>
+    a.state === 'ready' && a.version === version);
   const failedHere = answers.filter((a) => a.state === 'failed' && a.version === version);
   // Round-3 J3: un-acted answers for OTHER versions of this doc stay at the click
   // site, labeled with their own version — never wiped by a selection move or a
@@ -112,8 +121,10 @@ export function ExportMenu({
         useExportAnswers.getState().settle(key, outcome.ok
           ? { state: 'ready', version, format,
               // READY at the click site: the service's `download` is bridge-root-relative;
-              // resolved through the proxy it stays on the one origin (§5.3).
-              href: interactiveUrl(projectId, outcome.result.download), file: outcome.file }
+              // resolved through the proxy it stays on the one origin (§5.3). `report` is
+              // the bridge's additive layout report (interactive#219) — null on an older one.
+              href: interactiveUrl(projectId, outcome.result.download), file: outcome.file,
+              report: outcome.report }
           : { state: 'failed', version, format, hint: outcome.hint });
       });
   }
@@ -124,16 +135,21 @@ export function ExportMenu({
     const label = labelVersion
       ? (compact ? `${a.format} v${a.version} ↓` : `${a.format.toUpperCase()} v${a.version} ↓`)
       : (compact ? `${a.format} ↓` : `${a.format.toUpperCase()} ↓`);
+    // interactive#219: what was printed, when the bridge said — on the hover text here, and
+    // as its own line under the row (below) where the control is not compact.
+    const printed = exportReportTitle(a.report ?? null);
     return (
       <a
         key={`${a.format}-${a.version}`}
         data-testid="export-ready"
         data-format={a.format}
         data-version={String(a.version)}
+        data-pages={a.report?.pages ?? undefined}
+        data-page-size={a.report?.pageSize ?? undefined}
         href={a.href}
         download={a.file}
         onClick={() => useExportAnswers.getState().consume(key, a.version, a.format)}
-        title={`${a.format.toUpperCase()} of v${a.version} ready — download ${a.file}`}
+        title={`${a.format.toUpperCase()} of v${a.version} ready — download ${a.file}${printed === null ? '' : ` · ${printed}`}`}
         style={{ ...(compact ? COMPACT : BUTTON), ...READY }}
       >
         {label}
@@ -161,9 +177,9 @@ export function ExportMenu({
         {EXPORT_FORMATS.map((format) => (
           // §7.2 READY: the control that was clicked IS the download now — a real
           // anchor with the artifact's name, at the click site. The thread message
-          // remains; this is the click site answering (EC37).
-          readyHere !== undefined && readyHere.format === format ? (
-            readyAnchor(readyHere as Extract<ExportAnswer, { state: 'ready' }>, false)
+          // remains; this is the click site answering (EC37). Per format (F-4R2-016).
+          readyHere(format) !== undefined ? (
+            readyAnchor(readyHere(format)!, false)
           ) : (
             <button
               key={format}
@@ -212,6 +228,26 @@ export function ExportMenu({
           </span>
         )}
       </div>
+      {/* interactive#219 (F-4R2-016): what the finished export actually printed — "PDF ready —
+          2 pages · A4 portrait" — under the row, where the download is. Only when the bridge
+          reported it; an older bridge renders nothing here. Compact controls carry it on hover. */}
+      {!compact && readyHereAll.map((a) => {
+        const phrase = describeExportReport(a.report ?? null);
+        if (phrase === null) return null;
+        return (
+          <span
+            key={`report-${a.format}-${a.version}`}
+            data-testid="export-report"
+            data-format={a.format}
+            data-version={String(a.version)}
+            title={exportReportTitle(a.report ?? null) ?? undefined}
+            style={{ color: S.muted, fontSize: '9px', fontFamily: 'var(--font-mono)',
+                     overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+          >
+            {a.format.toUpperCase()} ready — {phrase}
+          </span>
+        );
+      })}
       {/* §7.2 FAILED, §3.3: the reason is stated and the control that retries it is the
           row above — adjacent, not a toast that takes the fix away with it when it fades. */}
       {[...failedHere, ...failedElsewhere].map((a) => (

--- a/src/components/ExportMenu.tsx
+++ b/src/components/ExportMenu.tsx
@@ -174,12 +174,13 @@ export function ExportMenu({
             Export v{version}
           </span>
         )}
-        {EXPORT_FORMATS.map((format) => (
+        {EXPORT_FORMATS.map((format) => {
           // §7.2 READY: the control that was clicked IS the download now — a real
           // anchor with the artifact's name, at the click site. The thread message
           // remains; this is the click site answering (EC37). Per format (F-4R2-016).
-          readyHere(format) !== undefined ? (
-            readyAnchor(readyHere(format)!, false)
+          const ready = readyHere(format);
+          return ready !== undefined ? (
+            readyAnchor(ready, false)
           ) : (
             <button
               key={format}
@@ -200,8 +201,8 @@ export function ExportMenu({
                 ? <span data-testid="export-pending" className="animate-pulse">{format}…</span>
                 : compact ? format : format.toUpperCase()}
             </button>
-          )
-        ))}
+          );
+        })}
         {/* VIDEO-FB: the recording is already an artifact — no render step, so it
             is a download from the start, same-origin through the project proxy. */}
         {recording !== null && (

--- a/src/interactive/exportReport.ts
+++ b/src/interactive/exportReport.ts
@@ -1,0 +1,62 @@
+/**
+ * The bridge's additive export report (wicked-interactive #219; acceptance finding F-4R2-016).
+ *
+ * `POST /d/:doc/api/export` and the `wicked.interactive.export.generated` echo gained four
+ * optional fields describing what was actually printed: `layout` (`document` | `deck`),
+ * `layout_source` (why — the author's `@page`, a recorded style, declared slides…),
+ * `page_size` (measured from the produced PDF, e.g. `A4 portrait`, `16:9 (960 × 540 pt)`) and
+ * `pages`. Read DEFENSIVELY off an untyped bag — every field optional, wrong types ignored — so
+ * an older bridge that sends none of them changes nothing on screen.
+ */
+
+export interface ExportReport {
+  layout: string | null;
+  layoutSource: string | null;
+  pageSize: string | null;
+  pages: number | null;
+}
+
+function str(bag: Record<string, unknown>, key: string): string | null {
+  const v = bag[key];
+  return typeof v === 'string' && v.trim() !== '' ? v.trim() : null;
+}
+
+/** The report the bag carries, or `null` when it carries none of the four fields. */
+export function exportReportOf(bag: unknown): ExportReport | null {
+  if (typeof bag !== 'object' || bag === null) return null;
+  const b = bag as Record<string, unknown>;
+  const pagesRaw = b['pages'];
+  const pages = typeof pagesRaw === 'number' && Number.isInteger(pagesRaw) && pagesRaw >= 0 ? pagesRaw : null;
+  const report: ExportReport = {
+    layout: str(b, 'layout'),
+    layoutSource: str(b, 'layout_source'),
+    pageSize: str(b, 'page_size'),
+    pages,
+  };
+  return report.layout === null && report.layoutSource === null && report.pageSize === null && report.pages === null
+    ? null
+    : report;
+}
+
+/**
+ * The short customer phrase — "2 pages · A4 portrait", "deck · 3 pages · 16:9 (960 × 540 pt)".
+ * A `document` layout is the default reading and goes unsaid; `deck` is worth a word because
+ * it is the surprise the #219 fix exists for. `null` when there is nothing to say.
+ */
+export function describeExportReport(report: ExportReport | null): string | null {
+  if (report === null) return null;
+  const parts: string[] = [];
+  if (report.layout !== null && report.layout !== 'document') parts.push(report.layout);
+  if (report.pages !== null) parts.push(`${report.pages} page${report.pages === 1 ? '' : 's'}`);
+  if (report.pageSize !== null) parts.push(report.pageSize);
+  return parts.length === 0 ? null : parts.join(' · ');
+}
+
+/** The hover text: the phrase plus WHY the layout was chosen, when the bridge said. */
+export function exportReportTitle(report: ExportReport | null): string | null {
+  const phrase = describeExportReport(report);
+  if (phrase === null) return null;
+  return report?.layoutSource !== null && report?.layoutSource !== undefined
+    ? `${phrase} — layout from ${report.layoutSource}`
+    : phrase;
+}

--- a/src/interactive/exportWire.ts
+++ b/src/interactive/exportWire.ts
@@ -18,6 +18,7 @@
 
 import { postExport, ServiceHintError } from '../api/interactive.js';
 import type { ExportFormat, ExportResult } from '../api/interactive.js';
+import { describeExportReport, exportReportOf, type ExportReport } from './exportReport.js';
 import { threadKey, useDocThreadStore } from '../store/docThread.js';
 
 /** Offered in §4.4's own order. Parity is all three, from every surface that exports. */
@@ -58,8 +59,16 @@ export interface ExportArgs {
 
 /** What the pressed control needs back. Everything a READER needs is in the thread. */
 export type ExportOutcome =
-  | { ok: true; file: string; result: ExportResult }
+  // `report`: the bridge's additive layout report (interactive#219), `null` when it sent none.
+  | { ok: true; file: string; result: ExportResult; report: ExportReport | null }
   | { ok: false; hint: string };
+
+/** The thread line for a finished export — the file, then what was printed when the bridge said
+ *  ("PDF export ready — brochure_v3.pdf · 2 pages · A4 portrait"). */
+export function exportReadyText(format: ExportFormat, file: string, report: ExportReport | null): string {
+  const phrase = describeExportReport(report);
+  return `${format.toUpperCase()} export ready — ${file}${phrase === null ? '' : ` · ${phrase}`}`;
+}
 
 /**
  * Export one version and put the whole of it in the conversation. Never throws: a refused
@@ -75,9 +84,9 @@ export async function runExport(
   try {
     const result = await postExport(projectId, docId, version, format);
     const file = exportFilename(docId, version, format, result.file);
-    store.addAgentMsg(key, 'export', `${format.toUpperCase()} export ready — ${file}`,
-                      { href: result.download, file });
-    return { ok: true, file, result };
+    const report = exportReportOf(result);
+    store.addAgentMsg(key, 'export', exportReadyText(format, file, report), { href: result.download, file });
+    return { ok: true, file, result, report };
   } catch (e: unknown) {
     const hint = exportHint(e);
     store.addActionable(

--- a/src/interactive/runBinding.ts
+++ b/src/interactive/runBinding.ts
@@ -1,0 +1,98 @@
+/**
+ * Which governed run a document thread is bound to (acceptance finding F-4R2-006).
+ *
+ * Crew's interactive seams narrate their governed runs over `wicked.interactive.status.posted`
+ * frames that carry `document_id` + `message` and NO run id; the bridge's announce history
+ * (`GET /d/:doc/api/conversation`) keeps only `{role, text, ts}`. So after a reload the thread
+ * could not know a run was still executing until the next heartbeat (≤15 s) — and for that
+ * interval the composer read `terminal` over a live run. `GET /runs` carries no doc filter
+ * either, but every seam DECLARES the run's own inbox as its write root
+ * (`extraWriteRoots: [runDir]`, per-run isolation — crew#313/#314), and that directory is named
+ * by the doc:
+ *
+ *   drafts   <state>/interactive-drafts/<docId>
+ *   asks     <state>/interactive-chats/<docId>-m-<sourceMessageId>  |  <docId>-e-<eventId>
+ *   edits    <state>/interactive-edits/<docId>-v<version>
+ *   demos    <state>/interactive-demos/<docId>[-…]
+ *
+ * (`safeKey = key.replace(/[^a-zA-Z0-9_-]/g, '-')` over `<docId>:m:<id>` / `<docId>:e:<n>` /
+ * `<docId>:v<n>`; the doc grammar is `[a-z0-9-]`, so the `:`→`-` fold is unambiguous per seam.)
+ * That is the binding this module reads back: a run is the doc's when one of its write roots
+ * sits under an `interactive-*` directory and is named by the doc this way. The match is then
+ * narrowed to the thread's project (the DTO's `project_id`, when the daemon joins it).
+ */
+
+import { api } from '../api/client.js';
+import type { SessionView } from '../api/types.js';
+import { LIVE_RUN, threadKey, useDocThreadStore } from '../store/docThread.js';
+
+/** The seams' state-home directories — the parent a doc run's write root sits under. */
+const SEAM_DIR = /^interactive-(drafts|chats|edits|demos)$/;
+
+/** Is `base` (a write root's own name) the doc's, under the seams' key grammars? */
+function namesDoc(base: string, docId: string): boolean {
+  if (base === docId) return true;
+  if (!base.startsWith(`${docId}-`)) return false;
+  const tail = base.slice(docId.length + 1);
+  // `-m-<msg>` / `-e-<n>` (asks), `-v<n>` (edits), or a demo handoff's `-v<n>`-style tail.
+  return /^(m-.+|e-.+|v\d+)$/.test(tail);
+}
+
+/** True when this run's declared write roots bind it to `docId`. */
+export function isDocRun(view: SessionView, docId: string): boolean {
+  if (docId === '') return false;
+  for (const root of view.session.extra_write_roots ?? []) {
+    const parts = root.split(/[\\/]+/).filter((p) => p !== '');
+    if (parts.length < 2) continue;
+    const base = parts[parts.length - 1] ?? '';
+    const parent = parts[parts.length - 2] ?? '';
+    if (SEAM_DIR.test(parent) && namesDoc(base, docId)) return true;
+  }
+  return false;
+}
+
+/** Whether a run's filing agrees with the thread's project — an unjoined DTO (no `project_id`)
+ *  cannot disagree; the Unfiled mount matches unfiled runs (`null` / `'default'`). */
+function inProject(view: SessionView, projectId: string): boolean {
+  const pid = view.session.project_id;
+  if (pid === undefined) return true;
+  if (pid === null || pid === 'default') return projectId === 'default';
+  return pid === projectId;
+}
+
+/**
+ * The doc's bound run off the run list, LIVE runs first (daemon order is actionable-first then
+ * newest-first, so the first live match is the one executing now), else the newest terminal
+ * record; `null` when no run declares this doc.
+ */
+export function docRunOf(runs: readonly SessionView[], projectId: string, docId: string): SessionView | null {
+  const mine = runs.filter((v) => v.session.archived_at == null && inProject(v, projectId) && isDocRun(v, docId));
+  return mine.find((v) => LIVE_RUN.has(v.session.status)) ?? mine[0] ?? null;
+}
+
+/** Threads whose run binding this session has already read (one `GET /runs` per doc open). */
+const restored = new Set<string>();
+
+/** Test seam. */
+export function clearRunRestores(): void {
+  restored.clear();
+}
+
+/**
+ * Read the runs wire once for this doc and adopt what it says (F-4R2-006). Never throws: a
+ * daemon that cannot list runs leaves the thread exactly as the conversation read left it.
+ */
+export async function restoreDocRun(projectId: string, docId: string): Promise<void> {
+  const key = threadKey(projectId, docId);
+  if (restored.has(key)) return;
+  restored.add(key);
+  let runs: SessionView[];
+  try {
+    ({ runs } = await api.listRuns());
+  } catch {
+    restored.delete(key); // nothing learned — the next open may try again
+    return;
+  }
+  const run = docRunOf(runs, projectId, docId);
+  if (run !== null) useDocThreadStore.getState().adoptRun(key, run);
+}

--- a/src/interactive/runFailure.ts
+++ b/src/interactive/runFailure.ts
@@ -1,0 +1,107 @@
+/**
+ * The crew seams' run-failure line, read for a human (acceptance finding F-4R2-014).
+ *
+ * When the governed run behind a document ask dies, crew's interactive seams (`chat-events`,
+ * `draft-events`, `edit-events`, `demo-events`) narrate it as ONE `status.posted
+ * {state:"error"}` frame whose message is the operator dump verbatim:
+ *
+ *   The crew run answering your ask failed (run <uuid>). Reason: [wicked-crew] deliverable
+ *   floor: this phase declared 1 artifact(s); … [wicked-crew] EXPECTED: /abs/state/…/revised.html
+ *   [wicked-crew] FOUND: (nothing) … DELIVERABLE FLOOR FAILED — … Inspect it via the crew API
+ *   (GET /api/v1/runs/<uuid>), then resend the message.
+ *
+ * The failure is HONEST and stays — the floor did its job — but a document chat is not the
+ * place for absolute state-home paths, issue numbers and a raw API URL. This module reads the
+ * line into: the run it names (so the thread can LINK the run page instead of quoting a GET),
+ * whether it failed or was cancelled, which seam spoke (ask / document / edit / demo), and a
+ * one-sentence customer summary derived from the floor's own EXPECTED path (the step that
+ * produced no file). The raw text is kept whole for the collapsed "details" block — translation
+ * never paraphrases a refusal away, it only moves the dump behind a fold.
+ *
+ * A line that does not match the seams' spelling is not a run failure and parses to `null`;
+ * the thread renders it as the plain error narration it always did.
+ */
+
+export type RunFailureSeam = 'ask' | 'document' | 'edit' | 'demo';
+
+export interface RunFailure {
+  /** The run the seam named — `null` never happens for a matching line, kept nullable for callers. */
+  runId: string;
+  cancelled: boolean;
+  seam: RunFailureSeam;
+  /** The seam's reason text after `Reason:` (or `''`), with the trailing "Inspect it via …" remedy removed. */
+  reason: string;
+  /** The deliverable the floor expected (the first `EXPECTED:` path), when the floor spoke. */
+  expected: string | null;
+  /** The named step that produced no file — derived from `expected`'s file name. */
+  step: string | null;
+  /** The customer sentence. */
+  summary: string;
+}
+
+// The four seams' spellings (crew `interactive/*-events.ts`), one regex. The uuid is the run.
+const HEAD =
+  /^The crew run answering (your ask|this document|this edit|this demo) (failed|was cancelled) \(run ([0-9a-fA-F-]{8,})\)\.\s*(.*)$/s;
+
+const SEAM: Record<string, RunFailureSeam> = {
+  'your ask': 'ask',
+  'this document': 'document',
+  'this edit': 'edit',
+  'this demo': 'demo',
+};
+
+/** What each seam's deliverable is called in the summary — the noun the customer used. */
+const NOUN: Record<RunFailureSeam, string> = {
+  ask: 'document',
+  document: 'document',
+  edit: 'document',
+  demo: 'demo',
+};
+
+/** The crew seams' remedy tail — an API URL and "resend"/"assist loop" prose: dropped from `reason`. */
+const REMEDY_TAIL = /\s*Inspect it via the crew API \(GET [^)]*\)[^.]*\.?\s*$/;
+
+/** The floor's first EXPECTED path (absolute, up to the next `[wicked-crew]` marker or whitespace-run). */
+const EXPECTED = /EXPECTED:\s*(\S+)/;
+
+/** The step a deliverable path names, by the floor's own file conventions (crew `interactive/*-events.ts`). */
+export function stepOf(expectedPath: string | null): string | null {
+  if (expectedPath === null) return null;
+  const base = expectedPath.split(/[\\/]/).pop() ?? '';
+  if (/^revised\.html$/i.test(base)) return 'revise';
+  if (/-v1\.html$/i.test(base)) return 'draft';
+  if (/\.spec\.(mjs|js|ts)$/i.test(base)) return 'demo spec';
+  if (/edited|fragment|handoff/i.test(base) || /interactive-edits/.test(expectedPath)) return 'edit';
+  return null;
+}
+
+/** True when the reason is the deterministic deliverable floor speaking. */
+function isFloor(reason: string): boolean {
+  return /deliverable floor/i.test(reason);
+}
+
+/** The one customer sentence, from what the line actually says. */
+export function summarize(seam: RunFailureSeam, cancelled: boolean, reason: string, step: string | null): string {
+  const noun = NOUN[seam];
+  if (cancelled) return `The run was cancelled before it produced anything — nothing changed in your ${noun}.`;
+  if (isFloor(reason)) {
+    return step !== null
+      ? `The ${step} step produced no file, so this turn did not land — nothing changed in your ${noun}.`
+      : `The run finished without producing the new version, so this turn did not land — nothing changed in your ${noun}.`;
+  }
+  return `The run failed before it produced the new version — nothing changed in your ${noun}.`;
+}
+
+/** Read one crew run-failure narration; `null` for any other line. */
+export function parseRunFailure(text: string): RunFailure | null {
+  const m = HEAD.exec(text.trim());
+  if (m === null) return null;
+  const seam = SEAM[m[1] ?? ''] ?? 'ask';
+  const cancelled = m[2] === 'was cancelled';
+  const runId = m[3] ?? '';
+  let reason = (m[4] ?? '').trim();
+  reason = reason.replace(/^Reason:\s*/i, '').replace(REMEDY_TAIL, '').trim();
+  const expected = EXPECTED.exec(reason)?.[1] ?? null;
+  const step = stepOf(expected);
+  return { runId, cancelled, seam, reason, expected, step, summary: summarize(seam, cancelled, reason, step) };
+}

--- a/src/interactive/runFailure.ts
+++ b/src/interactive/runFailure.ts
@@ -24,6 +24,32 @@
 
 export type RunFailureSeam = 'ask' | 'document' | 'edit' | 'demo';
 
+/**
+ * Whether the SAME ask can be re-sent from the thread for this seam (F-4R2-014, review F3). Only the
+ * chat seam listens on the wire the composer speaks (`chat.posted`); an edit batch re-posts on its
+ * own wire (`feedback.submitted`, when the thread still holds the items); a draft is launched by
+ * `doc.created` and a demo's spec by the demo surface — neither can be re-sent as a message, and
+ * re-posting the brief as a chat ask fails again with a path in the message (crew's chat seam
+ * refuses: "Crew could not read the document's current version (missing <path>)").
+ */
+export function seamRetry(seam: RunFailureSeam): 'ask' | 'batch' | 'none' {
+  return seam === 'ask' ? 'ask' : seam === 'edit' ? 'batch' : 'none';
+}
+
+/** The way back for a seam whose ask cannot be re-sent from here — said instead of a dead Retry. */
+export function seamWayBack(seam: RunFailureSeam): string | null {
+  switch (seam) {
+    case 'document':
+      return 'A draft cannot be re-sent from here — start the document again from the launch composer (your brief is above; copy it).';
+    case 'demo':
+      return 'The demo\'s spec cannot be re-sent from here — start the demo again from the launch composer, or re-record once a spec exists.';
+    case 'edit':
+      return 'Re-send the feedback from the canvas — click the block and comment again.';
+    default:
+      return null;
+  }
+}
+
 export interface RunFailure {
   /** The run the seam named — `null` never happens for a matching line, kept nullable for callers. */
   runId: string;
@@ -40,14 +66,18 @@ export interface RunFailure {
 }
 
 // The four seams' spellings (crew `interactive/*-events.ts`), one regex. The uuid is the run.
+//   chat  "The crew run answering your ask {failed|was cancelled} (run <id>).…"      (chat-events.ts)
+//   draft "The crew run answering this document {failed|was cancelled} (run <id>).…" (draft-events.ts)
+//   edit  "The crew run answering this edit {failed|was cancelled} (run <id>).…"     (edit-events.ts)
+//   demo  "The crew run authoring this demo's spec {failed|was cancelled} (run <id>).…" (demo-events.ts —
+//         a different VERB and object; the studio's own earlier spelling never matched it, F-review)
 const HEAD =
-  /^The crew run answering (your ask|this document|this edit|this demo) (failed|was cancelled) \(run ([0-9a-fA-F-]{8,})\)\.\s*(.*)$/s;
+  /^The crew run (?:answering (your ask|this document|this edit)|(authoring) this demo's spec) (failed|was cancelled) \(run ([0-9a-fA-F-]{8,})\)\.\s*(.*)$/s;
 
 const SEAM: Record<string, RunFailureSeam> = {
   'your ask': 'ask',
   'this document': 'document',
   'this edit': 'edit',
-  'this demo': 'demo',
 };
 
 /** What each seam's deliverable is called in the summary — the noun the customer used. */
@@ -96,10 +126,10 @@ export function summarize(seam: RunFailureSeam, cancelled: boolean, reason: stri
 export function parseRunFailure(text: string): RunFailure | null {
   const m = HEAD.exec(text.trim());
   if (m === null) return null;
-  const seam = SEAM[m[1] ?? ''] ?? 'ask';
-  const cancelled = m[2] === 'was cancelled';
-  const runId = m[3] ?? '';
-  let reason = (m[4] ?? '').trim();
+  const seam: RunFailureSeam = m[2] === 'authoring' ? 'demo' : (SEAM[m[1] ?? ''] ?? 'ask');
+  const cancelled = m[3] === 'was cancelled';
+  const runId = m[4] ?? '';
+  let reason = (m[5] ?? '').trim();
   reason = reason.replace(/^Reason:\s*/i, '').replace(REMEDY_TAIL, '').trim();
   const expected = EXPECTED.exec(reason)?.[1] ?? null;
   const step = stepOf(expected);

--- a/src/store/docThread.ts
+++ b/src/store/docThread.ts
@@ -18,7 +18,9 @@ import {
 } from '../interactive/threadStopgap.js';
 import { UNFILED_MOUNT } from '../api/interactive.js';
 import type { ConversationEntry, ExportFormat } from '../api/interactive.js';
-import type { CoreEvent } from '../api/types.js';
+import { describeExportReport, exportReportOf } from '../interactive/exportReport.js';
+import { parseRunFailure } from '../interactive/runFailure.js';
+import type { CoreEvent, SessionStatus, SessionView } from '../api/types.js';
 
 // ── Transcript ───────────────────────────────────────────────────────────────
 
@@ -72,10 +74,19 @@ export type DocMsg =
   | { kind: 'user';      id: string; text: string; version?: number;
       items?: FeedbackItem[]; notRecorded?: boolean; failed?: boolean; refused?: boolean;
       restored?: boolean; sentAt?: number }
-  | { kind: 'narration'; id: string; text: string }
+  // F-4R2-005: crew's seams re-emit the CURRENT narration on a ≤15 s heartbeat, so one
+  // phase reads as N identical rows. A repeat of the newest narration is FOLDED into it:
+  // `repeats` counts the heartbeats folded in, `firstAt`/`lastAt` bound the span (arrival
+  // clocks — the frame carries none) so the row can show how long the phase has held.
+  | { kind: 'narration'; id: string; text: string; repeats?: number; firstAt?: number; lastAt?: number }
   // `href` + `file` make an agent message DOWNLOADABLE (§4.4): an export is an ordinary
   // message from the service, carrying its artifact — never a toast, never a second origin.
   | { kind: 'agent';     id: string; author: string; text: string; href?: string; file?: string }
+  // F-4R2-014: the crew seams' "The crew run answering … failed (run <id>). Reason: …" line,
+  // read for a human (`parseRunFailure`): the run it names (linked, never a quoted GET), a
+  // one-sentence summary, and the raw dump kept whole behind a fold. `text` is the line verbatim.
+  | { kind: 'run-failed'; id: string; text: string; runId: string; cancelled: boolean;
+      summary: string; reason: string }
   // §3.3's actionable kind: what happened, the fix NAMED verbatim, and — where the action
   // repeats — what to retry. An error with no next action is banned, so `hint` is required.
   | { kind: 'actionable'; id: string; text: string; hint: string; retry?: ExportRetry }
@@ -207,10 +218,73 @@ export interface VersionLanding { projectId: string; version: number; kind: stri
 /** Ring cap on the observed-landings list — a lens over recent activity, not a ledger. */
 const LANDINGS_CAP = 200;
 
+/**
+ * The governed run a thread is bound to (F-4R2-006), as the runs wire last described it. Crew's
+ * interactive frames carry no run id, so this is learned from `GET /runs` (`runBinding.ts`
+ * matches the run's declared write root to the doc) — on doc open, so a reload mid-run restores
+ * the in-flight state from the run record instead of showing `terminal` until the next heartbeat.
+ */
+export interface BoundRun { runId: string; status: SessionStatus }
+
+/** Run statuses that mean the run is still working (or waiting on a human) — the thread stays live. */
+export const LIVE_RUN: ReadonlySet<SessionStatus> = new Set<SessionStatus>(['planning', 'distributing', 'executing', 'awaiting_human']);
+
+/** The line the thread adds when a reload finds its run still executing (client-authored, §3.3). */
+export const RESTORED_RUN_NARRATION =
+  'Still in progress — a governed run picked this up before the page reloaded and is executing now.';
+
+/**
+ * F-4R2-005: fold a status line into the newest narration when it repeats it verbatim — the
+ * heartbeat's re-emission — instead of appending another identical row. Returns the thread
+ * unchanged-in-length with the newest row's `repeats`/`lastAt` advanced, or `null` when the
+ * line is NOT a repeat (the caller appends). Only the NEWEST message counts: an identical line
+ * after something else happened is a new phase saying the same words, not a heartbeat.
+ */
+function foldRepeat(thread: DocMsg[], text: string, at: number): DocMsg[] | null {
+  const last = thread[thread.length - 1];
+  if (last === undefined || last.kind !== 'narration' || last.text !== text) return null;
+  const folded: DocMsg = {
+    ...last,
+    repeats: (last.repeats ?? 0) + 1,
+    firstAt: last.firstAt ?? at,
+    lastAt: at,
+  };
+  return [...thread.slice(0, -1), folded];
+}
+
+/** A status line as a message: the crew run-failure line becomes the actionable `run-failed`
+ *  kind (F-4R2-014); everything else stays narration. */
+function statusMessage(text: string, at: number): DocMsg {
+  const failure = parseRunFailure(text);
+  if (failure !== null) {
+    return {
+      kind: 'run-failed', id: nextMsgId(), text, runId: failure.runId, cancelled: failure.cancelled,
+      summary: failure.summary, reason: failure.reason,
+    };
+  }
+  return { kind: 'narration', id: nextMsgId(), text, firstAt: at, lastAt: at };
+}
+
 interface DocThreadStore {
   messages: Record<string, DocMsg[]>;
   /** What the stream last said the generation is doing, per thread. */
   genState: Record<string, GenState>;
+  /** The governed run each thread is bound to, when the runs wire named one (F-4R2-006). */
+  boundRun: Record<string, BoundRun>;
+  /**
+   * Adopt the run record the runs wire holds for this thread (F-4R2-006): remember it, and —
+   * when it is still LIVE while the thread believes nothing is in flight — flip the composer
+   * to `generating` and say why in one client-authored line, so a reload mid-run never shows
+   * `terminal` over an executing run. A terminal record only updates the binding. `null` drops it.
+   */
+  adoptRun: (key: string, run: SessionView | null) => void;
+  /**
+   * The bound run's lifecycle frame said it ended (F-4R2-006, belt and braces): record the
+   * terminal status and, when nothing is still queued behind it, retire a `generating` composer
+   * — the seam's own `status.posted {complete|error}` normally does this first; this catches the
+   * one it never sends to this thread.
+   */
+  markRunEnded: (key: string, status: SessionStatus) => void;
   /** The newest `status.posted {state:"error"}` line, per thread — what the
    *  brand-learn poll (learnPoll.ts) reads to surface the bridge's ASYNC
    *  refusals (the SSRF guard's, a failed grab) while it waits on the
@@ -400,6 +474,7 @@ export const useDocThreadStore = create<DocThreadStore>((set, get) => {
   return {
   messages: {},
   genState: {},
+  boundRun: {},
   pending: {},
   hydrated: {},
   landed: {},
@@ -409,6 +484,43 @@ export const useDocThreadStore = create<DocThreadStore>((set, get) => {
   bindings: {},
   held: {},
   expectedDividers: {},
+
+  adoptRun: (key, run) => {
+    if (run === null) {
+      set((s) => {
+        const boundRun = { ...s.boundRun };
+        delete boundRun[key];
+        return { boundRun };
+      });
+      return;
+    }
+    const status = run.session.status;
+    set((s) => {
+      const bound = { boundRun: { ...s.boundRun, [key]: { runId: run.session.id, status } } };
+      const believedIdle = (s.genState[key] ?? 'terminal') === 'terminal';
+      if (!LIVE_RUN.has(status) || !believedIdle) return bound;
+      // The run record outranks the thread's silence: it IS executing. Said once, in words.
+      const thread = s.messages[key] ?? [];
+      const already = thread.some((m) => m.kind === 'narration' && m.text === RESTORED_RUN_NARRATION);
+      return {
+        ...bound,
+        genState: { ...s.genState, [key]: 'generating' },
+        ...(already ? {} : {
+          messages: append(s.messages, key, { kind: 'narration', id: nextMsgId(), text: RESTORED_RUN_NARRATION }),
+        }),
+      };
+    });
+  },
+
+  markRunEnded: (key, status) =>
+    set((s) => {
+      const bound = s.boundRun[key];
+      if (bound === undefined) return s;
+      const boundRun = { ...s.boundRun, [key]: { ...bound, status } };
+      const queued = (s.pending[key] ?? []).length > 0;
+      if (queued || (s.genState[key] ?? 'terminal') !== 'generating') return { boundRun };
+      return { boundRun, genState: { ...s.genState, [key]: 'terminal' } };
+    }),
 
   bindDoc: (projectId, docId, opts) => {
     const pending = opts?.pending === true;
@@ -525,11 +637,22 @@ export const useDocThreadStore = create<DocThreadStore>((set, get) => {
         if (text === null || isFiller(text)) {
           return { messages: base, genState: { ...s.genState, [key]: next }, ...failed, ...pending };
         }
+        // F-4R2-005: a heartbeat re-emitting the newest narration folds into it (one row, a
+        // repeat count and a span) — never a second identical row. A run that ended takes the
+        // thread's live binding with it (F-4R2-006): the record it left is terminal.
+        const at = Date.now();
+        const folded = done ? null : foldRepeat(base[key] ?? [], text, at);
+        const bound = done && s.boundRun[key] !== undefined
+          ? { boundRun: { ...s.boundRun, [key]: { ...s.boundRun[key]!, status: (state === 'error' ? 'failed' : 'completed') as SessionStatus } } }
+          : {};
         return {
-          messages: append(base, key, { kind: 'narration', id: nextMsgId(), text }),
+          messages: folded !== null
+            ? { ...base, [key]: folded }
+            : append(base, key, statusMessage(text, at)),
           genState: { ...s.genState, [key]: next },
           ...failed,
           ...pending,
+          ...bound,
         };
       }
 
@@ -567,7 +690,10 @@ export const useDocThreadStore = create<DocThreadStore>((set, get) => {
         if (href !== null && (messages[key] ?? []).some(
           (m) => m.kind === 'agent' && m.href === href,
         )) return s;
-        const text = `${format.toUpperCase()} export ready — ${file}`;
+        // F-4R2-016 / interactive#219: the additive layout report rides the event too —
+        // rendered when present, silent on an older bridge.
+        const report = describeExportReport(exportReportOf(payload));
+        const text = `${format.toUpperCase()} export ready — ${file}${report === null ? '' : ` · ${report}`}`;
         // Round-3 minor: the announce history carries no exports, so the entry is
         // ALSO recorded in the session stopgap — the reload restores the download.
         if (href !== null) exportEntry = { text, href, file };
@@ -777,8 +903,17 @@ export const useDocThreadStore = create<DocThreadStore>((set, get) => {
           pushRefused(ord);
         } else if (!isFiller(text)) {
           // Agent narration (including error states) at the same seam live frames
-          // cross: filler is dropped here too — one rule, both sources (§3.2).
-          restored.push({ kind: 'narration', id: nextMsgId(), text });
+          // cross: filler is dropped here too — one rule, both sources (§3.2). The
+          // heartbeat's repeats fold the same way (F-4R2-005), and the crew run-failure
+          // line becomes the same actionable card it is live (F-4R2-014). The transcript's
+          // `ts` is the closest clock a restored span has; absent, the span is unknown.
+          const at = typeof e.ts === 'number' ? e.ts : typeof e.ts === 'string' ? Date.parse(e.ts) || 0 : 0;
+          const folded = foldRepeat(restored, text, at);
+          if (folded !== null) {
+            restored.splice(0, restored.length, ...folded);
+          } else {
+            restored.push(statusMessage(text, at));
+          }
         }
       }
       // Round-3 minor: the transcript's export downloads, restored at the tail —
@@ -864,7 +999,8 @@ export const useDocThreadStore = create<DocThreadStore>((set, get) => {
       const lastSignalAt = { ...s.lastSignalAt }; delete lastSignalAt[key];
       const expectedDividers = { ...s.expectedDividers }; delete expectedDividers[key];
       const held = { ...s.held }; delete held[docId];
-      return { messages, genState, pending, hydrated, landed, lastError, lastSignalAt, expectedDividers, held };
+      const boundRun = { ...s.boundRun }; delete boundRun[key];
+      return { messages, genState, pending, hydrated, landed, lastError, lastSignalAt, expectedDividers, held, boundRun };
     });
   },
   };

--- a/src/store/docThread.ts
+++ b/src/store/docThread.ts
@@ -19,7 +19,7 @@ import {
 import { UNFILED_MOUNT } from '../api/interactive.js';
 import type { ConversationEntry, ExportFormat } from '../api/interactive.js';
 import { describeExportReport, exportReportOf } from '../interactive/exportReport.js';
-import { parseRunFailure } from '../interactive/runFailure.js';
+import { parseRunFailure, type RunFailureSeam } from '../interactive/runFailure.js';
 import type { CoreEvent, SessionStatus, SessionView } from '../api/types.js';
 
 // ── Transcript ───────────────────────────────────────────────────────────────
@@ -86,7 +86,7 @@ export type DocMsg =
   // read for a human (`parseRunFailure`): the run it names (linked, never a quoted GET), a
   // one-sentence summary, and the raw dump kept whole behind a fold. `text` is the line verbatim.
   | { kind: 'run-failed'; id: string; text: string; runId: string; cancelled: boolean;
-      summary: string; reason: string }
+      summary: string; reason: string; seam: RunFailureSeam }
   // §3.3's actionable kind: what happened, the fix NAMED verbatim, and — where the action
   // repeats — what to retry. An error with no next action is banned, so `hint` is required.
   | { kind: 'actionable'; id: string; text: string; hint: string; retry?: ExportRetry }
@@ -232,6 +232,15 @@ export const LIVE_RUN: ReadonlySet<SessionStatus> = new Set<SessionStatus>(['pla
 /** The line the thread adds when a reload finds its run still executing (client-authored, §3.3). */
 export const RESTORED_RUN_NARRATION =
   'Still in progress — a governed run picked this up before the page reloaded and is executing now.';
+/** …and when the run is parked at a human gate: it is waiting, not executing (review F4). */
+export const RESTORED_RUN_GATED_NARRATION =
+  'Still in progress — a governed run picked this up before the page reloaded and is waiting at a gate (open run).';
+
+/** The restored line for a live status — worded per status, never "executing" over a gated run. */
+export function restoredRunNarration(status: SessionStatus): string {
+  return status === 'awaiting_human' ? RESTORED_RUN_GATED_NARRATION : RESTORED_RUN_NARRATION;
+}
+const RESTORED_RUN_LINES: ReadonlySet<string> = new Set([RESTORED_RUN_NARRATION, RESTORED_RUN_GATED_NARRATION]);
 
 /**
  * F-4R2-005: fold a status line into the newest narration when it repeats it verbatim — the
@@ -259,7 +268,7 @@ function statusMessage(text: string, at: number): DocMsg {
   if (failure !== null) {
     return {
       kind: 'run-failed', id: nextMsgId(), text, runId: failure.runId, cancelled: failure.cancelled,
-      summary: failure.summary, reason: failure.reason,
+      summary: failure.summary, reason: failure.reason, seam: failure.seam,
     };
   }
   return { kind: 'narration', id: nextMsgId(), text, firstAt: at, lastAt: at };
@@ -499,14 +508,15 @@ export const useDocThreadStore = create<DocThreadStore>((set, get) => {
       const bound = { boundRun: { ...s.boundRun, [key]: { runId: run.session.id, status } } };
       const believedIdle = (s.genState[key] ?? 'terminal') === 'terminal';
       if (!LIVE_RUN.has(status) || !believedIdle) return bound;
-      // The run record outranks the thread's silence: it IS executing. Said once, in words.
+      // The run record outranks the thread's silence: it IS live. Said once, in words — worded
+      // per status (a run parked at a human gate is waiting, not executing; review F4).
       const thread = s.messages[key] ?? [];
-      const already = thread.some((m) => m.kind === 'narration' && m.text === RESTORED_RUN_NARRATION);
+      const already = thread.some((m) => m.kind === 'narration' && RESTORED_RUN_LINES.has(m.text));
       return {
         ...bound,
         genState: { ...s.genState, [key]: 'generating' },
         ...(already ? {} : {
-          messages: append(s.messages, key, { kind: 'narration', id: nextMsgId(), text: RESTORED_RUN_NARRATION }),
+          messages: append(s.messages, key, { kind: 'narration', id: nextMsgId(), text: restoredRunNarration(status) }),
         }),
       };
     });
@@ -609,7 +619,15 @@ export const useDocThreadStore = create<DocThreadStore>((set, get) => {
         // pending resolves to the VISIBLE failed state (with its retry) rather than
         // a chip that generates forever. Probe 4 (§8.4.1): the death is one
         // doc-scoped `status.posted {state:"error"}`; nothing else will answer them.
-        const backlog = state === 'error' ? new Set(s.pending[key] ?? []) : null;
+        // F-4R2-014 (review F5): when the error IS a crew run-failure line, the HEAD send did
+        // not fail — its run did, and the card that lands carries the one retry. The head
+        // resolves as answered (no `send failed` chip beside the card's Retry); only the sends
+        // queued BEHIND it — never worked — wear the failed state.
+        const runFailure = state === 'error' && text !== null && parseRunFailure(text) !== null;
+        const queueAtError = s.pending[key] ?? [];
+        const backlog = state === 'error'
+          ? new Set(runFailure ? queueAtError.slice(1) : queueAtError)
+          : null;
         const base = backlog === null || backlog.size === 0
           ? messages
           : {
@@ -625,7 +643,7 @@ export const useDocThreadStore = create<DocThreadStore>((set, get) => {
         // this up" at the budget). The head send resolves here, UN-TAGGED: there
         // is no landing to tag, and nothing else will answer it.
         const queue = s.pending[key] ?? [];
-        const pending = backlog !== null && backlog.size > 0
+        const pending = state === 'error' && queue.length > 0
           ? { pending: { ...s.pending, [key]: [] } }
           : state === 'complete' && queue.length > 0
             ? { pending: { ...s.pending, [key]: queue.slice(1) } }

--- a/src/store/exportAnswers.ts
+++ b/src/store/exportAnswers.ts
@@ -21,10 +21,12 @@
 
 import { create } from 'zustand';
 import type { ExportFormat } from '../api/interactive.js';
+import type { ExportReport } from '../interactive/exportReport.js';
 
 export type ExportAnswer =
   | { state: 'pending'; version: number; format: ExportFormat }
-  | { state: 'ready'; version: number; format: ExportFormat; href: string; file: string }
+  // `report` is the bridge's additive layout report (interactive#219) — `null` on an older bridge.
+  | { state: 'ready'; version: number; format: ExportFormat; href: string; file: string; report?: ExportReport | null }
   | { state: 'failed'; version: number; format: ExportFormat; hint: string };
 
 /** One click site's identity: the doc, on its project mount. */

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -11,8 +11,8 @@
   "studioVersion": "0.5.5",
   "counts": {
     "files": 144,
-    "occurrences": 1242,
-    "static": 1068,
+    "occurrences": 1259,
+    "static": 1082,
     "dynamic": 59,
     "computed": 7
   },
@@ -1524,6 +1524,12 @@
       ]
     },
     {
+      "testId": "doc-bound-run",
+      "files": [
+        "src/components/DocumentThread.tsx"
+      ]
+    },
+    {
       "testId": "doc-canvas",
       "files": [
         "src/components/DocumentCanvas.tsx"
@@ -1537,6 +1543,18 @@
     },
     {
       "testId": "doc-composer-error",
+      "files": [
+        "src/components/DocumentThread.tsx"
+      ]
+    },
+    {
+      "testId": "doc-composer-open-existing",
+      "files": [
+        "src/components/DocumentThread.tsx"
+      ]
+    },
+    {
+      "testId": "doc-composer-rename",
       "files": [
         "src/components/DocumentThread.tsx"
       ]
@@ -1620,7 +1638,31 @@
       ]
     },
     {
+      "testId": "doc-name",
+      "files": [
+        "src/components/DocumentThread.tsx"
+      ]
+    },
+    {
+      "testId": "doc-name-reset",
+      "files": [
+        "src/components/DocumentThread.tsx"
+      ]
+    },
+    {
+      "testId": "doc-name-row",
+      "files": [
+        "src/components/DocumentThread.tsx"
+      ]
+    },
+    {
       "testId": "doc-narration",
+      "files": [
+        "src/components/DocumentThread.tsx"
+      ]
+    },
+    {
+      "testId": "doc-narration-elapsed",
       "files": [
         "src/components/DocumentThread.tsx"
       ]
@@ -1659,6 +1701,42 @@
       "testId": "doc-picker-row",
       "files": [
         "src/components/DocumentCanvas.tsx"
+      ]
+    },
+    {
+      "testId": "doc-run-failed",
+      "files": [
+        "src/components/DocumentThread.tsx"
+      ]
+    },
+    {
+      "testId": "doc-run-failed-details",
+      "files": [
+        "src/components/DocumentThread.tsx"
+      ]
+    },
+    {
+      "testId": "doc-run-failed-raw",
+      "files": [
+        "src/components/DocumentThread.tsx"
+      ]
+    },
+    {
+      "testId": "doc-run-failed-run",
+      "files": [
+        "src/components/DocumentThread.tsx"
+      ]
+    },
+    {
+      "testId": "doc-run-failed-summary",
+      "files": [
+        "src/components/DocumentThread.tsx"
+      ]
+    },
+    {
+      "testId": "doc-run-failed-wayback",
+      "files": [
+        "src/components/DocumentThread.tsx"
       ]
     },
     {
@@ -1879,6 +1957,12 @@
     },
     {
       "testId": "export-recording",
+      "files": [
+        "src/components/ExportMenu.tsx"
+      ]
+    },
+    {
+      "testId": "export-report",
       "files": [
         "src/components/ExportMenu.tsx"
       ]

--- a/tests/DocumentThread.name.test.tsx
+++ b/tests/DocumentThread.name.test.tsx
@@ -1,0 +1,153 @@
+// F-4R2-003 — the document's NAME before Create. The launch composer shows the id the bridge
+// will mint (its own slug of the quoted name or the brief's first six words), live, editable;
+// the create sends the edited name; a 409 still names the colliding document with a link and
+// offers "use a different name" inline — never only the daemon's sentence.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ApiError } from '../src/api/errors.js';
+
+const createDoc = vi.fn();
+
+vi.mock('../src/api/interactive.js', () => ({
+  UNFILED_MOUNT: 'default',
+  createDoc: (...a: unknown[]) => createDoc(...a),
+  docBinding: (pid: string) => (pid === 'default' ? {} : { project: pid }),
+  postFork: vi.fn(),
+  postEvent: vi.fn(),
+  injectDocMessage: vi.fn(),
+  getVersions: vi.fn(),
+  interactiveUrl: (p: string, path: string) => `/api/v1/projects/${p}/interactive${path}`,
+}));
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    listProjectMembers: async () => ({ members: [] }),
+    listRepos: async () => ({ repos: [] }),
+  },
+}));
+
+const { DocumentThread } = await import('../src/components/DocumentThread.js');
+const { useDocThreadStore } = await import('../src/store/docThread.js');
+
+const PROJECT = 'proj-abc';
+const navigate = vi.fn();
+const BRIEF = 'Create a high-end, salesy product brochure for Wicked Studio — two pages, A4.';
+const DERIVED = 'create-a-high-end-salesy-product-brochure';
+
+function mount(): void {
+  render(<DocumentThread projectId={PROJECT} docId={null} selectedVersion={null} navigate={navigate} />);
+}
+
+/** The launch composer refuses to submit until the project's repositories are known (F-046). */
+async function subjectReady(): Promise<void> {
+  await waitFor(() => expect(screen.getByTestId('doc-subject')).toHaveAttribute('data-subject-status', 'ready'));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useDocThreadStore.setState({ messages: {}, genState: {}, pending: {}, hydrated: {}, bindings: {}, held: {} });
+  createDoc.mockImplementation((_p: string, body: { name: string }) =>
+    Promise.resolve({ name: body.name.toLowerCase().replace(/[^a-z0-9-]+/g, '-'), head: 0, generating: true }));
+});
+afterEach(cleanup);
+
+describe('the name field on the launch composer', () => {
+  it('shows the bridge\'s own slug of the brief live, and a quoted name when the ask carries one', async () => {
+    mount();
+    const name = screen.getByTestId('doc-name') as HTMLInputElement;
+    expect(name.value).toBe('');
+    expect(screen.getByTestId('doc-name-row')).toHaveAttribute('data-derived', 'true');
+    fireEvent.change(screen.getByTestId('doc-composer'), { target: { value: BRIEF } });
+    expect(name.value).toBe(DERIVED);
+    fireEvent.change(screen.getByTestId('doc-composer'), { target: { value: 'a brochure titled "Wicked Studio brochure r2" for leaders' } });
+    expect(name.value).toBe('wicked-studio-brochure-r2');
+    // The quoted-parse line still renders beside it (§7.3 — unchanged).
+    expect(screen.getByTestId('create-parse').textContent).toContain('Wicked Studio brochure r2');
+  });
+
+  it('an edited name wins the create and stops following the brief; "use the derived name" returns to it', async () => {
+    mount();
+    fireEvent.change(screen.getByTestId('doc-composer'), { target: { value: BRIEF } });
+    fireEvent.change(screen.getByTestId('doc-name'), { target: { value: 'brochure-r3' } });
+    expect(screen.getByTestId('doc-name-row')).toHaveAttribute('data-derived', 'false');
+    fireEvent.change(screen.getByTestId('doc-composer'), { target: { value: `${BRIEF} Premium.` } });
+    expect((screen.getByTestId('doc-name') as HTMLInputElement).value).toBe('brochure-r3');
+
+    await subjectReady();
+    fireEvent.click(screen.getByTestId('doc-composer-submit'));
+    await waitFor(() => expect(createDoc).toHaveBeenCalledTimes(1));
+    expect(createDoc.mock.calls[0]![1]).toMatchObject({ name: 'brochure-r3', brief: `${BRIEF} Premium.` });
+    expect(navigate).toHaveBeenCalledWith(`/p/${PROJECT}/document/brochure-r3`);
+    // The pending binding was claimed under the typed name's slug — the id every frame carries.
+    expect(Object.keys(useDocThreadStore.getState().bindings)).toEqual(['brochure-r3']);
+  });
+
+  it('the reset control returns to the derived name', () => {
+    mount();
+    fireEvent.change(screen.getByTestId('doc-composer'), { target: { value: BRIEF } });
+    fireEvent.change(screen.getByTestId('doc-name'), { target: { value: 'my-name' } });
+    fireEvent.click(screen.getByTestId('doc-name-reset'));
+    expect((screen.getByTestId('doc-name') as HTMLInputElement).value).toBe(DERIVED);
+    expect(screen.queryByTestId('doc-name-reset')).toBeNull();
+  });
+});
+
+describe('a 409 names the colliding document and offers a way out (F-4R2-003)', () => {
+  it('the daemon\'s 409 renders the collision copy with a link to the existing doc and "use a different name"', async () => {
+    createDoc.mockRejectedValueOnce(new ApiError(409, 'doc already exists'));
+    mount();
+    const user = userEvent.setup();
+    await user.type(screen.getByTestId('doc-composer'), BRIEF);
+    await user.click(screen.getByTestId('doc-composer-submit'));
+
+    const err = await screen.findByTestId('doc-composer-error');
+    expect(err).toHaveAttribute('data-status', '409');
+    expect(err).toHaveAttribute('data-collides-with', DERIVED);
+    expect(err.textContent).toContain(`A document named “${DERIVED}” already exists`);
+    // The daemon's own sentence stays, whole.
+    expect(err.textContent).toContain('doc already exists');
+    // The brief is kept — nothing was sent, nothing lost.
+    expect(screen.getByTestId('doc-composer')).toHaveValue(BRIEF);
+    // The pending claim was released.
+    expect(Object.keys(useDocThreadStore.getState().bindings)).toEqual([]);
+
+    const open = screen.getByTestId('doc-composer-open-existing');
+    expect(open).toHaveAttribute('href', `/p/${PROJECT}/document/${DERIVED}`);
+    fireEvent.click(open);
+    expect(navigate).toHaveBeenCalledWith(`/p/${PROJECT}/document/${DERIVED}`);
+
+    // "use a different name" puts the next free-looking name in the field and clears the collision.
+    fireEvent.click(screen.getByTestId('doc-composer-rename'));
+    expect((screen.getByTestId('doc-name') as HTMLInputElement).value).toBe(`${DERIVED}-2`);
+    expect(screen.queryByTestId('doc-composer-error')).toBeNull();
+
+    // The retried create carries the new name.
+    await user.click(screen.getByTestId('doc-composer-submit'));
+    await waitFor(() => expect(createDoc).toHaveBeenCalledTimes(2));
+    expect(createDoc.mock.calls[1]![1]).toMatchObject({ name: `${DERIVED}-2` });
+  });
+
+  it('a numbered name increments on the way out', async () => {
+    createDoc.mockRejectedValueOnce(new ApiError(409, 'doc already exists'));
+    mount();
+    fireEvent.change(screen.getByTestId('doc-composer'), { target: { value: BRIEF } });
+    fireEvent.change(screen.getByTestId('doc-name'), { target: { value: 'brochure-7' } });
+    await subjectReady();
+    fireEvent.click(screen.getByTestId('doc-composer-submit'));
+    await screen.findByTestId('doc-composer-rename');
+    fireEvent.click(screen.getByTestId('doc-composer-rename'));
+    expect((screen.getByTestId('doc-name') as HTMLInputElement).value).toBe('brochure-8');
+  });
+
+  it('any other refusal keeps the plain composer error', async () => {
+    createDoc.mockRejectedValueOnce(new ApiError(400, 'repo_not_in_project'));
+    mount();
+    fireEvent.change(screen.getByTestId('doc-composer'), { target: { value: BRIEF } });
+    await subjectReady();
+    fireEvent.click(screen.getByTestId('doc-composer-submit'));
+    const err = await screen.findByTestId('doc-composer-error');
+    expect(err).not.toHaveAttribute('data-status');
+    expect(err.textContent).toContain('repo_not_in_project — nothing was sent; edit and try again.');
+  });
+});

--- a/tests/DocumentThread.runFailed.test.tsx
+++ b/tests/DocumentThread.runFailed.test.tsx
@@ -1,0 +1,166 @@
+// F-4R2-014 — the crew run-failure line rendered for a human: one sentence, a link to the run
+// page (never a quoted GET), a Retry that re-sends the SAME ask, and the raw dump behind a
+// collapsed details fold. Plus F-4R2-005's folded narration row and F-4R2-006's bound-run chip.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import type { CoreEvent } from '../src/api/types.js';
+
+const postEvent = vi.fn();
+
+vi.mock('../src/api/interactive.js', () => ({
+  UNFILED_MOUNT: 'default',
+  createDoc: vi.fn(),
+  docBinding: () => ({}),
+  postFork: vi.fn(),
+  postEvent: (...a: unknown[]) => postEvent(...a),
+  injectDocMessage: (p: string, d: string, text: string, id: string) =>
+    postEvent(p, {
+      event_type: 'wicked.interactive.chat.posted',
+      payload: { role: 'user', text, document_id: d, source_message_id: id },
+    }),
+  getVersions: vi.fn(),
+  interactiveUrl: (p: string, path: string) => `/api/v1/projects/${p}/interactive${path}`,
+}));
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    listProjectMembers: async () => ({ members: [] }),
+    listRepos: async () => ({ repos: [] }),
+    listRuns: async () => ({ runs: [] }),
+  },
+}));
+
+const { DocumentThread, fmtSpan } = await import('../src/components/DocumentThread.js');
+const { threadKey, useDocThreadStore } = await import('../src/store/docThread.js');
+const { useRunEventStore } = await import('../src/store/events.js');
+
+const PROJECT = 'proj-abc';
+const DOC = 'brochure';
+const KEY = threadKey(PROJECT, DOC);
+const RUN = '37f020cc-e42c-48aa-b3ec-aa18ec6f9f63';
+const ASK = 'Design change only — replace the violet accent with a deep teal.';
+const LINE =
+  `The crew run answering your ask failed (run ${RUN}). Reason: [wicked-crew] deliverable floor: this phase declared 1 artifact(s). ` +
+  `[wicked-crew] EXPECTED: /w5/state/interactive-chats/${DOC}-m-dmsg-7/revised.html [wicked-crew] FOUND: (nothing) ` +
+  `[wicked-crew] DELIVERABLE FLOOR FAILED — the run reported done without producing the artifact(s) it was launched to produce. ` +
+  `Inspect it via the crew API (GET /api/v1/runs/${RUN}), then resend the message.`;
+
+function status(message: string, state = 'working'): CoreEvent {
+  return {
+    type: 'interactiveEvent',
+    event: { event_type: 'wicked.interactive.status.posted', payload: { project_id: PROJECT, document_id: DOC, state, message } },
+  } as unknown as CoreEvent;
+}
+
+const navigate = vi.fn();
+
+function mount(): void {
+  render(<DocumentThread projectId={PROJECT} docId={DOC} selectedVersion={null} navigate={navigate} />);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  postEvent.mockResolvedValue({ ok: true, event_id: 'e1', correlation_id: 'c1' });
+  useDocThreadStore.setState({ messages: {}, genState: {}, pending: {}, hydrated: {}, landed: {}, lastSignalAt: {}, boundRun: {} });
+  useRunEventStore.setState({ byRun: {} });
+});
+afterEach(() => { cleanup(); vi.useRealTimers(); });
+
+describe('the run-failed card (F-4R2-014)', () => {
+  it('renders the customer sentence, links the run page, folds the raw dump, and Retry re-sends the same ask', async () => {
+    const store = useDocThreadStore.getState();
+    store.addUserMsg(KEY, 'm-1', ASK);
+    store.setGenState(KEY, 'generating');
+    store.ingest(status(LINE, 'error'));
+    mount();
+
+    const card = screen.getByTestId('doc-run-failed');
+    expect(card).toHaveAttribute('data-run-id', RUN);
+    expect(within(card).getByTestId('doc-run-failed-summary')).toHaveTextContent(
+      'The revise step produced no file, so this turn did not land — nothing changed in your document.');
+    // The link is a real anchor to the run page — the raw GET is not in the visible copy.
+    const link = within(card).getByTestId('doc-run-failed-run');
+    expect(link).toHaveAttribute('href', `/runs/${RUN}/timeline`);
+    fireEvent.click(link);
+    expect(navigate).toHaveBeenCalledWith(`/runs/${RUN}/timeline`);
+    const details = within(card).getByTestId('doc-run-failed-details') as HTMLDetailsElement;
+    expect(details.open).toBe(false);
+    expect(within(details).getByTestId('doc-run-failed-raw')).toHaveTextContent('/w5/state/interactive-chats');
+    // The visible (non-details) copy carries no absolute path and no API URL.
+    const visible = Array.from(card.childNodes)
+      .filter((n) => !(n instanceof HTMLElement && n.tagName === 'DETAILS'))
+      .map((n) => n.textContent).join(' ');
+    expect(visible).not.toContain('/w5/state');
+    expect(visible).not.toContain('GET /api/v1/runs');
+
+    // Retry — the SAME ask goes out again as a new send on the inject wire.
+    const retry = within(card).getByTestId('doc-actionable-retry');
+    expect(retry).toHaveAttribute('data-kind', 'resend');
+    await act(async () => { fireEvent.click(retry); });
+    expect(postEvent).toHaveBeenCalledTimes(1);
+    expect(postEvent.mock.calls[0]![1]).toMatchObject({
+      event_type: 'wicked.interactive.chat.posted',
+      payload: { role: 'user', text: ASK, document_id: DOC },
+    });
+    const users = useDocThreadStore.getState().messages[KEY]!.filter((m) => m.kind === 'user');
+    expect(users).toHaveLength(2);
+    expect(useDocThreadStore.getState().genState[KEY]).toBe('generating');
+    expect(screen.getByTestId('thread')).toHaveAttribute('data-composer-state', 'generating');
+  });
+
+  it('a restored card with no user line above it offers the link but no Retry (nothing to resend)', () => {
+    useDocThreadStore.getState().hydrate(KEY, [{ role: 'agent', text: LINE, ts: 2, state: 'error' }], []);
+    mount();
+    const card = screen.getByTestId('doc-run-failed');
+    expect(within(card).getByTestId('doc-run-failed-run')).toBeInTheDocument();
+    expect(within(card).queryByTestId('doc-actionable-retry')).toBeNull();
+  });
+});
+
+describe('the folded narration row (F-4R2-005)', () => {
+  it('seven heartbeats render ONE doc-narration row with a live elapsed counter while generating', () => {
+    vi.useFakeTimers({ now: 10_000_000 });
+    const store = useDocThreadStore.getState();
+    store.addUserMsg(KEY, 'm-1', 'a brochure');
+    for (let i = 0; i < 7; i += 1) {
+      store.ingest(status('Convening a 5-seat council to pick who writes the draft…'));
+      vi.advanceTimersByTime(15_000);
+    }
+    mount();
+    const rows = screen.getAllByTestId('doc-narration');
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toHaveAttribute('data-repeats', '6');
+    const elapsed = within(rows[0]!).getByTestId('doc-narration-elapsed');
+    expect(elapsed.textContent).toContain('for ');
+    const before = elapsed.textContent;
+    act(() => { vi.advanceTimersByTime(3_000); });
+    expect(within(rows[0]!).getByTestId('doc-narration-elapsed').textContent).not.toBe(before);
+  });
+
+  it('fmtSpan reads in words', () => {
+    expect(fmtSpan(48_000)).toBe('48s');
+    expect(fmtSpan(135_000)).toBe('2m 15s');
+    expect(fmtSpan(3_840_000)).toBe('1h 04m');
+  });
+});
+
+describe('the bound run (F-4R2-006)', () => {
+  it('a live bound run keeps the composer generating with an "open run" link, and its lifecycle frame ends it', () => {
+    useDocThreadStore.getState().adoptRun(KEY, {
+      session: { id: RUN, status: 'executing', extra_write_roots: [] }, units: [],
+    } as never);
+    mount();
+    expect(screen.getByTestId('thread')).toHaveAttribute('data-composer-state', 'generating');
+    const chip = screen.getByTestId('steering-chip');
+    expect(chip.textContent).toContain('steering the live document run');
+    const link = within(chip).getByTestId('doc-bound-run');
+    expect(link).toHaveAttribute('href', `/runs/${RUN}/timeline`);
+    expect(link).toHaveAttribute('data-run-status', 'executing');
+
+    act(() => {
+      useRunEventStore.getState().ingest({ type: 'sessionCompleted', session: RUN } as unknown as CoreEvent);
+    });
+    expect(screen.getByTestId('thread')).toHaveAttribute('data-composer-state', 'terminal');
+    expect(useDocThreadStore.getState().boundRun[KEY]).toEqual({ runId: RUN, status: 'completed' });
+  });
+});

--- a/tests/DocumentThread.runFailed.test.tsx
+++ b/tests/DocumentThread.runFailed.test.tsx
@@ -6,6 +6,7 @@ import { act, cleanup, fireEvent, render, screen, within } from '@testing-librar
 import type { CoreEvent } from '../src/api/types.js';
 
 const postEvent = vi.fn();
+const getVersions = vi.fn();
 
 vi.mock('../src/api/interactive.js', () => ({
   UNFILED_MOUNT: 'default',
@@ -18,7 +19,7 @@ vi.mock('../src/api/interactive.js', () => ({
       event_type: 'wicked.interactive.chat.posted',
       payload: { role: 'user', text, document_id: d, source_message_id: id },
     }),
-  getVersions: vi.fn(),
+  getVersions: (...a: unknown[]) => getVersions(...a),
   interactiveUrl: (p: string, path: string) => `/api/v1/projects/${p}/interactive${path}`,
 }));
 
@@ -61,6 +62,7 @@ function mount(): void {
 beforeEach(() => {
   vi.clearAllMocks();
   postEvent.mockResolvedValue({ ok: true, event_id: 'e1', correlation_id: 'c1' });
+  getVersions.mockResolvedValue({ head: 3, versions: [] });
   useDocThreadStore.setState({ messages: {}, genState: {}, pending: {}, hydrated: {}, landed: {}, lastSignalAt: {}, boundRun: {} });
   useRunEventStore.setState({ byRun: {} });
 });
@@ -93,6 +95,10 @@ describe('the run-failed card (F-4R2-014)', () => {
     expect(visible).not.toContain('/w5/state');
     expect(visible).not.toContain('GET /api/v1/runs');
 
+    // Review F5: ONE retry affordance — the bubble above the card wears no "send failed · retry".
+    expect(screen.queryByTestId('thread-send-failed')).toBeNull();
+    expect(screen.queryByTestId('thread-send-retry')).toBeNull();
+
     // Retry — the SAME ask goes out again as a new send on the inject wire.
     const retry = within(card).getByTestId('doc-actionable-retry');
     expect(retry).toHaveAttribute('data-kind', 'resend');
@@ -114,6 +120,80 @@ describe('the run-failed card (F-4R2-014)', () => {
     const card = screen.getByTestId('doc-run-failed');
     expect(within(card).getByTestId('doc-run-failed-run')).toBeInTheDocument();
     expect(within(card).queryByTestId('doc-actionable-retry')).toBeNull();
+  });
+
+  // Review F3: Retry rides the wire that failed. A DRAFT-seam failure (the brief is the user
+  // line above) must not re-post the brief as a chat ask — crew's chat seam refuses with a path.
+  it('a draft-seam failure offers NO Retry and says the way back; the brief above wears no failed chip', () => {
+    const DRAFT_LINE =
+      `The crew run answering this document failed (run ${RUN}). Reason: [wicked-crew] deliverable floor: ` +
+      `[wicked-crew] EXPECTED: /w5/state/interactive-drafts/${DOC}/${DOC}-v1.html [wicked-crew] FOUND: (nothing). ` +
+      `Inspect it via the crew API (GET /api/v1/runs/${RUN}); the assist loop can still take over.`;
+    const store = useDocThreadStore.getState();
+    store.addUserMsg(KEY, 'm-1', 'a two-page A4 brochure about the studio');
+    store.setGenState(KEY, 'generating');
+    store.ingest(status(DRAFT_LINE, 'error'));
+    mount();
+    const card = screen.getByTestId('doc-run-failed');
+    expect(within(card).getByTestId('doc-run-failed-summary')).toHaveTextContent('The draft step produced no file');
+    expect(within(card).queryByTestId('doc-actionable-retry')).toBeNull();
+    const way = within(card).getByTestId('doc-run-failed-wayback');
+    expect(way).toHaveAttribute('data-seam', 'document');
+    expect(way).toHaveTextContent('start the document again from the launch composer');
+    expect(screen.queryByTestId('thread-send-failed')).toBeNull();
+    expect(postEvent).not.toHaveBeenCalled();
+  });
+
+  it('a demo-seam failure (crew\'s real "authoring this demo\'s spec" sentence) renders the card, not the raw dump', () => {
+    const DEMO_LINE =
+      `The crew run authoring this demo's spec failed (run ${RUN}). Reason: worker exited 137. ` +
+      `Inspect it via the crew API (GET /api/v1/runs/${RUN}); no recording was triggered.`;
+    useDocThreadStore.getState().ingest(status(DEMO_LINE, 'error'));
+    mount();
+    const card = screen.getByTestId('doc-run-failed');
+    expect(within(card).getByTestId('doc-run-failed-summary')).toHaveTextContent('nothing changed in your demo');
+    expect(within(card).getByTestId('doc-run-failed-wayback')).toHaveAttribute('data-seam', 'demo');
+    expect(screen.queryByTestId('doc-narration')).toBeNull();
+  });
+
+  it('an edit-seam failure re-sends the SAME feedback batch on the batch wire — never as plain chat', async () => {
+    const EDIT_LINE =
+      `The crew run answering this edit failed (run ${RUN}). Reason: [wicked-crew] deliverable floor: ` +
+      `[wicked-crew] EXPECTED: /w5/state/interactive-edits/${DOC}-v3/edited-fragments.json [wicked-crew] FOUND: (nothing). ` +
+      `Inspect it via the crew API (GET /api/v1/runs/${RUN}); the assist loop can still take over.`;
+    const items = [{ wid: 'section-4', text: 'Remove the CI note', mode: 'comment' as const }];
+    const store = useDocThreadStore.getState();
+    store.addUserMsg(KEY, 'm-1', 'Feedback on 1 place in this document:\n1. [section-4] Remove the CI note', items);
+    store.setGenState(KEY, 'generating');
+    store.ingest(status(EDIT_LINE, 'error'));
+    mount();
+    const card = screen.getByTestId('doc-run-failed');
+    const retry = within(card).getByTestId('doc-actionable-retry');
+    expect(retry).toHaveAttribute('data-kind', 'resend-batch');
+    expect(retry).toHaveTextContent('send the same feedback again (1 place)');
+    await act(async () => { fireEvent.click(retry); });
+    // Write 1: the batch event, on the head version, with the same anchors; write 2: the inject.
+    await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+    expect(getVersions).toHaveBeenCalledWith(PROJECT, DOC);
+    const batch = postEvent.mock.calls.find((c) => (c[1] as { event_type: string }).event_type === 'wicked.interactive.feedback.submitted');
+    expect(batch).toBeDefined();
+    expect((batch![1] as { payload: Record<string, unknown> }).payload).toMatchObject({ document_id: DOC, version: 3 });
+    expect(JSON.stringify((batch![1] as { payload: Record<string, unknown> }).payload.items)).toContain('section-4');
+    const inject = postEvent.mock.calls.find((c) => (c[1] as { event_type: string }).event_type === 'wicked.interactive.chat.posted');
+    expect(inject).toBeDefined();
+    expect(useDocThreadStore.getState().genState[KEY]).toBe('generating');
+  });
+
+  it('an edit-seam failure whose batch items the thread no longer holds (a restored transcript) says the way back instead', () => {
+    const EDIT_LINE = `The crew run answering this edit failed (run ${RUN}). Reason: worker exited 1. Inspect it via the crew API (GET /api/v1/runs/${RUN}); the assist loop can still take over.`;
+    useDocThreadStore.getState().hydrate(KEY, [
+      { role: 'user', text: 'Feedback on 1 place in this document:\n1. [section-4] Remove the CI note', ts: 1 },
+      { role: 'agent', text: EDIT_LINE, ts: 2, state: 'error' },
+    ], []);
+    mount();
+    const card = screen.getByTestId('doc-run-failed');
+    expect(within(card).queryByTestId('doc-actionable-retry')).toBeNull();
+    expect(within(card).getByTestId('doc-run-failed-wayback')).toHaveTextContent('click the block and comment again');
   });
 });
 

--- a/tests/DocumentThread.test.tsx
+++ b/tests/DocumentThread.test.tsx
@@ -114,7 +114,14 @@ describe('state 1 — idle: typing CREATES the doc-generation run', () => {
     createDoc.mockRejectedValue(new Error('API 409: doc already exists'));
     mount(null);
     await send('a deck for the Q3 review');
-    await waitFor(() => expect(screen.getByTestId('doc-composer-error')).toHaveTextContent('409'));
+    // F-4R2-003: a collision NAMES the document and offers the way out; the daemon's own
+    // sentence still rides along, dimmed — carried whole, never paraphrased away.
+    const err = await screen.findByTestId('doc-composer-error');
+    expect(err).toHaveAttribute('data-status', '409');
+    expect(err).toHaveTextContent('A document named “a-deck-for-the-q3-review” already exists');
+    expect(err).toHaveTextContent('409');
+    expect(screen.getByTestId('doc-composer-open-existing')).toHaveAttribute('href', `/p/${PROJECT}/document/a-deck-for-the-q3-review`);
+    expect(screen.getByTestId('doc-composer-rename')).toBeInTheDocument();
     expect(screen.getByTestId('doc-composer')).toHaveValue('a deck for the Q3 review');
   });
 });

--- a/tests/ExportMenu.test.tsx
+++ b/tests/ExportMenu.test.tsx
@@ -153,6 +153,44 @@ describe('the version strip exports the SELECTED version (§4.4, §4.2)', () => 
     expect(screen.getAllByTestId('export-format')).toHaveLength(2);
   });
 
+  // F-4R2-016: readiness is PER FORMAT. Pre-fix, `readyHere` was the FIRST ready answer for
+  // the version, so an un-consumed HTML answer shadowed the PDF that finished after it — the
+  // PDF button spun for 120 s while the file already sat in the thread.
+  it('F-4R2-016: a second format finishing while the first READY answer is un-acted flips ITS OWN chip', async () => {
+    strip();
+    postExport.mockResolvedValue(reply('roadmap_v3.html', 'html'));
+    await press('html');
+    const html = await screen.findByTestId('export-ready');
+    expect(html).toHaveAttribute('data-format', 'html');
+
+    // The HTML download is NOT clicked (un-consumed) — then the PDF is asked for.
+    let release: (v: unknown) => void = () => {};
+    postExport.mockImplementation(() => new Promise((res) => { release = res; }));
+    await press('pdf');
+    expect(screen.getByTestId('export-pending').closest('[data-format="pdf"]')).not.toBeNull();
+    release({ ...reply('roadmap_v3.pdf'), layout: 'document', layout_source: 'author @page', page_size: 'A4 portrait', pages: 2 });
+
+    await waitFor(() => expect(screen.getAllByTestId('export-ready')).toHaveLength(2));
+    const ready = screen.getAllByTestId('export-ready').map((a) => a.getAttribute('data-format'));
+    expect(ready).toEqual(['html', 'pdf']);
+    expect(screen.queryByTestId('export-pending')).toBeNull();
+    // Only PPTX is still a plain button.
+    expect(screen.getAllByTestId('export-format').map((b) => b.getAttribute('data-format'))).toEqual(['pptx']);
+
+    // interactive#219: what the PDF printed — on the anchor and as its own line under the row.
+    const pdf = screen.getAllByTestId('export-ready')[1]!;
+    expect(pdf).toHaveAttribute('data-pages', '2');
+    expect(pdf).toHaveAttribute('data-page-size', 'A4 portrait');
+    expect(pdf.getAttribute('title')).toContain('2 pages · A4 portrait — layout from author @page');
+    const report = screen.getByTestId('export-report');
+    expect(report).toHaveAttribute('data-format', 'pdf');
+    expect(report).toHaveTextContent('PDF ready — 2 pages · A4 portrait');
+    // The thread line carries it too.
+    expect(messages().some((m) => m.kind === 'agent' && m.text === 'PDF export ready — roadmap_v3.pdf · 2 pages · A4 portrait')).toBe(true);
+    // The HTML answer (no report on an older bridge's reply) has no report line.
+    expect(screen.getAllByTestId('export-report')).toHaveLength(1);
+  });
+
   it('round-3 J3: a new version selection KEEPS the un-acted READY answer, wearing its own version', async () => {
     const { rerender } = render(
       <VersionStrip projectId={PROJECT} docId={DOC} manifest={MANIFEST}

--- a/tests/docThread.collapse.test.ts
+++ b/tests/docThread.collapse.test.ts
@@ -105,19 +105,33 @@ describe('the crew run-failure line becomes the actionable run-failed kind (F-4R
     `[wicked-crew] DELIVERABLE FLOOR FAILED — the run reported done without producing the artifact(s). ` +
     `Inspect it via the crew API (GET /api/v1/runs/${RUN}), then resend the message.`;
 
-  it('live: the error frame lands as run-failed with the run id, the summary and the raw text; the send fails visibly', () => {
+  it('live: the error frame lands as run-failed with the run id, seam, summary and raw text; the HEAD send resolves (the card carries the one retry), a QUEUED send fails visibly', () => {
     useDocThreadStore.getState().addUserMsg(KEY, 'm-1', 'make the palette teal');
+    useDocThreadStore.getState().addUserMsg(KEY, 'm-2', 'and then the fonts');
     useDocThreadStore.getState().setGenState(KEY, 'generating');
     ingest(status(LINE, 'error'));
     const card = messages().find((m) => m.kind === 'run-failed') as Extract<DocMsg, { kind: 'run-failed' }>;
     expect(card).toBeDefined();
     expect(card.runId).toBe(RUN);
+    expect(card.seam).toBe('ask');
     expect(card.summary).toBe('The revise step produced no file, so this turn did not land — nothing changed in your document.');
     expect(card.text).toBe(LINE);
     expect(useDocThreadStore.getState().genState[KEY]).toBe('terminal');
-    expect((messages()[0] as Extract<DocMsg, { kind: 'user' }>).failed).toBe(true);
+    // Review F5: the head send did not fail — its RUN did; one retry, on the card, never a second
+    // "send failed · retry" chip on the bubble above it. The send queued behind it was never worked.
+    expect((messages()[0] as Extract<DocMsg, { kind: 'user' }>).failed).toBeUndefined();
+    expect((messages()[1] as Extract<DocMsg, { kind: 'user' }>).failed).toBe(true);
+    expect(useDocThreadStore.getState().pending[KEY]).toEqual([]);
     // The error is still indexed as the thread's newest failure (the brand-learn poll reads it).
     expect(useDocThreadStore.getState().lastError[KEY]?.text).toBe(LINE);
+  });
+
+  it('a plain error line (not a crew run failure) still fails the whole backlog visibly (EC36 unchanged)', () => {
+    useDocThreadStore.getState().addUserMsg(KEY, 'm-1', 'make the palette teal');
+    useDocThreadStore.getState().setGenState(KEY, 'generating');
+    ingest(status('Crew could not start a run for this document: engine busy.', 'error'));
+    expect((messages()[0] as Extract<DocMsg, { kind: 'user' }>).failed).toBe(true);
+    expect(messages().some((m) => m.kind === 'run-failed')).toBe(false);
   });
 
   it('a bound run that the seam reports failed is recorded as such', () => {

--- a/tests/docThread.collapse.test.ts
+++ b/tests/docThread.collapse.test.ts
@@ -1,0 +1,140 @@
+// F-4R2-005 + F-4R2-014 at the store seam.
+//
+// Crew's seams re-emit the CURRENT narration on a ≤15 s heartbeat — the phase4-r2 draft thread
+// carried 39 narration rows for one draft ("Crew phase 2/3: writing the draft (draft)…" ×16).
+// A repeat of the NEWEST narration folds into it (one row, a repeat count, a span); a line
+// that differs is a new row; the same words after something else happened are a new phase.
+// And the crew run-failure line becomes the actionable `run-failed` kind, live and restored.
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ConversationEntry } from '../src/api/interactive.js';
+import type { CoreEvent } from '../src/api/types.js';
+import { threadKey, useDocThreadStore, type DocMsg } from '../src/store/docThread.js';
+
+const PROJECT = 'proj-abc';
+const DOC = 'brochure';
+const KEY = threadKey(PROJECT, DOC);
+const RUN = 'bb28ad5a-febb-411f-b8db-aed1dee8e515';
+
+function status(message: string, state = 'working'): CoreEvent {
+  return {
+    type: 'interactiveEvent',
+    event: { event_type: 'wicked.interactive.status.posted', payload: { project_id: PROJECT, document_id: DOC, state, message } },
+  } as unknown as CoreEvent;
+}
+
+const ingest = (e: CoreEvent): void => useDocThreadStore.getState().ingest(e);
+const messages = (): DocMsg[] => useDocThreadStore.getState().messages[KEY] ?? [];
+const texts = (): string[] => messages().map((m) => ('text' in m ? m.text : m.kind));
+
+const CONVENE = 'Convening a 5-seat council to pick who writes the draft…';
+const PHASE2 = 'Crew phase 2/3: writing the draft (draft)…';
+
+beforeEach(() => {
+  useDocThreadStore.setState({
+    messages: {}, genState: {}, pending: {}, hydrated: {}, landed: {}, lastError: {},
+    lastSignalAt: {}, expectedDividers: {}, bindings: {}, held: {}, boundRun: {},
+  });
+  vi.useRealTimers();
+});
+
+describe('heartbeat repeats fold into ONE narration row (F-4R2-005)', () => {
+  it('seven identical heartbeats are one row carrying repeats=6 and the span they covered', () => {
+    vi.useFakeTimers({ now: 1_000_000 });
+    ingest(status(CONVENE));
+    for (let i = 0; i < 6; i += 1) {
+      vi.advanceTimersByTime(15_000);
+      ingest(status(CONVENE));
+    }
+    expect(texts()).toEqual([CONVENE]);
+    const row = messages()[0] as Extract<DocMsg, { kind: 'narration' }>;
+    expect(row.repeats).toBe(6);
+    expect(row.firstAt).toBe(1_000_000);
+    expect(row.lastAt).toBe(1_000_000 + 6 * 15_000);
+    // The state transition each heartbeat rode in on still applies.
+    expect(useDocThreadStore.getState().genState[KEY]).toBe('generating');
+    vi.useRealTimers();
+  });
+
+  it('a different line is a new row; the same words after another line are a NEW phase, not a fold', () => {
+    ingest(status(CONVENE));
+    ingest(status(CONVENE));
+    ingest(status('Council picked claude for draft…'));
+    ingest(status(PHASE2));
+    ingest(status(PHASE2));
+    ingest(status(PHASE2));
+    ingest(status('Gate approved draft — moving on…'));
+    ingest(status(PHASE2)); // said again after the gate: a new row, not folded into the earlier one
+    expect(texts()).toEqual([
+      CONVENE, 'Council picked claude for draft…', PHASE2, 'Gate approved draft — moving on…', PHASE2,
+    ]);
+    const rows = messages() as Extract<DocMsg, { kind: 'narration' }>[];
+    expect(rows[0]!.repeats).toBe(1);
+    expect(rows[2]!.repeats).toBe(2);
+    expect(rows[4]!.repeats).toBeUndefined();
+  });
+
+  it('a terminal line (complete / error) never folds into the working line it repeats', () => {
+    ingest(status('Landing the draft…'));
+    ingest(status('Landing the draft…', 'complete'));
+    expect(texts()).toEqual(['Landing the draft…', 'Landing the draft…']);
+    expect(useDocThreadStore.getState().genState[KEY]).toBe('terminal');
+  });
+
+  it('the restored transcript folds the same way — 16 repeated rows come back as one', () => {
+    const entries: ConversationEntry[] = [
+      { role: 'user', text: 'a brochure', ts: 1_000 },
+      { role: 'agent', text: 'A governed crew picked up your brief — planning the draft…', ts: 2_000 },
+      ...Array.from({ length: 16 }, (_, i) => ({ role: 'agent', text: PHASE2, ts: 3_000 + i * 15_000 })),
+      { role: 'agent', text: 'Gate approved draft — moving on…', ts: 300_000 },
+    ];
+    useDocThreadStore.getState().hydrate(KEY, entries, []);
+    expect(texts()).toEqual([
+      'a brochure', 'A governed crew picked up your brief — planning the draft…', PHASE2, 'Gate approved draft — moving on…',
+    ]);
+    const folded = messages()[2] as Extract<DocMsg, { kind: 'narration' }>;
+    expect(folded.repeats).toBe(15);
+    expect(folded.firstAt).toBe(3_000);
+    expect(folded.lastAt).toBe(3_000 + 15 * 15_000);
+  });
+});
+
+describe('the crew run-failure line becomes the actionable run-failed kind (F-4R2-014)', () => {
+  const LINE =
+    `The crew run answering your ask failed (run ${RUN}). Reason: [wicked-crew] deliverable floor: this phase declared 1 artifact(s). ` +
+    `[wicked-crew] EXPECTED: /w5/state/interactive-chats/${DOC}-m-dmsg-7/revised.html [wicked-crew] FOUND: (nothing) ` +
+    `[wicked-crew] DELIVERABLE FLOOR FAILED — the run reported done without producing the artifact(s). ` +
+    `Inspect it via the crew API (GET /api/v1/runs/${RUN}), then resend the message.`;
+
+  it('live: the error frame lands as run-failed with the run id, the summary and the raw text; the send fails visibly', () => {
+    useDocThreadStore.getState().addUserMsg(KEY, 'm-1', 'make the palette teal');
+    useDocThreadStore.getState().setGenState(KEY, 'generating');
+    ingest(status(LINE, 'error'));
+    const card = messages().find((m) => m.kind === 'run-failed') as Extract<DocMsg, { kind: 'run-failed' }>;
+    expect(card).toBeDefined();
+    expect(card.runId).toBe(RUN);
+    expect(card.summary).toBe('The revise step produced no file, so this turn did not land — nothing changed in your document.');
+    expect(card.text).toBe(LINE);
+    expect(useDocThreadStore.getState().genState[KEY]).toBe('terminal');
+    expect((messages()[0] as Extract<DocMsg, { kind: 'user' }>).failed).toBe(true);
+    // The error is still indexed as the thread's newest failure (the brand-learn poll reads it).
+    expect(useDocThreadStore.getState().lastError[KEY]?.text).toBe(LINE);
+  });
+
+  it('a bound run that the seam reports failed is recorded as such', () => {
+    useDocThreadStore.getState().adoptRun(KEY, {
+      session: { id: RUN, status: 'executing' } as never, units: [],
+    } as never);
+    ingest(status(LINE, 'error'));
+    expect(useDocThreadStore.getState().boundRun[KEY]).toEqual({ runId: RUN, status: 'failed' });
+  });
+
+  it('restored: the transcript\'s error line comes back as the same card', () => {
+    useDocThreadStore.getState().hydrate(KEY, [
+      { role: 'user', text: 'make the palette teal', ts: 1 },
+      { role: 'agent', text: LINE, ts: 2, state: 'error' },
+    ], []);
+    const card = messages()[1] as Extract<DocMsg, { kind: 'run-failed' }>;
+    expect(card.kind).toBe('run-failed');
+    expect(card.runId).toBe(RUN);
+  });
+});

--- a/tests/exportReport.test.ts
+++ b/tests/exportReport.test.ts
@@ -1,0 +1,37 @@
+// F-4R2-016 / wicked-interactive #219 — the additive export report (`layout`, `layout_source`,
+// `page_size`, `pages`), read null-safely off the response and the event, and phrased for the
+// thread line and the click site. An older bridge that sends none of it renders nothing new.
+import { describe, expect, it } from 'vitest';
+import { describeExportReport, exportReportOf, exportReportTitle } from '../src/interactive/exportReport.js';
+import { exportReadyText } from '../src/interactive/exportWire.js';
+
+describe('exportReportOf', () => {
+  it('reads the four #219 fields and ignores wrong types', () => {
+    expect(exportReportOf({ format: 'pdf', layout: 'document', layout_source: "author @page", page_size: 'A4 portrait', pages: 2 }))
+      .toEqual({ layout: 'document', layoutSource: 'author @page', pageSize: 'A4 portrait', pages: 2 });
+    expect(exportReportOf({ pages: '2', page_size: '' })).toBeNull();
+    expect(exportReportOf({ pages: -1 })).toBeNull();
+    expect(exportReportOf(null)).toBeNull();
+    expect(exportReportOf({ format: 'html', file: 'x.html', download: '/d/x' })).toBeNull();
+  });
+});
+
+describe('describeExportReport / exportReportTitle', () => {
+  it('phrases pages and page size; a document layout goes unsaid, a deck is named', () => {
+    expect(describeExportReport({ layout: 'document', layoutSource: null, pageSize: 'A4 portrait', pages: 2 })).toBe('2 pages · A4 portrait');
+    expect(describeExportReport({ layout: 'deck', layoutSource: 'declared .wi-slide', pageSize: '16:9 (960 × 540 pt)', pages: 3 }))
+      .toBe('deck · 3 pages · 16:9 (960 × 540 pt)');
+    expect(describeExportReport({ layout: null, layoutSource: null, pageSize: null, pages: 1 })).toBe('1 page');
+    expect(describeExportReport({ layout: 'document', layoutSource: 'recorded style', pageSize: null, pages: null })).toBeNull();
+    expect(describeExportReport(null)).toBeNull();
+    expect(exportReportTitle({ layout: 'document', layoutSource: 'author @page', pageSize: 'A4 portrait', pages: 2 }))
+      .toBe('2 pages · A4 portrait — layout from author @page');
+    expect(exportReportTitle({ layout: 'document', layoutSource: null, pageSize: 'A4 portrait', pages: 2 })).toBe('2 pages · A4 portrait');
+  });
+
+  it('the thread line carries the report after the file, and stays the old line without one', () => {
+    expect(exportReadyText('pdf', 'brochure_v3.pdf', { layout: 'document', layoutSource: null, pageSize: 'A4 portrait', pages: 2 }))
+      .toBe('PDF export ready — brochure_v3.pdf · 2 pages · A4 portrait');
+    expect(exportReadyText('html', 'brochure_v3.html', null)).toBe('HTML export ready — brochure_v3.html');
+  });
+});

--- a/tests/runBinding.test.ts
+++ b/tests/runBinding.test.ts
@@ -10,7 +10,7 @@ const listRuns = vi.fn<() => Promise<{ runs: SessionView[] }>>();
 vi.mock('../src/api/client.js', () => ({ api: { listRuns: () => listRuns() } }));
 
 const { clearRunRestores, docRunOf, isDocRun, restoreDocRun } = await import('../src/interactive/runBinding.js');
-const { RESTORED_RUN_NARRATION, threadKey, useDocThreadStore } = await import('../src/store/docThread.js');
+const { RESTORED_RUN_GATED_NARRATION, RESTORED_RUN_NARRATION, threadKey, useDocThreadStore } = await import('../src/store/docThread.js');
 
 const PROJECT = 'proj_178902523421000000';
 const DOC = 'wicked-studio-brochure-r2';
@@ -78,6 +78,19 @@ describe('restoreDocRun — adopting the record on doc open', () => {
     // Once per doc per session — a second open does not re-read the runs wire.
     await restoreDocRun(PROJECT, DOC);
     expect(listRuns).toHaveBeenCalledTimes(1);
+  });
+
+  it('a run parked at a human gate restores as "waiting at a gate", never "executing now" (review F4)', async () => {
+    listRuns.mockResolvedValue({ runs: [run('r-gated', `${STATE}/interactive-drafts/${DOC}`, 'awaiting_human')] });
+    await restoreDocRun(PROJECT, DOC);
+    const s = useDocThreadStore.getState();
+    expect(s.genState[KEY]).toBe('generating');
+    expect(s.messages[KEY]?.map((m) => ('text' in m ? m.text : m.kind))).toEqual([RESTORED_RUN_GATED_NARRATION]);
+    expect(RESTORED_RUN_GATED_NARRATION).toContain('waiting at a gate');
+    expect(RESTORED_RUN_GATED_NARRATION).not.toContain('executing');
+    // A second adoption never doubles either spelling.
+    s.adoptRun(KEY, run('r-gated', `${STATE}/interactive-drafts/${DOC}`, 'executing'));
+    expect(useDocThreadStore.getState().messages[KEY]?.filter((m) => m.kind === 'narration')).toHaveLength(1);
   });
 
   it('a terminal record only binds — the composer stays terminal and no line is added', async () => {

--- a/tests/runBinding.test.ts
+++ b/tests/runBinding.test.ts
@@ -1,0 +1,124 @@
+// F-4R2-006 — the doc↔run binding read back off the runs wire. Crew's frames carry no run id
+// and the announce history no state, so a reload mid-run showed `terminal` until the next
+// heartbeat. Every seam declares the run's own inbox as its write root, named by the doc;
+// that is the binding these tests pin — and what `restoreDocRun` adopts on doc open.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SessionView } from '../src/api/types.js';
+import { makeView } from './factories.js';
+
+const listRuns = vi.fn<() => Promise<{ runs: SessionView[] }>>();
+vi.mock('../src/api/client.js', () => ({ api: { listRuns: () => listRuns() } }));
+
+const { clearRunRestores, docRunOf, isDocRun, restoreDocRun } = await import('../src/interactive/runBinding.js');
+const { RESTORED_RUN_NARRATION, threadKey, useDocThreadStore } = await import('../src/store/docThread.js');
+
+const PROJECT = 'proj_178902523421000000';
+const DOC = 'wicked-studio-brochure-r2';
+const KEY = threadKey(PROJECT, DOC);
+const STATE = '/w5/state';
+
+function run(id: string, root: string, status: SessionView['session']['status'] = 'executing', projectId: string | null | undefined = PROJECT): SessionView {
+  return makeView({
+    id, status, workflow_id: 'interactive-draft', extra_write_roots: [root],
+    ...(projectId === undefined ? {} : { project_id: projectId }),
+  });
+}
+
+beforeEach(() => {
+  listRuns.mockReset();
+  clearRunRestores();
+  useDocThreadStore.setState({ messages: {}, genState: {}, pending: {}, hydrated: {}, boundRun: {} });
+});
+afterEach(() => vi.useRealTimers());
+
+describe('isDocRun — the seams\' write-root grammars', () => {
+  it('matches the draft, ask, edit and demo directories named by this doc, and nothing else', () => {
+    expect(isDocRun(run('d', `${STATE}/interactive-drafts/${DOC}`), DOC)).toBe(true);
+    expect(isDocRun(run('c', `${STATE}/interactive-chats/${DOC}-m-dmsg-7`), DOC)).toBe(true);
+    expect(isDocRun(run('c2', `${STATE}/interactive-chats/${DOC}-e-4412`), DOC)).toBe(true);
+    expect(isDocRun(run('e', `${STATE}/interactive-edits/${DOC}-v3`), DOC)).toBe(true);
+    expect(isDocRun(run('v', `${STATE}/interactive-demos/${DOC}`), DOC)).toBe(true);
+    // A sibling doc whose slug EXTENDS this one is not this doc.
+    expect(isDocRun(run('x', `${STATE}/interactive-drafts/${DOC}-2`), DOC)).toBe(false);
+    expect(isDocRun(run('x', `${STATE}/interactive-chats/${DOC}-2-m-dmsg-1`), DOC)).toBe(false);
+    // A run whose write root is not a seam inbox (a repo worktree) never binds.
+    expect(isDocRun(run('w', `/w5/repos/${DOC}`), DOC)).toBe(false);
+    expect(isDocRun(makeView({ extra_write_roots: [] }), DOC)).toBe(false);
+    // Windows separators read the same.
+    expect(isDocRun(run('win', `C:\\state\\interactive-drafts\\${DOC}`), DOC)).toBe(true);
+  });
+});
+
+describe('docRunOf — which record is the thread\'s', () => {
+  it('prefers the LIVE run, falls back to the newest terminal record, narrows to the project', () => {
+    const done = run('r-done', `${STATE}/interactive-drafts/${DOC}`, 'completed');
+    const live = run('r-live', `${STATE}/interactive-chats/${DOC}-m-dmsg-7`, 'executing');
+    const other = run('r-other', `${STATE}/interactive-drafts/${DOC}`, 'executing', 'proj_other');
+    const unjoined = run('r-old-daemon', `${STATE}/interactive-drafts/${DOC}`, 'executing', undefined);
+    expect(docRunOf([done, live, other], PROJECT, DOC)?.session.id).toBe('r-live');
+    expect(docRunOf([done, other], PROJECT, DOC)?.session.id).toBe('r-done');
+    expect(docRunOf([other], PROJECT, DOC)).toBeNull();
+    // A daemon that does not join project_id cannot disagree with the thread's project.
+    expect(docRunOf([unjoined], PROJECT, DOC)?.session.id).toBe('r-old-daemon');
+    // Archived records are written off.
+    expect(docRunOf([{ ...done, session: { ...done.session, archived_at: 1 } }], PROJECT, DOC)).toBeNull();
+    // The Unfiled mount owns unfiled runs.
+    expect(docRunOf([run('u', `${STATE}/interactive-drafts/${DOC}`, 'executing', null)], 'default', DOC)?.session.id).toBe('u');
+  });
+});
+
+describe('restoreDocRun — adopting the record on doc open', () => {
+  it('an executing run flips a silent thread to generating, says why once, and binds the run', async () => {
+    listRuns.mockResolvedValue({ runs: [run('r-live', `${STATE}/interactive-chats/${DOC}-m-dmsg-7`)] });
+    await restoreDocRun(PROJECT, DOC);
+    const s = useDocThreadStore.getState();
+    expect(s.genState[KEY]).toBe('generating');
+    expect(s.boundRun[KEY]).toEqual({ runId: 'r-live', status: 'executing' });
+    expect(s.messages[KEY]?.map((m) => ('text' in m ? m.text : m.kind))).toEqual([RESTORED_RUN_NARRATION]);
+    // Once per doc per session — a second open does not re-read the runs wire.
+    await restoreDocRun(PROJECT, DOC);
+    expect(listRuns).toHaveBeenCalledTimes(1);
+  });
+
+  it('a terminal record only binds — the composer stays terminal and no line is added', async () => {
+    listRuns.mockResolvedValue({ runs: [run('r-done', `${STATE}/interactive-drafts/${DOC}`, 'failed')] });
+    await restoreDocRun(PROJECT, DOC);
+    const s = useDocThreadStore.getState();
+    expect(s.genState[KEY]).toBeUndefined();
+    expect(s.boundRun[KEY]).toEqual({ runId: 'r-done', status: 'failed' });
+    expect(s.messages[KEY]).toBeUndefined();
+  });
+
+  it('a thread that already knows it is generating (a restored pending send) is not narrated twice', async () => {
+    useDocThreadStore.getState().addUserMsg(KEY, 'm-1', 'the ask');
+    useDocThreadStore.getState().setGenState(KEY, 'generating');
+    listRuns.mockResolvedValue({ runs: [run('r-live', `${STATE}/interactive-chats/${DOC}-m-m-1`)] });
+    await restoreDocRun(PROJECT, DOC);
+    expect(useDocThreadStore.getState().messages[KEY]?.some((m) => m.kind === 'narration')).toBe(false);
+    expect(useDocThreadStore.getState().boundRun[KEY]?.runId).toBe('r-live');
+  });
+
+  it('a daemon that cannot list runs leaves the thread as it was — and the next open may retry', async () => {
+    listRuns.mockRejectedValue(new Error('offline'));
+    await restoreDocRun(PROJECT, DOC);
+    expect(useDocThreadStore.getState().genState[KEY]).toBeUndefined();
+    listRuns.mockResolvedValue({ runs: [run('r-live', `${STATE}/interactive-drafts/${DOC}`)] });
+    await restoreDocRun(PROJECT, DOC);
+    expect(useDocThreadStore.getState().genState[KEY]).toBe('generating');
+  });
+
+  it('markRunEnded retires a generating composer with nothing queued; a queued send keeps it live', () => {
+    const store = useDocThreadStore.getState();
+    store.adoptRun(KEY, run('r-live', `${STATE}/interactive-drafts/${DOC}`));
+    expect(useDocThreadStore.getState().genState[KEY]).toBe('generating');
+    store.markRunEnded(KEY, 'completed');
+    expect(useDocThreadStore.getState().genState[KEY]).toBe('terminal');
+    expect(useDocThreadStore.getState().boundRun[KEY]).toEqual({ runId: 'r-live', status: 'completed' });
+
+    useDocThreadStore.getState().addUserMsg(KEY, 'm-2', 'another ask');
+    useDocThreadStore.getState().setGenState(KEY, 'generating');
+    useDocThreadStore.getState().adoptRun(KEY, run('r-2', `${STATE}/interactive-chats/${DOC}-m-m-2`));
+    useDocThreadStore.getState().markRunEnded(KEY, 'failed');
+    expect(useDocThreadStore.getState().genState[KEY]).toBe('generating');
+  });
+});

--- a/tests/runFailure.test.ts
+++ b/tests/runFailure.test.ts
@@ -1,0 +1,77 @@
+// F-4R2-014 — the crew seams' run-failure line, read for a human. The line is the operator
+// dump verbatim (absolute state-home paths, issue ids, a raw GET); the customer gets one
+// sentence derived from the floor's own EXPECTED path, the run id for a link, and the dump
+// kept whole for the details fold. Anything else parses to null and stays plain narration.
+import { describe, expect, it } from 'vitest';
+import { parseRunFailure, stepOf, summarize } from '../src/interactive/runFailure.js';
+
+const RUN = '37f020cc-e42c-48aa-b3ec-aa18ec6f9f63';
+
+/** The phase4-r2 chat1b line, privacy-scrubbed paths (`/w5/state/…`). */
+const FLOOR_LINE =
+  `The crew run answering your ask failed (run ${RUN}). Reason: [wicked-crew] deliverable floor: this phase declared ` +
+  `1 artifact(s); this run launched at 2026-09-11T10:32:54.984Z. [wicked-crew] EXPECTED: ` +
+  `/w5/state/interactive-chats/wicked-studio-brochure-r2-m-dmsg-7/revised.html [wicked-crew] FOUND: (nothing) ` +
+  `[wicked-crew] MISSING: /w5/state/interactive-chats/wicked-studio-brochure-r2-m-dmsg-7/revised.html (does not exist) ` +
+  `[wicked-crew] DELIVERABLE FLOOR FAILED — the run reported done without producing the artifact(s) it was launched ` +
+  `to produce. A prose reply is not a deliverable (crew#311), and a prior run's leftover file is not this run's. ` +
+  `Inspect it via the crew API (GET /api/v1/runs/${RUN}), then resend the message.`;
+
+describe('parseRunFailure — the seams\' spelling', () => {
+  it('reads the ask seam\'s deliverable-floor failure into run id, step and the customer sentence', () => {
+    const f = parseRunFailure(FLOOR_LINE);
+    expect(f).not.toBeNull();
+    expect(f!.runId).toBe(RUN);
+    expect(f!.cancelled).toBe(false);
+    expect(f!.seam).toBe('ask');
+    expect(f!.expected).toBe('/w5/state/interactive-chats/wicked-studio-brochure-r2-m-dmsg-7/revised.html');
+    expect(f!.step).toBe('revise');
+    expect(f!.summary).toBe(
+      'The revise step produced no file, so this turn did not land — nothing changed in your document.');
+    // The remedy tail (the raw GET + "resend") is not part of the reason the details show twice.
+    expect(f!.reason).not.toContain('Inspect it via the crew API');
+    expect(f!.reason).toContain('DELIVERABLE FLOOR FAILED');
+  });
+
+  it('a draft seam failure names the draft step; a demo names the demo; an edit the edit', () => {
+    const draft = parseRunFailure(
+      `The crew run answering this document failed (run ${RUN}). Reason: [wicked-crew] deliverable floor: ` +
+      `[wicked-crew] EXPECTED: /w5/state/interactive-drafts/launch-deck/launch-deck-v1.html [wicked-crew] FOUND: (nothing). ` +
+      `Inspect it via the crew API (GET /api/v1/runs/${RUN}); the assist loop can still take over.`);
+    expect(draft?.seam).toBe('document');
+    expect(draft?.step).toBe('draft');
+    expect(draft?.summary).toContain('The draft step produced no file');
+    expect(draft?.summary).toContain('in your document.');
+
+    const demo = parseRunFailure(
+      `The crew run answering this demo failed (run ${RUN}). Reason: deliverable floor: EXPECTED: ` +
+      `/w5/state/interactive-demos/checkout-demo-v2/demo.spec.mjs FOUND: (nothing). ` +
+      `Inspect it via the crew API (GET /api/v1/runs/${RUN}); no recording was triggered.`);
+    expect(demo?.seam).toBe('demo');
+    expect(demo?.step).toBe('demo spec');
+    expect(demo?.summary).toContain('in your demo.');
+
+    expect(stepOf('/w5/state/interactive-edits/launch-deck-v3/edited-fragments.json')).toBe('edit');
+    expect(stepOf(null)).toBeNull();
+  });
+
+  it('a cancelled run and a non-floor failure each get their own honest sentence', () => {
+    const cancelled = parseRunFailure(`The crew run answering your ask was cancelled (run ${RUN}). Inspect it via the crew API (GET /api/v1/runs/${RUN}), then resend the message.`);
+    expect(cancelled?.cancelled).toBe(true);
+    expect(cancelled?.summary).toBe('The run was cancelled before it produced anything — nothing changed in your document.');
+    expect(cancelled?.reason).toBe('');
+
+    const other = parseRunFailure(`The crew run answering your ask failed (run ${RUN}). Reason: worker exited 137 (out of memory). Inspect it via the crew API (GET /api/v1/runs/${RUN}), then resend the message.`);
+    expect(other?.summary).toBe('The run failed before it produced the new version — nothing changed in your document.');
+    expect(other?.reason).toBe('worker exited 137 (out of memory).');
+    // A floor that names no EXPECTED path still says the honest generic thing.
+    expect(summarize('ask', false, 'deliverable floor: nothing declared', null))
+      .toBe('The run finished without producing the new version, so this turn did not land — nothing changed in your document.');
+  });
+
+  it('any other narration is NOT a run failure', () => {
+    expect(parseRunFailure('A governed crew picked up your ask — revising the document…')).toBeNull();
+    expect(parseRunFailure('Crew could not start a run for this document: engine busy. The assist loop can still take over.')).toBeNull();
+    expect(parseRunFailure('')).toBeNull();
+  });
+});

--- a/tests/runFailure.test.ts
+++ b/tests/runFailure.test.ts
@@ -3,7 +3,7 @@
 // sentence derived from the floor's own EXPECTED path, the run id for a link, and the dump
 // kept whole for the details fold. Anything else parses to null and stays plain narration.
 import { describe, expect, it } from 'vitest';
-import { parseRunFailure, stepOf, summarize } from '../src/interactive/runFailure.js';
+import { parseRunFailure, seamRetry, seamWayBack, stepOf, summarize } from '../src/interactive/runFailure.js';
 
 const RUN = '37f020cc-e42c-48aa-b3ec-aa18ec6f9f63';
 
@@ -43,11 +43,24 @@ describe('parseRunFailure — the seams\' spelling', () => {
     expect(draft?.summary).toContain('The draft step produced no file');
     expect(draft?.summary).toContain('in your document.');
 
+    // The demo seam's REAL sentence (crew demo-events.ts): a different verb and object —
+    // "authoring this demo's spec" — the studio's earlier "answering this demo" never matched it
+    // (review F2), so a demo failure stayed the raw dump.
     const demo = parseRunFailure(
-      `The crew run answering this demo failed (run ${RUN}). Reason: deliverable floor: EXPECTED: ` +
+      `The crew run authoring this demo's spec failed (run ${RUN}). Reason: deliverable floor: EXPECTED: ` +
       `/w5/state/interactive-demos/checkout-demo-v2/demo.spec.mjs FOUND: (nothing). ` +
       `Inspect it via the crew API (GET /api/v1/runs/${RUN}); no recording was triggered.`);
+    expect(demo).not.toBeNull();
     expect(demo?.seam).toBe('demo');
+    expect(demo?.runId).toBe(RUN);
+    // …and the cancelled spelling of the same seam, with no `Reason:` at all.
+    const demoCancelled = parseRunFailure(
+      `The crew run authoring this demo's spec was cancelled (run ${RUN}). Inspect it via the crew API (GET /api/v1/runs/${RUN}); no recording was triggered.`);
+    expect(demoCancelled?.seam).toBe('demo');
+    expect(demoCancelled?.cancelled).toBe(true);
+    expect(demoCancelled?.summary).toBe('The run was cancelled before it produced anything — nothing changed in your demo.');
+    // The studio's own invented spelling is NOT a crew sentence and must not parse.
+    expect(parseRunFailure(`The crew run answering this demo failed (run ${RUN}).`)).toBeNull();
     expect(demo?.step).toBe('demo spec');
     expect(demo?.summary).toContain('in your demo.');
 
@@ -67,6 +80,17 @@ describe('parseRunFailure — the seams\' spelling', () => {
     // A floor that names no EXPECTED path still says the honest generic thing.
     expect(summarize('ask', false, 'deliverable floor: nothing declared', null))
       .toBe('The run finished without producing the new version, so this turn did not land — nothing changed in your document.');
+  });
+
+  it('Retry is routed to the wire that failed: chat re-posts, an edit re-posts its batch, a draft/demo says the way back (review F3)', () => {
+    expect(seamRetry('ask')).toBe('ask');
+    expect(seamRetry('edit')).toBe('batch');
+    expect(seamRetry('document')).toBe('none');
+    expect(seamRetry('demo')).toBe('none');
+    expect(seamWayBack('ask')).toBeNull();
+    expect(seamWayBack('document')).toContain('start the document again from the launch composer');
+    expect(seamWayBack('demo')).toContain('start the demo again');
+    expect(seamWayBack('edit')).toContain('click the block and comment again');
   });
 
   it('any other narration is NOT a run failure', () => {


### PR DESCRIPTION
## Wave 5 — document thread hardening (phase4-r2 re-run findings)

Five customer-facing findings from the Phase 4 re-run (brochure via Document mode on the 0.7.29 rig), each fixed at the seam it was found, with the honest failure kept where there was one.

| Finding | What the customer saw | Fix |
|---|---|---|
| **F-4R2-016** (MEDIUM) | PDF button spun for 120 s while the PDF already sat in the thread; HTML had flipped in 574 ms | `ExportMenu.tsx:88` took the **first** ready answer for the version, so the un-consumed HTML answer shadowed the PDF. Readiness is now **per (version, format)** — each button asks for its own answer. The bridge's additive report from wicked-interactive #219 (`layout`, `layout_source`, `page_size`, `pages`) is read null-safely off the export **response and the `export.generated` echo** and rendered where present: `export-report` under the row ("PDF ready — 2 pages · A4 portrait"), on the anchor's hover text (`data-pages`, `data-page-size`), and on the thread line. An older bridge renders nothing new. |
| **F-4R2-005** (MEDIUM) | 39 narration rows for one draft — "Crew phase 2/3: writing the draft (draft)…" ×16 | Crew's seams re-emit the **current** narration on a ≤15 s heartbeat. A repeat of the **newest** narration now folds into it (`repeats`, `firstAt`/`lastAt`); the row shows the phase once with a live elapsed counter while generating (`doc-narration[data-repeats]`, `doc-narration-elapsed`). Same fold on the restored transcript. The same words after another line are a new phase, not a fold. |
| **F-4R2-006** (LOW) | Reload mid-run showed `data-composer-state=terminal` for ~20 s until the next heartbeat | Neither the frames nor the announce history carry a run id, and `GET /runs` has no doc filter — but every seam **declares the run's own inbox as its write root**, named by the doc (`interactive-drafts/<doc>`, `interactive-chats/<doc>-m-…` / `-e-…`, `interactive-edits/<doc>-v…`, `interactive-demos/<doc>`). On doc open the thread reads `GET /runs` once (`runBinding.ts`), adopts the matching run (live first, project-narrowed), flips a silent composer to `generating` with one honest line, and links the run from the chip (`doc-bound-run`). The run's `sessionCompleted` / `sessionFailed` / `runCancelled` frame ends the live state if the seam's terminal frame never reaches the thread. |
| **F-4R2-014** (MEDIUM copy) | The raw floor dump in the chat — absolute state-home paths, issue ids, a `GET /api/v1/runs/…` URL, "resend the message" | The crew run-failure line (`parseRunFailure` — the four seams' spelling) renders as a **card**: one sentence derived from the floor's own `EXPECTED:` path ("The revise step produced no file, so this turn did not land — nothing changed in your document"), an **`open the run`** link to `/runs/:id/timeline`, a **Retry** that re-sends the same ask as a new message (`doc-actionable-retry[data-kind=resend]`), and the raw dump whole behind a collapsed `<details>` (`doc-run-failed-details`). The failure itself is unchanged. |
| **F-4R2-003** (MEDIUM) | 409 "doc already exists" with no name field, no link to the colliding doc, no way out | The launch composer shows the id the bridge **will** mint (`docSlug` of the quoted name or the brief's first six words), live and editable (`doc-name`, `doc-name-reset`); an edited name rides the create and the pending binding. A 409 (typed `ApiError.status`, with the wire words as fallback) renders `doc-composer-error[data-status=409]`: "A document named “x” already exists — **open it** · **use a different name**" — the rename puts `x-2` (or `x-N+1`) in the field and focuses it; the daemon's own sentence stays, dimmed. |

### Wire gaps recorded (not fixable studio-side)
- **Narration keyed on unit ord / one council at a time** (F-4R2-005's second half): crew's `status.posted` frames carry `document_id`, `state`, `message` only — no `unit_ord`, no `run_id`. The identical-repeat fold removes the heartbeat duplication (39 → ~8 rows on the recorded thread); interleaving the two councils' lines needs the seam to stamp the unit ord on the frame (wicked-crew `interactive/*-events.ts` `narrate()`).
- **`GET /runs` has no doc filter**; the doc↔run binding is read from `extra_write_roots` (the seams' declared inbox). A `?doc=` filter or a `document_id` on the DTO would make this a direct read.

### Tests
- Unit: `tests/runFailure.test.ts`, `tests/runBinding.test.ts`, `tests/docThread.collapse.test.ts`, `tests/exportReport.test.ts`.
- Component: `tests/DocumentThread.runFailed.test.tsx` (card copy, link, folded details, Retry re-posts the same ask; folded row + ticking span; bound run chip + lifecycle end), `tests/DocumentThread.name.test.tsx` (derived name, edited name wins, 409 copy / link / rename / retried create), `tests/ExportMenu.test.tsx` gains the two-formats case with the #219 report; `tests/DocumentThread.test.tsx`'s 409 case updated to the new copy.
- Browser: `e2e/ux5_document_hardening_test.py` — five scenes against the loopback fixture (new gated switches `export_report`, `doc_fail_floor`, `doc_heartbeat_ms`, `doc_bound_run`, `create_409_existing`; all default off, no standing rig changes). Run locally with the already-installed Chromium: all steps `ok` (no browser install).
- `testid-inventory.json` regenerated via `npm run manifest:testids`.

Gates, each on its own: `npm run lint` ✓ · `npm run typecheck` ✓ · `npm test` ✓ (273 files, 2965 tests) · `npm run build` ✓.

No version bump; CHANGELOG bullets under Unreleased. Does not touch the Skills surface (#257 stays disjoint).

### Independent review (verdict: REVISE — all findings addressed in the bundled follow-up commit)
- **F1 (MEDIUM) the rig's scene 4 was red at head** — the scene created its doc under `doc_run_ms=60000`, so the fixture's run narrated over WS before `GET /runs` answered and `adoptRun` (correctly) added no second line. The scene now creates the doc with an instant, silent run (`doc_run_ms=0`) — the finding's actual condition, a run the thread has not heard — and keeps every assertion (state `generating`, the `doc-bound-run` link, the "Still in progress" line). Re-run at head: all 8 checks pass.
- **F2 (MEDIUM) the demo seam never parsed** — crew's demo seam says "The crew run **authoring this demo's spec** {failed|was cancelled} (run …)" (`demo-events.ts`), not "answering this demo". `runFailure.ts`'s `HEAD` regex carries the real spelling as a second alternation; the test pins crew's sentence (failed and cancelled) and asserts the studio's earlier invented spelling does NOT parse. A demo failure now renders the card ("…nothing changed in your demo").
- **F3 (MEDIUM) Retry re-sent on the chat wire whatever seam failed** — the `run-failed` message carries `seam`; `seamRetry()` routes it: `ask` → Retry re-posts the same ask (`data-kind=resend`); `edit` → Retry re-submits the same feedback batch on the batch wire (`feedback.submitted` + inject, the same anchors, on the head version — `data-kind=resend-batch`) when the thread still holds the items; `document` / `demo` (and an edit whose items a restored transcript no longer holds) get no Retry and say the way back (`doc-run-failed-wayback`) — a draft brief re-posted as a chat ask would fail again with a path (crew's chat seam refuses on the missing head). Pinned per seam in `DocumentThread.runFailed.test.tsx`.
- **F4 (LOW) "is executing now" over a gated run** — `restoredRunNarration(status)`: `awaiting_human` → "…is waiting at a gate (open run)"; both spellings dedupe. Pinned in `runBinding.test.ts`.
- **F5 (LOW) two retry affordances** — when the error frame is a crew run-failure line, the HEAD send resolves as answered (its run failed, not the send) and only sends queued behind it wear the EC36 failed chip; a plain error line still fails the whole backlog as before. Pinned in `docThread.collapse.test.ts` and the component test (no `thread-send-failed` beside the card).
- **F6 (NIT)** — `layout?: string`; `readyHere(format)` computed once per button.
- F7 (400 px thread width) is pre-existing and out of this PR's scope, as the review noted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
