### PR TITLE
fix(repos,projects,chat,health): graph readiness from the engine's findings, project repo-row findings, Build project graph, honest signed-out seats (F-2R2-003/-004/-008/-009)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,39 +11,6 @@ npm publish dates. Every version listed here exists on
 [npm](https://www.npmjs.com/package/wicked-studio?activeTab=versions).
 
 ## [Unreleased]
-### Fixed
-- **Repo readiness honesty + the project graph control** (phase2-r2 acceptance findings F-2R2-003 /
-  -004 / -008 / -009).
-  - */repos KPIs and card status* (F-2R2-003): "GRAPHS READY 9 of 9 · INDEX GAPS 0" and "graph ready —
-    onboard completed" over two repos whose engine findings said no live graph existed. The graph story
-    is now the run history CORRECTED by `RepoEntry.findings` (wicked-core#406): a repo whose finding
-    names the re-onboard remedy (`in_tree_code_graph_ignored`, no live graph) or `code_graph_root_
-    unresolvable` reads **"graph missing — re-run onboarding"** (`repo-graph-state[data-state=missing]`),
-    is excluded from Graphs ready, counted on Index gaps ("2 graph missing · …"), and gets its own
-    `Graph missing` filter chip; tooltips say what the reading derives from.
-  - *Project dashboard REPOSITORIES rows* (F-2R2-004): the `project-repo-findings` mount existed but
-    the row's registry lookup stayed undefined until the attach picker's gesture warmed the repo
-    cache. A project WITH repo members now warms the one session cache on mount (still at most one
-    `GET /repos` per session), so rows show the finding and **Re-run onboarding**.
-  - *Build project graph* (F-2R2-008, studio half): a new `ProjectGraphAction` calls crew's existing
-    `POST /api/v1/projects/:id/graph/refresh` (`api.refreshProjectGraph`; standing from the new
-    `api.getProjectGraph`, `GET /projects/:id/graph`) with honest state — the build is synchronous on
-    the daemon and says so ("Building… indexing 9 repositories — this can take a few minutes"), the
-    result is the daemon's indexed / skipped / failed labels. On the project dashboard (standing +
-    control, hidden on a daemon without the route) and on the chat scope card for a project scope
-    whose reason names an unbuilt graph (the result says it grounds NEW chats — the open chat keeps
-    the scope it opened with). The scope card's reason is now customer copy: the raw `POST …`
-    sentence is dropped, "repo-less" is said only when the scope names no repository, the daemon's
-    own words stay (raw sentence on hover).
-  - *Health rail seat rows* (F-2R2-009): an active seat with `signed_in: false` wore a green ✓ and
-    "active · signed out" as if nothing followed. It now wears the amber `!` and says **"signed out —
-    councils bench this seat"** (`rail-seat-row[data-signed-in]`), degrades the heart, and puts the
-    free-tier possibility on hover as a possibility — the roster wire has no field for it (recorded as
-    a wire gap: crew `seat-signin.ts` / core `AgenticCli` carry `signed_in` and `login_invocation`
-    only).
-  - Tests: `RepositoriesPanel.graphMissing`, `ProjectRepositories.findings`, `ProjectGraphAction`,
-    `GroupChat.graphBuild`, `HealthRailSection.signin`, `ProjectDashboard.graph`.
-
 ### Added
 - **Reassign to <seat> + retry on a failure-escalation gate** (phase7-r2 acceptance finding
   F-7R2-007, HIGH). At every "Unit N failed and triage escalated" gate the card offered Approve — a
@@ -139,6 +106,40 @@ npm publish dates. Every version listed here exists on
   never a different badge (`portable` stays the admission key).
 
 ### Fixed
+- **Repo readiness honesty + the project graph control** (phase2-r2 acceptance findings F-2R2-003 /
+  -004 / -008 / -009).
+  - */repos KPIs and card status* (F-2R2-003): "GRAPHS READY 9 of 9 · INDEX GAPS 0" and "graph ready —
+    onboard completed" over two repos whose engine findings said no live graph existed. The graph story
+    is now the run history CORRECTED by `RepoEntry.findings` (wicked-core#406): a repo whose finding
+    names the re-onboard remedy (`in_tree_code_graph_ignored`, no live graph) or `code_graph_root_
+    unresolvable` reads **"graph missing — re-run onboarding"** (`repo-graph-state[data-state=missing]`),
+    is excluded from Graphs ready, counted on Index gaps ("2 graph missing · …"), and gets its own
+    `Graph missing` filter chip; tooltips say what the reading derives from.
+  - *Project dashboard REPOSITORIES rows* (F-2R2-004): the `project-repo-findings` mount existed but
+    the row's registry lookup stayed undefined until the attach picker's gesture warmed the repo
+    cache. A project WITH repo members now warms the one session cache on mount (still at most one
+    `GET /repos` per session), so rows show the finding and **Re-run onboarding**.
+  - *Build project graph* (F-2R2-008, studio half): a new `ProjectGraphAction` calls crew's existing
+    `POST /api/v1/projects/:id/graph/refresh` (`api.refreshProjectGraph`; standing from the new
+    `api.getProjectGraph`, `GET /projects/:id/graph`) with honest state — the build is synchronous on
+    the daemon and says so ("Building… indexing 9 repositories — this can take a few minutes"), the
+    result is the daemon's indexed / skipped / failed labels. On the project dashboard (standing +
+    control, hidden on a daemon without the route) and on the chat scope card for a project scope
+    whose reason names an unbuilt graph (the result says it grounds NEW chats — the open chat keeps
+    the scope it opened with). The scope card's reason is now customer copy: the raw `POST …`
+    sentence is dropped, "repo-less" is said only when the scope names no repository, the daemon's
+    own words stay (raw sentence on hover).
+  - *Health rail seat rows* (F-2R2-009): an active seat with `signed_in: false` wore a green ✓ and
+    "active · signed out" as if nothing followed. It now wears the amber `!` and says **"signed out —
+    councils may bench this seat"** (`rail-seat-row[data-signed-in][data-standing]`) — hedged, because
+    today's roster (api-types 0.33.0) carries no eligibility field and the rig saw a "signed out" seat
+    answer on its free tier — with the free-tier possibility on hover; the heuristic is never folded
+    into the heart. When a daemon sends crew#533's `auth` / `free_tier` / `council_eligible` /
+    `council_ineligible_reason` (api-types 0.35.0) the row believes those instead ("no sign-in needed
+    (<tier>)" with a ✓, "not council-eligible — <the daemon's reason>", "signed out — still
+    council-eligible"), and only a daemon-declared ineligibility degrades the heart.
+  - Tests: `RepositoriesPanel.graphMissing`, `ProjectRepositories.findings`, `ProjectGraphAction`,
+    `GroupChat.graphBuild`, `HealthRailSection.signin`, `ProjectDashboard.graph`.
 - **The gate card's verdict block is about THIS gate's unit** (F-7R2-018): on an escalation gate
   about unit N the block rendered the LAST `gateEvaluated` at or below N — unit N−1's vacuous pass
   under a card about the unit that failed. `gateVerdictFor` keys an escalation gate ("Unit N failed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,39 @@ npm publish dates. Every version listed here exists on
 [npm](https://www.npmjs.com/package/wicked-studio?activeTab=versions).
 
 ## [Unreleased]
+### Fixed
+- **Repo readiness honesty + the project graph control** (phase2-r2 acceptance findings F-2R2-003 /
+  -004 / -008 / -009).
+  - */repos KPIs and card status* (F-2R2-003): "GRAPHS READY 9 of 9 · INDEX GAPS 0" and "graph ready —
+    onboard completed" over two repos whose engine findings said no live graph existed. The graph story
+    is now the run history CORRECTED by `RepoEntry.findings` (wicked-core#406): a repo whose finding
+    names the re-onboard remedy (`in_tree_code_graph_ignored`, no live graph) or `code_graph_root_
+    unresolvable` reads **"graph missing — re-run onboarding"** (`repo-graph-state[data-state=missing]`),
+    is excluded from Graphs ready, counted on Index gaps ("2 graph missing · …"), and gets its own
+    `Graph missing` filter chip; tooltips say what the reading derives from.
+  - *Project dashboard REPOSITORIES rows* (F-2R2-004): the `project-repo-findings` mount existed but
+    the row's registry lookup stayed undefined until the attach picker's gesture warmed the repo
+    cache. A project WITH repo members now warms the one session cache on mount (still at most one
+    `GET /repos` per session), so rows show the finding and **Re-run onboarding**.
+  - *Build project graph* (F-2R2-008, studio half): a new `ProjectGraphAction` calls crew's existing
+    `POST /api/v1/projects/:id/graph/refresh` (`api.refreshProjectGraph`; standing from the new
+    `api.getProjectGraph`, `GET /projects/:id/graph`) with honest state — the build is synchronous on
+    the daemon and says so ("Building… indexing 9 repositories — this can take a few minutes"), the
+    result is the daemon's indexed / skipped / failed labels. On the project dashboard (standing +
+    control, hidden on a daemon without the route) and on the chat scope card for a project scope
+    whose reason names an unbuilt graph (the result says it grounds NEW chats — the open chat keeps
+    the scope it opened with). The scope card's reason is now customer copy: the raw `POST …`
+    sentence is dropped, "repo-less" is said only when the scope names no repository, the daemon's
+    own words stay (raw sentence on hover).
+  - *Health rail seat rows* (F-2R2-009): an active seat with `signed_in: false` wore a green ✓ and
+    "active · signed out" as if nothing followed. It now wears the amber `!` and says **"signed out —
+    councils bench this seat"** (`rail-seat-row[data-signed-in]`), degrades the heart, and puts the
+    free-tier possibility on hover as a possibility — the roster wire has no field for it (recorded as
+    a wire gap: crew `seat-signin.ts` / core `AgenticCli` carry `signed_in` and `login_invocation`
+    only).
+  - Tests: `RepositoriesPanel.graphMissing`, `ProjectRepositories.findings`, `ProjectGraphAction`,
+    `GroupChat.graphBuild`, `HealthRailSection.signin`, `ProjectDashboard.graph`.
+
 ### Added
 - **Reassign to <seat> + retry on a failure-escalation gate** (phase7-r2 acceptance finding
   F-7R2-007, HIGH). At every "Unit N failed and triage escalated" gate the card offered Approve — a

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -646,4 +646,25 @@ export const api = {
       method: 'POST',
       body: JSON.stringify(cli === undefined ? {} : { cli }),
     }),
+
+  /**
+   * `GET /projects/:id/graph` — the project graph's standing (crew `projects/routes.ts`): always
+   * 200 for a known project, `state` naming what it holds and `detail` its cause + remedy;
+   * `default` answers the synthesized no-graph status. 404 unknown project; 501 engine too old.
+   */
+  getProjectGraph: (id: string) =>
+    apiFetch<{ status: import('./types.js').ProjectGraphStatus }>(`/projects/${encodeURIComponent(id)}/graph`),
+
+  /**
+   * `POST /projects/:id/graph/refresh` — the incremental (re)build over every `crew.repo` member
+   * (acceptance finding F-2R2-008: the ONE control that builds a project graph from the UI).
+   * SYNCHRONOUS on the daemon: the answer describes a graph that IS built, so this can take as
+   * long as the slowest member's index. `{}` is the plain refresh; `force` re-indexes every repo.
+   * 404 unknown project; 409 the `default` project; 501 engine too old.
+   */
+  refreshProjectGraph: (id: string, body?: import('./types.js').RefreshProjectGraphBody) =>
+    apiFetch<import('./types.js').ProjectGraphRefreshResult>(`/projects/${encodeURIComponent(id)}/graph/refresh`, {
+      method: 'POST',
+      body: JSON.stringify(body ?? {}),
+    }),
 };

--- a/src/board/repoStats.ts
+++ b/src/board/repoStats.ts
@@ -1,4 +1,5 @@
-import type { RepoEntry, SessionView } from '../api/types.js';
+import type { RepoEntry, RepoFinding, SessionView } from '../api/types.js';
+import { findingNeedsReonboard, REPO_FINDING_ROOT_UNRESOLVABLE } from '../components/RepoFindings.js';
 import { outcomeOf } from './metrics.js';
 import { statusCounts, type StatusCounts } from './windowStats.js';
 
@@ -40,6 +41,33 @@ export interface RepoOnboard {
   run: SessionView | null;
 }
 
+/**
+ * The engine's own word on whether a LIVE graph exists (acceptance finding F-2R2-003): the
+ * run history said "graph ready — onboard completed" while the repo's findings said the
+ * checkout's in-tree graph is ignored and NO live graph has been indexed under the state
+ * home — two in-tree repos read as ready on the KPI tiles. `RepoEntry.findings[]`
+ * (wicked-core#406) is derived by the engine on every read, so it outranks a run verdict:
+ *  - `no-live-graph`  — `in_tree_code_graph_ignored` with the re-onboard remedy: the live
+ *                       graph was never built; onboarding again builds it;
+ *  - `no-graph-root`  — `code_graph_root_unresolvable`: no graph can exist for this daemon.
+ * `null` = the findings name no gap (or the daemon predates the field).
+ */
+export type RepoGraphGapKind = 'no-live-graph' | 'no-graph-root';
+
+export interface RepoGraphGap {
+  kind: RepoGraphGapKind;
+  finding: RepoFinding;
+}
+
+/** The graph gap the engine's findings name for this repo, or `null`. */
+export function repoGraphGap(repo: Pick<RepoEntry, 'findings'>): RepoGraphGap | null {
+  for (const finding of repo.findings ?? []) {
+    if (finding.code === REPO_FINDING_ROOT_UNRESOLVABLE) return { kind: 'no-graph-root', finding };
+    if (findingNeedsReonboard(finding)) return { kind: 'no-live-graph', finding };
+  }
+  return null;
+}
+
 /** One repo's fleet-card model — one fold per card, shared by grid and chips. */
 export interface RepoFleetModel {
   repo: RepoEntry;
@@ -52,8 +80,15 @@ export interface RepoFleetModel {
   /** Failed runs in the window, or the graph build itself failed. */
   failing: boolean;
   onboard: RepoOnboard;
+  /** The engine's checkout findings say no live graph exists (F-2R2-003) — outranks `onboard`. */
+  graphGap: RepoGraphGap | null;
   /** Newest attach clock among the repo's runs; `null` = no clock known. */
   lastAt: number | null;
+}
+
+/** Whether the repo's graph is READY: the newest onboard completed AND the engine names no gap. */
+export function graphReady(m: Pick<RepoFleetModel, 'onboard' | 'graphGap'>): boolean {
+  return m.onboard.state === 'ready' && m.graphGap === null;
 }
 
 /**
@@ -103,6 +138,7 @@ export function repoFleetModels(
       activeNow: mine.some((v) => outcomeOf(v.session.status) === 'run'),
       failing: counts.failed > 0 || onboard.state === 'failed',
       onboard,
+      graphGap: repoGraphGap(repo),
       lastAt: clocks.length > 0 ? Math.max(...clocks) : null,
     };
   }).sort((a, b) =>
@@ -114,13 +150,15 @@ export function repoFleetModels(
   );
 }
 
-export type RepoChip = 'all' | 'needs-you' | 'active' | 'failing' | 'ready' | 'never';
+export type RepoChip = 'all' | 'needs-you' | 'active' | 'failing' | 'ready' | 'never' | 'graph-missing';
 
 export function matchesRepoChip(m: RepoFleetModel, chip: RepoChip): boolean {
   if (chip === 'all') return true;
   if (chip === 'needs-you') return m.waiting.length > 0;
   if (chip === 'active') return m.activeNow;
   if (chip === 'failing') return m.failing;
-  if (chip === 'ready') return m.onboard.state === 'ready';
+  // Ready means READY: a completed onboard whose live graph the engine does not dispute.
+  if (chip === 'ready') return graphReady(m);
+  if (chip === 'graph-missing') return m.graphGap !== null;
   return m.onboard.state === 'never'; // never onboarded (no run on record)
 }

--- a/src/components/GroupChat.tsx
+++ b/src/components/GroupChat.tsx
@@ -26,6 +26,7 @@ import {
 } from './ChatThread.js';
 import { NewProjectModal } from './NewProjectModal.js';
 import { NowBar } from './NowBar.js';
+import { humanizeGraphReason, ProjectGraphAction, reasonWantsProjectGraph } from './ProjectGraphAction.js';
 import {
   buildChatFeed,
   deriveChatArtifacts,
@@ -1500,8 +1501,23 @@ export function GroupChat({
               title={scope.graph.reason}
               style={{ color: scope.graph.bound ? 'var(--status-run)' : 'var(--status-gate)' }}
             >
-              {scope.graph.bound ? 'code graph bound' : `no code graph — ${scope.graph.reason}`}
+              {/* F-2R2-008: the daemon's reason, for a customer — no raw POST, "repo-less" only
+                  when the scope names no repository; the daemon's own words otherwise (the raw
+                  sentence stays on hover). */}
+              {scope.graph.bound ? 'code graph bound' : `no code graph — ${humanizeGraphReason(scope.graph.reason, scope.repos.length)}`}
             </span>
+          )}
+          {/* F-2R2-008: a project scope with no project graph gets the control that builds it —
+              crew's existing refresh route. The open chat's scope was decided when it opened, so
+              the result says what it grounds: the NEXT chats in this project. */}
+          {scope !== null && !scope.graph.bound && scope.kind === 'project'
+            && scope.projectId !== undefined && reasonWantsProjectGraph(scope.graph.reason) && (
+            <ProjectGraphAction
+              projectId={scope.projectId}
+              variant="inline"
+              repoCount={scope.repos.length}
+              builtNote="new chats in this project ground on it (this chat keeps the scope it opened with)"
+            />
           )}
           {scope !== null && scope.dangling.length > 0 && (
             <span

--- a/src/components/HealthRailSection.tsx
+++ b/src/components/HealthRailSection.tsx
@@ -63,24 +63,44 @@ function CheckRow({ label, ok, detail }: { label: string; ok: boolean | null; de
 
 const EXCERPT_CH = 40;
 
+/**
+ * What a signed-out seat MEANS (acceptance finding F-2R2-009): the roster's `signed_in` is the
+ * daemon's cheap file/env heuristic and the engine's council rule benches a seat it reads as
+ * signed out — so the rail must not wear a green ✓ over "active · signed out" as if nothing
+ * followed from it. The wire carries NO field that says whether the seat could still answer
+ * without a sign-in (the rig saw opencode answer a chat on a provider free tier while
+ * `signed_in:false`), so the row states exactly what IS known — councils bench it — and puts
+ * the free-tier possibility on hover as a possibility, never as a claim.
+ */
+export const SIGNED_OUT_DETAIL = 'signed out — councils bench this seat';
+export const SIGNED_OUT_TITLE =
+  'No sign-in observed for this seat (the daemon\'s file/env check) — a council benches a signed-out seat. '
+  + 'A chat may still seat it on a provider free tier; the roster cannot tell yet. Sign in from Settings.';
+
 /** One registry row (§6.2's anatomy): glyph, name, the honest detail. */
 function SeatRow({ seat }: { seat: RosterSeat }): React.ReactElement {
   const h = seat.health;
+  const signedOut = seat.signed_in === false;
   // Absent health (a daemon predating crew#274) is UNKNOWN — a dim `·`, no
-  // message, never a fabricated "active" (§6.2).
-  const glyph = h === undefined ? '·' : h.status === 'active' ? '✓' : '✗';
-  const color = h === undefined ? 'var(--ink-dim)' : h.status === 'active' ? 'var(--status-run)' : 'var(--status-fail)';
-  const signedIn = seat.signed_in === true ? 'signed in' : seat.signed_in === false ? 'signed out' : null;
+  // message, never a fabricated "active" (§6.2). An ACTIVE seat that is signed
+  // out is reachable but benched: the `!` in gate-amber, not a green ✓ (F-2R2-009).
+  const glyph = h === undefined ? '·' : h.status === 'active' ? (signedOut ? '!' : '✓') : '✗';
+  const color = h === undefined
+    ? 'var(--ink-dim)'
+    : h.status === 'active' ? (signedOut ? 'var(--status-gate)' : 'var(--status-run)') : 'var(--status-fail)';
+  const signedIn = seat.signed_in === true ? 'signed in' : signedOut ? SIGNED_OUT_DETAIL : null;
   const message = h?.status === 'inactive' && h.message !== undefined ? h.message : null;
   const detail = message !== null
     ? message.length > EXCERPT_CH ? `${message.slice(0, EXCERPT_CH)}…` : message
     : [h?.status, signedIn].filter((s): s is string => s != null).join(' · ');
+  const detailColor = message !== null ? 'var(--status-fail)' : signedOut ? 'var(--status-gate)' : 'var(--ink-dim)';
   return (
     <div
       data-testid="rail-seat-row"
       data-seat={seat.key}
       data-health={h?.status ?? 'unknown'}
-      title={message ?? undefined}
+      data-signed-in={seat.signed_in === true ? 'true' : signedOut ? 'false' : 'unknown'}
+      title={message ?? (signedOut ? SIGNED_OUT_TITLE : undefined)}
       style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-2)', marginBottom: '5px' }}
     >
       <span style={{ width: '12px', fontSize: 'var(--text-xs)', color, fontFamily: 'var(--font-mono)', flexShrink: 0 }}>{glyph}</span>
@@ -89,7 +109,7 @@ function SeatRow({ seat }: { seat: RosterSeat }): React.ReactElement {
       </span>
       <span
         className="truncate"
-        style={{ marginLeft: 'auto', fontSize: 'var(--text-2xs)', color: message !== null ? 'var(--status-fail)' : 'var(--ink-dim)', fontFamily: 'var(--font-mono)' }}
+        style={{ marginLeft: 'auto', fontSize: 'var(--text-2xs)', color: detailColor, fontFamily: 'var(--font-mono)' }}
       >
         {detail}
       </span>
@@ -285,8 +305,10 @@ export function HealthRailSection({ open, onToggle }: Props): React.ReactElement
   // seat down or the socket gone), amber when degraded (socket still connecting,
   // a probe errored, or the API server not reporting ok), green otherwise. It
   // reads the same signals the section already computes — no new data source.
+  // F-2R2-009: a signed-out seat is benched by councils — degraded, said on the heart too.
+  const benched = (roster ?? []).some((s) => s.signed_in === false && s.health?.status !== 'inactive');
   const degraded =
-    wsStatus === 'connecting' || healthError || rosterError || govWarnings || (health !== null && health.status !== 'ok');
+    wsStatus === 'connecting' || healthError || rosterError || govWarnings || benched || (health !== null && health.status !== 'ok');
   const heartState = sick ? 'unhealthy' : degraded ? 'degraded' : 'healthy';
   const heartColor = sick
     ? 'var(--status-fail)'

--- a/src/components/HealthRailSection.tsx
+++ b/src/components/HealthRailSection.tsx
@@ -65,42 +65,79 @@ const EXCERPT_CH = 40;
 
 /**
  * What a signed-out seat MEANS (acceptance finding F-2R2-009): the roster's `signed_in` is the
- * daemon's cheap file/env heuristic and the engine's council rule benches a seat it reads as
- * signed out — so the rail must not wear a green ✓ over "active · signed out" as if nothing
- * followed from it. The wire carries NO field that says whether the seat could still answer
- * without a sign-in (the rig saw opencode answer a chat on a provider free tier while
- * `signed_in:false`), so the row states exactly what IS known — councils bench it — and puts
- * the free-tier possibility on hover as a possibility, never as a claim.
+ * daemon's cheap file/env heuristic — "never proof the credential still works", and never proof
+ * the seat cannot answer without one: the phase2-r2 rig saw opencode read `signed_in:false` and
+ * still answer a chat on its provider free tier. So the rail must neither wear a green ✓ over
+ * "active · signed out" as if nothing followed from it, nor assert an engine rule the wire does
+ * not carry. Today's roster (api-types 0.33.0) has no eligibility field, so the row states the
+ * OBSERVATION and HEDGES the consequence ("councils may bench this seat"). crew#533 (api-types
+ * 0.35.0) adds `auth` (`signed_in | signed_out | not_required | unknown`), `free_tier`,
+ * `council_eligible` and `council_ineligible_reason` — read off the seat when a daemon sends
+ * them (`seatStandingWord`), so a daemon that SAYS what a council would do is believed.
  */
-export const SIGNED_OUT_DETAIL = 'signed out — councils bench this seat';
+export const SIGNED_OUT_DETAIL = 'signed out — councils may bench this seat';
 export const SIGNED_OUT_TITLE =
-  'No sign-in observed for this seat (the daemon\'s file/env check) — a council benches a signed-out seat. '
-  + 'A chat may still seat it on a provider free tier; the roster cannot tell yet. Sign in from Settings.';
+  'The daemon\'s file/env check saw no sign-in for this seat. A seat that cannot authenticate fails at spawn '
+  + 'and a council benches it — but a provider free tier may still answer; the roster cannot tell yet. '
+  + 'Sign in from Settings.';
+
+/** The roster's word on one seat's standing, read for what the WIRE says (never inferred). */
+export type SeatStanding =
+  | { kind: 'signed-in'; detail: string; title: string | null; auth: string | null }
+  | { kind: 'no-sign-in-needed'; detail: string; title: string | null; auth: string | null }
+  | { kind: 'signed-out'; detail: string; title: string; auth: string | null }
+  | { kind: 'ineligible'; detail: string; title: string; auth: string | null }
+  | { kind: 'unknown'; detail: null; title: null; auth: string | null };
+
+export function seatStandingWord(seat: RosterSeat): SeatStanding {
+  const bag = seat as Record<string, unknown>;
+  const auth = typeof bag['auth'] === 'string' ? (bag['auth'] as string) : null;
+  const eligible = bag['council_eligible'];
+  const reason = typeof bag['council_ineligible_reason'] === 'string' ? (bag['council_ineligible_reason'] as string) : '';
+  const tier = typeof bag['free_tier'] === 'string' ? (bag['free_tier'] as string) : '';
+  // The daemon SAYS a council would not seat it — its reason, its words (crew#533).
+  if (eligible === false) {
+    return { kind: 'ineligible', detail: `not council-eligible — ${reason !== '' ? reason : 'the daemon says a council would not seat it'}`, title: reason !== '' ? reason : 'the daemon reports this seat as not council-eligible', auth };
+  }
+  if (auth === 'not_required') {
+    return { kind: 'no-sign-in-needed', detail: `no sign-in needed${tier !== '' ? ` (${tier})` : ''}`, title: tier !== '' ? `answers on its provider free tier: ${tier}` : null, auth };
+  }
+  if (auth === 'signed_in' || seat.signed_in === true) return { kind: 'signed-in', detail: 'signed in', title: null, auth };
+  if (auth === 'signed_out' || seat.signed_in === false) {
+    return eligible === true
+      ? { kind: 'signed-out', detail: 'signed out — still council-eligible', title: 'No sign-in observed, and the daemon still reports the seat as council-eligible.', auth }
+      : { kind: 'signed-out', detail: SIGNED_OUT_DETAIL, title: SIGNED_OUT_TITLE, auth };
+  }
+  return { kind: 'unknown', detail: null, title: null, auth };
+}
 
 /** One registry row (§6.2's anatomy): glyph, name, the honest detail. */
 function SeatRow({ seat }: { seat: RosterSeat }): React.ReactElement {
   const h = seat.health;
-  const signedOut = seat.signed_in === false;
+  const standing = seatStandingWord(seat);
+  const hedged = standing.kind === 'signed-out' || standing.kind === 'ineligible';
   // Absent health (a daemon predating crew#274) is UNKNOWN — a dim `·`, no
-  // message, never a fabricated "active" (§6.2). An ACTIVE seat that is signed
-  // out is reachable but benched: the `!` in gate-amber, not a green ✓ (F-2R2-009).
-  const glyph = h === undefined ? '·' : h.status === 'active' ? (signedOut ? '!' : '✓') : '✗';
+  // message, never a fabricated "active" (§6.2). An ACTIVE seat with no sign-in
+  // observed (or one the daemon calls ineligible) is reachable but in question:
+  // the `!` in gate-amber, not a green ✓ (F-2R2-009).
+  const glyph = h === undefined ? '·' : h.status === 'active' ? (hedged ? '!' : '✓') : '✗';
   const color = h === undefined
     ? 'var(--ink-dim)'
-    : h.status === 'active' ? (signedOut ? 'var(--status-gate)' : 'var(--status-run)') : 'var(--status-fail)';
-  const signedIn = seat.signed_in === true ? 'signed in' : signedOut ? SIGNED_OUT_DETAIL : null;
+    : h.status === 'active' ? (hedged ? 'var(--status-gate)' : 'var(--status-run)') : 'var(--status-fail)';
   const message = h?.status === 'inactive' && h.message !== undefined ? h.message : null;
   const detail = message !== null
     ? message.length > EXCERPT_CH ? `${message.slice(0, EXCERPT_CH)}…` : message
-    : [h?.status, signedIn].filter((s): s is string => s != null).join(' · ');
-  const detailColor = message !== null ? 'var(--status-fail)' : signedOut ? 'var(--status-gate)' : 'var(--ink-dim)';
+    : [h?.status, standing.detail].filter((s): s is string => s != null).join(' · ');
+  const detailColor = message !== null ? 'var(--status-fail)' : hedged ? 'var(--status-gate)' : 'var(--ink-dim)';
   return (
     <div
       data-testid="rail-seat-row"
       data-seat={seat.key}
       data-health={h?.status ?? 'unknown'}
-      data-signed-in={seat.signed_in === true ? 'true' : signedOut ? 'false' : 'unknown'}
-      title={message ?? (signedOut ? SIGNED_OUT_TITLE : undefined)}
+      data-signed-in={seat.signed_in === true ? 'true' : seat.signed_in === false ? 'false' : 'unknown'}
+      data-standing={standing.kind}
+      {...(standing.auth !== null ? { 'data-auth': standing.auth } : {})}
+      title={message ?? standing.title ?? undefined}
       style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-2)', marginBottom: '5px' }}
     >
       <span style={{ width: '12px', fontSize: 'var(--text-xs)', color, fontFamily: 'var(--font-mono)', flexShrink: 0 }}>{glyph}</span>
@@ -305,10 +342,13 @@ export function HealthRailSection({ open, onToggle }: Props): React.ReactElement
   // seat down or the socket gone), amber when degraded (socket still connecting,
   // a probe errored, or the API server not reporting ok), green otherwise. It
   // reads the same signals the section already computes — no new data source.
-  // F-2R2-009: a signed-out seat is benched by councils — degraded, said on the heart too.
-  const benched = (roster ?? []).some((s) => s.signed_in === false && s.health?.status !== 'inactive');
+  // F-2R2-009 (review): the sign-in HEURISTIC is said per row (the amber `!`), never folded into the
+  // heart — on a default roster most seats read `signed_in:false`, and a healthy daemon must not
+  // wear a permanently degraded heart over a guess. Only a daemon-declared `council_eligible: false`
+  // (crew#533, api-types 0.35.0) degrades it, because that IS the daemon's own word.
+  const ineligible = (roster ?? []).some((s) => (s as Record<string, unknown>)['council_eligible'] === false && s.health?.status !== 'inactive');
   const degraded =
-    wsStatus === 'connecting' || healthError || rosterError || govWarnings || benched || (health !== null && health.status !== 'ok');
+    wsStatus === 'connecting' || healthError || rosterError || govWarnings || ineligible || (health !== null && health.status !== 'ok');
   const heartState = sick ? 'unhealthy' : degraded ? 'degraded' : 'healthy';
   const heartColor = sick
     ? 'var(--status-fail)'

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -28,6 +28,7 @@ import { GateChip } from './GateChip.js';
 import { GateRejectNote } from './GateRejectNote.js';
 import { MODE_LABEL } from './ProjectShell.js';
 import { ago, ATTENTION_DOT } from './ProjectCard.js';
+import { ProjectGraphAction } from './ProjectGraphAction.js';
 import { ProjectRepositories } from './ProjectRepositories.js';
 import { ageWord } from './DashboardTiles.js';
 import { deliverySummary } from './delivery.js';
@@ -438,6 +439,13 @@ export function ProjectDashboard({ projectId, runs, navigate }: Props): React.Re
               );
             })}
           </p>
+        )}
+        {/* F-2R2-008: the project graph's standing and the ONE control that builds it
+            (`POST /projects/:id/graph/refresh`) — a project with repositories and no graph
+            grounds its chats and runs on files alone, and until now nothing in the UI could
+            change that. Read on mount with the membership; hidden on a daemon without the route. */}
+        {repoMembers.length > 0 && (
+          <ProjectGraphAction projectId={projectId} variant="row" repoCount={repoMembers.length} fetchStatus />
         )}
       </header>
 

--- a/src/components/ProjectGraphAction.tsx
+++ b/src/components/ProjectGraphAction.tsx
@@ -1,0 +1,208 @@
+import { useEffect, useState } from 'react';
+import { api } from '../api/client.js';
+import { apiStatus, isRouteAbsent } from '../api/errors.js';
+import type { ProjectGraphRefreshResult, ProjectGraphStatus } from '../api/types.js';
+import { ago } from './ProjectCard.js';
+
+/**
+ * "Build project graph" — the ONE UI control that calls crew's existing
+ * `POST /api/v1/projects/:id/graph/refresh` (acceptance finding F-2R2-008, studio half).
+ *
+ * The phase2-r2 rig had all nine repo graphs built and STILL no project graph: the chat scope
+ * card said "Project proj_… has 9 repo member(s) but no code graph yet. Build it with POST
+ * /api/v1/projects/<id>/graph/refresh. This repo-less run gets no code graph." — a raw POST for
+ * a customer, "repo-less" over a nine-repo scope, and no control anywhere that called the
+ * route (0 occurrences in the bundle). This component is that control, on the two surfaces
+ * the finding names: the project dashboard (with the graph's standing read from
+ * `GET /projects/:id/graph`) and the chat scope card (inline, no read — the scope already
+ * says the graph is unbound and why).
+ *
+ * Honest states, from the wire and nothing else:
+ *  - the refresh is SYNCHRONOUS on the daemon (indexing runs to completion before it answers),
+ *    so "building" is a real wait and says so — minutes on a first build;
+ *  - the result is the daemon's `ProjectGraphRefreshResult`: indexed / skipped / failed labels
+ *    and the status the graph now HAS — rendered as it came, failures included;
+ *  - a chat's scope was decided when the chat opened (`POST /chats`), so a build from the scope
+ *    card grounds NEW chats — that is said, never implied to have re-bound the open one.
+ */
+
+/** Sentences that are developer remedies, not customer copy: a raw route, an issue id. */
+const RAW_ROUTE_SENTENCE = /[^.]*\bPOST\s+\/api\/v1\/[^.]*\.?/g;
+/** The seams' "repo-less" clause — false over a scope that names repositories. */
+const REPO_LESS_SENTENCE = /\s*This repo-less run gets no code graph\.?/g;
+
+/**
+ * The daemon's graph reason, for a customer (F-2R2-008 copy): the raw `POST …` remedy sentence
+ * is dropped (the control beside the text IS the remedy), and "repo-less" is said only when the
+ * scope genuinely names no repository. What remains is the daemon's own words.
+ */
+export function humanizeGraphReason(reason: string, repoCount: number): string {
+  let text = reason.replace(RAW_ROUTE_SENTENCE, '');
+  if (repoCount > 0) text = text.replace(REPO_LESS_SENTENCE, '');
+  text = text.replace(/\s{2,}/g, ' ').trim();
+  if (text === '') return repoCount > 0 ? 'the project graph has not been built yet' : 'no repositories, no code graph';
+  return text;
+}
+
+/** Does this unbound reason name a project graph a refresh would build? */
+export function reasonWantsProjectGraph(reason: string): boolean {
+  return /no code graph yet|never been built|not in the graph yet|graph\/refresh/i.test(reason);
+}
+
+type Read =
+  | { kind: 'idle' }
+  | { kind: 'loading' }
+  | { kind: 'ok'; status: ProjectGraphStatus }
+  | { kind: 'absent' }
+  | { kind: 'error'; message: string };
+
+type Build =
+  | { kind: 'idle' }
+  | { kind: 'building' }
+  | { kind: 'built'; result: ProjectGraphRefreshResult }
+  | { kind: 'failed'; message: string };
+
+export interface ProjectGraphActionProps {
+  projectId: string;
+  /** `row` (the dashboard: reads the standing, then the control) or `inline` (the scope card: the control only). */
+  variant?: 'row' | 'inline';
+  /** How many repositories the surface knows are in scope — the honest wait copy. */
+  repoCount?: number;
+  /** Read `GET /projects/:id/graph` on mount (the dashboard). Off for the scope card. */
+  fetchStatus?: boolean;
+  /** Said after a build from a surface whose own binding does not change (the open chat). */
+  builtNote?: string;
+  onBuilt?: ((result: ProjectGraphRefreshResult) => void) | undefined;
+}
+
+/** One sentence for the graph's standing — the daemon's state, in words. */
+export function describeGraphStatus(status: ProjectGraphStatus, now = Date.now()): string {
+  const indexed = status.repos.filter((r) => r.indexed).length;
+  const when = status.updatedAt === null ? '' : ` · refreshed ${ago(status.updatedAt, now)} ago`;
+  switch (status.state) {
+    case 'ready':
+      return `ready · ${indexed} repositor${indexed === 1 ? 'y' : 'ies'} indexed${when}`
+        + (status.missingRepos.length > 0 ? ` · ${status.missingRepos.length} not in the graph yet` : '');
+    case 'ready-single-repo':
+      return `holds one repository (${status.repos.find((r) => r.indexed)?.label ?? '?'})${when}`
+        + (status.missingRepos.length > 0 ? ` · ${status.missingRepos.length} not in the graph yet` : '');
+    case 'not-indexed':
+      return 'not built — the seats read files, not a code graph';
+    case 'no-repo-members':
+      return 'no repositories attached — nothing to index';
+    case 'engine-too-old':
+      return humanizeGraphReason(status.detail, status.repos.length);
+    default:
+      return humanizeGraphReason(status.detail, status.repos.length);
+  }
+}
+
+const MONO: React.CSSProperties = { fontFamily: 'var(--font-mono)', fontSize: 'var(--text-2xs)' };
+
+export function ProjectGraphAction({
+  projectId, variant = 'row', repoCount, fetchStatus = false, builtNote, onBuilt,
+}: ProjectGraphActionProps): React.ReactElement | null {
+  const [read, setRead] = useState<Read>({ kind: fetchStatus ? 'loading' : 'idle' });
+  const [build, setBuild] = useState<Build>({ kind: 'idle' });
+
+  useEffect(() => {
+    setBuild({ kind: 'idle' });
+    if (!fetchStatus) { setRead({ kind: 'idle' }); return; }
+    let cancelled = false;
+    setRead({ kind: 'loading' });
+    // Through a resolved promise: a client that cannot serve the read (an older daemon, a
+    // partial mock) becomes the honest absent/error row, never a throw out of the effect.
+    Promise.resolve()
+      .then(() => api.getProjectGraph(projectId))
+      .then(({ status }) => { if (!cancelled) setRead({ kind: 'ok', status }); })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        if (isRouteAbsent(e) || apiStatus(e) === 501) setRead({ kind: 'absent' });
+        else setRead({ kind: 'error', message: e instanceof Error ? e.message : String(e) });
+      });
+    return () => { cancelled = true; };
+  }, [projectId, fetchStatus]);
+
+  // The synthesized Unfiled project has no graph to build (the route answers 409).
+  if (projectId === 'default') return null;
+  // An older daemon without the graph routes: no control to offer, nothing to invent.
+  if (read.kind === 'absent') return null;
+
+  const status = read.kind === 'ok' ? read.status : build.kind === 'built' ? build.result.status : null;
+  const n = repoCount ?? status?.repos.length;
+  const built = status !== null && (status.state === 'ready' || status.state === 'ready-single-repo');
+  const busy = build.kind === 'building';
+
+  async function run(): Promise<void> {
+    if (busy) return;
+    setBuild({ kind: 'building' });
+    try {
+      const result = await api.refreshProjectGraph(projectId);
+      setBuild({ kind: 'built', result });
+      setRead({ kind: 'ok', status: result.status });
+      onBuilt?.(result);
+    } catch (e: unknown) {
+      setBuild({ kind: 'failed', message: e instanceof Error ? e.message : String(e) });
+    }
+  }
+
+  const label = busy
+    ? `Building… indexing ${n === undefined ? 'the repositories' : `${n} repositor${n === 1 ? 'y' : 'ies'}`} — this can take a few minutes`
+    : built ? 'Refresh project graph' : 'Build project graph';
+
+  return (
+    <div
+      data-testid="project-graph"
+      data-project-id={projectId}
+      data-state={status?.state ?? read.kind}
+      data-build={build.kind}
+      style={{ display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap', minWidth: 0, ...(variant === 'row' ? { margin: '6px 0 0' } : {}) }}
+    >
+      {variant === 'row' && (
+        <span data-testid="project-graph-state" style={{ ...MONO, color: 'var(--ink-dim)' }} title={status?.detail}>
+          <span style={{ letterSpacing: '0.06em', textTransform: 'uppercase' }}>project graph</span>
+          {' · '}
+          {read.kind === 'loading'
+            ? 'checking…'
+            : read.kind === 'error'
+              ? `standing unknown — ${read.message}`
+              : status !== null ? describeGraphStatus(status) : 'not built'}
+        </span>
+      )}
+      <button
+        type="button"
+        data-testid="project-graph-build"
+        data-building={busy}
+        disabled={busy}
+        onClick={() => void run()}
+        title={built
+          ? 'Re-index the project graph over every attached repository (incremental: clean checkouts at an indexed HEAD are skipped)'
+          : 'Build the project graph over every attached repository, so chats and runs filed into this project can ground on code — synchronous, as long as the slowest repository takes to index'}
+        className="disabled:opacity-60"
+        style={{
+          ...MONO, cursor: busy ? 'default' : 'pointer', flexShrink: 0,
+          background: built ? 'transparent' : 'var(--accent)', color: built ? 'var(--ink-muted)' : 'var(--accent-fg)',
+          border: built ? '1px solid var(--surface-raised)' : 'none', borderRadius: 'var(--radius-md)', padding: '2px 10px',
+          fontWeight: 'var(--weight-semi)',
+        }}
+      >
+        {label}
+      </button>
+      {build.kind === 'built' && (
+        <span data-testid="project-graph-result" style={{ ...MONO, color: build.result.failed.length > 0 ? 'var(--status-gate)' : 'var(--status-run)' }}>
+          {build.result.failed.length === 0
+            ? `project graph ${build.result.status.state === 'ready' || build.result.status.state === 'ready-single-repo' ? 'ready' : build.result.status.state} — ${build.result.indexed.length} indexed`
+              + (build.result.skipped.length > 0 ? `, ${build.result.skipped.length} already current` : '')
+            : `built with failures — ${build.result.indexed.length} indexed, ${build.result.failed.length} failed: `
+              + build.result.failed.map((f) => `${f.label} (${f.error})`).join('; ')}
+          {builtNote !== undefined ? ` · ${builtNote}` : ''}
+        </span>
+      )}
+      {build.kind === 'failed' && (
+        <span data-testid="project-graph-error" style={{ ...MONO, color: 'var(--status-fail)' }}>
+          not built — {build.message}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/ProjectGraphAction.tsx
+++ b/src/components/ProjectGraphAction.tsx
@@ -26,9 +26,14 @@ import { ago } from './ProjectCard.js';
  *    card grounds NEW chats — that is said, never implied to have re-bound the open one.
  */
 
-/** Sentences that are developer remedies, not customer copy: a raw route, an issue id. */
+/** Sentences that are developer remedies, not customer copy: a raw route, an issue id. Keyed on
+ *  crew's prose (`projects/graph.ts`: "Build it with POST /api/v1/projects/<id>/graph/refresh." and
+ *  "POST /api/v1/projects/<id>/graph/refresh fixes it."); a reworded daemon fails CLOSED — the
+ *  sentence is kept verbatim, nothing is lost. */
 const RAW_ROUTE_SENTENCE = /[^.]*\bPOST\s+\/api\/v1\/[^.]*\.?/g;
-/** The seams' "repo-less" clause — false over a scope that names repositories. */
+/** The seams' "repo-less" clause (crew `draft-events.ts` / `edit-events.ts` / `demo-events.ts` /
+ *  `projects/graph.ts`, spelled exactly "This repo-less run gets no code graph.") — false over a
+ *  scope that names repositories; kept when the scope genuinely names none. */
 const REPO_LESS_SENTENCE = /\s*This repo-less run gets no code graph\.?/g;
 
 /**
@@ -44,7 +49,10 @@ export function humanizeGraphReason(reason: string, repoCount: number): string {
   return text;
 }
 
-/** Does this unbound reason name a project graph a refresh would build? */
+/** Does this unbound reason name a project graph a refresh would build? Keyed on crew's
+ *  `projects/graph.ts` `not-indexed` / never-refreshed sentences ("no code graph yet", "the
+ *  project graph has never been built", "not in the graph yet") and on the route it names; a
+ *  reworded daemon fails CLOSED — the control is simply not offered. */
 export function reasonWantsProjectGraph(reason: string): boolean {
   return /no code graph yet|never been built|not in the graph yet|graph\/refresh/i.test(reason);
 }
@@ -90,11 +98,15 @@ export function describeGraphStatus(status: ProjectGraphStatus, now = Date.now()
       return 'not built — the seats read files, not a code graph';
     case 'no-repo-members':
       return 'no repositories attached — nothing to index';
-    case 'engine-too-old':
-      return humanizeGraphReason(status.detail, status.repos.length);
-    default:
+    default: // `engine-too-old`, and any state a newer daemon adds: the daemon's own sentence, humanized
       return humanizeGraphReason(status.detail, status.repos.length);
   }
+}
+
+/** A per-repo index error, for one line: its first line, capped — the whole text rides the hover. */
+function briefError(error: string, max = 160): string {
+  const line = error.replace(/\r/g, '').split('\n')[0] ?? '';
+  return line.length > max ? `${line.slice(0, max - 1)}…` : line;
 }
 
 const MONO: React.CSSProperties = { fontFamily: 'var(--font-mono)', fontSize: 'var(--text-2xs)' };
@@ -107,7 +119,9 @@ export function ProjectGraphAction({
 
   useEffect(() => {
     setBuild({ kind: 'idle' });
-    if (!fetchStatus) { setRead({ kind: 'idle' }); return; }
+    // The synthesized Unfiled project has no graph to read or build (the route answers 409 on a
+    // refresh and the synthesized no-graph status on a read) — no request is spent on it.
+    if (!fetchStatus || projectId === 'default') { setRead({ kind: 'idle' }); return; }
     let cancelled = false;
     setRead({ kind: 'loading' });
     // Through a resolved promise: a client that cannot serve the read (an older daemon, a
@@ -189,12 +203,16 @@ export function ProjectGraphAction({
         {label}
       </button>
       {build.kind === 'built' && (
-        <span data-testid="project-graph-result" style={{ ...MONO, color: build.result.failed.length > 0 ? 'var(--status-gate)' : 'var(--status-run)' }}>
+        <span
+          data-testid="project-graph-result"
+          title={build.result.failed.length > 0 ? build.result.failed.map((f) => `${f.label}: ${f.error}`).join('\n') : undefined}
+          style={{ ...MONO, color: build.result.failed.length > 0 ? 'var(--status-gate)' : 'var(--status-run)' }}
+        >
           {build.result.failed.length === 0
             ? `project graph ${build.result.status.state === 'ready' || build.result.status.state === 'ready-single-repo' ? 'ready' : build.result.status.state} — ${build.result.indexed.length} indexed`
               + (build.result.skipped.length > 0 ? `, ${build.result.skipped.length} already current` : '')
             : `built with failures — ${build.result.indexed.length} indexed, ${build.result.failed.length} failed: `
-              + build.result.failed.map((f) => `${f.label} (${f.error})`).join('; ')}
+              + build.result.failed.map((f) => `${f.label} (${briefError(f.error)})`).join('; ')}
           {builtNote !== undefined ? ` · ${builtNote}` : ''}
         </span>
       )}

--- a/src/components/ProjectRepositories.tsx
+++ b/src/components/ProjectRepositories.tsx
@@ -19,7 +19,12 @@ import { RepoFindings, repoFindings } from './RepoFindings.js';
  * selected at registration — and detach is `DELETE /projects/:id/members/:mid`.
  * The picker is the registered-repo list from the ONE session repo cache
  * (DES-FEEDBACK-002 §1.4): fetched on the first gesture that needs it (the
- * search field's focus), never on mount.
+ * search field's focus) — and, since acceptance finding F-2R2-004, on mount
+ * for a project that HAS repository members: the rows' engine findings
+ * (`in_tree_code_graph_ignored` + "Re-run onboarding") live on the registry
+ * record, and the checklist path "project → repositories" showed none while
+ * the cache stayed cold. Still the one shared cache: at most one GET /repos
+ * per session however many surfaces ask.
  *
  * Membership state stays with the parent (the dashboard's / detail page's one
  * membership read): this section filters to `crew.repo` and reports every
@@ -204,6 +209,20 @@ export function ProjectRepositories({ projectId, members, onMembersChange }: Pro
     () => members.filter((m) => m.member_kind === REPO_KIND),
     [members],
   );
+
+  // F-2R2-004: the rows can only show the engine's findings (and their "Re-run onboarding")
+  // once the registry is known — warm the ONE session cache when this project has members and
+  // the cache is cold. A failed read stays silent here: the picker's gesture retries and
+  // reports it (`registryError`), so the failure is never lost, only not doubled.
+  useEffect(() => {
+    if (repos !== null || repoMembers.length === 0 || projectId === DEFAULT_PROJECT_ID) return;
+    let cancelled = false;
+    Promise.resolve()
+      .then(() => fetchReposCached())
+      .then((rs) => { if (!cancelled) setRepos(rs); })
+      .catch(() => { /* the picker's gesture retries and reports */ });
+    return () => { cancelled = true; };
+  }, [repos, repoMembers.length, projectId]);
 
   const options = useMemo(() => {
     if (repos === null) return [];

--- a/src/components/RepositoriesPanel.tsx
+++ b/src/components/RepositoriesPanel.tsx
@@ -3,7 +3,7 @@ import { api } from '../api/client.js';
 import type { Project, RepoEntry, SessionView } from '../api/types.js';
 import { gateOpenPath } from '../board/gateActions.js';
 import {
-  matchesRepoChip, repoFleetModels, type RepoChip, type RepoFleetModel,
+  graphReady, matchesRepoChip, repoFleetModels, type OnboardState, type RepoChip, type RepoFleetModel,
 } from '../board/repoStats.js';
 import {
   attachSeries, deltaWord, healthColor, healthOf, statusCounts, windowBuckets, windowDelta,
@@ -82,11 +82,24 @@ const CARD_STAT: React.CSSProperties = {
   whiteSpace: 'nowrap',
 };
 
+/** The card's graph state — the engine's checkout findings OUTRANK the run verdict (F-2R2-003). */
+function graphState(m: RepoFleetModel): OnboardState | 'missing' {
+  // An onboard in flight is building the graph the finding says is missing — say so.
+  if (m.graphGap !== null && m.onboard.state !== 'onboarding') return 'missing';
+  return m.onboard.state;
+}
+
 /** The graph-state line's words — one honest sentence per state. */
 function graphStateWord(m: RepoFleetModel, attachedAt: Record<string, number>, now: number): string {
-  const { state, run } = m.onboard;
+  const { run } = m.onboard;
+  const state = graphState(m);
   const clock = run === null ? undefined : attachedAt[run.session.id];
   const when = clock === undefined ? '' : ` · ${ago(clock, now)} ago`;
+  if (state === 'missing') {
+    return m.graphGap?.kind === 'no-graph-root'
+      ? 'graph missing — no graph root resolves for this daemon'
+      : `graph missing — re-run onboarding${m.onboard.state === 'ready' ? ' (the onboard that completed predates the live graph)' : ''}`;
+  }
   if (state === 'ready') return `graph ready — onboard completed${when}`;
   if (state === 'onboarding') return 'onboarding now — index + annotate in flight';
   if (state === 'failed') return `onboard FAILED${when} — the graph may be stale or absent`;
@@ -98,7 +111,12 @@ const GRAPH_STATE_COLOR: Record<string, string> = {
   onboarding: 'var(--status-run)',
   failed: 'var(--status-fail)',
   never: 'var(--status-gate)',
+  missing: 'var(--status-fail)',
 };
+
+/** The hover text every graph-state reading shares: what the story is derived from. */
+const GRAPH_STATE_TITLE =
+  'Derived from the repo\'s newest onboarding run AND the engine\'s checkout findings (RepoEntry.findings): a finding that says no live graph has been indexed outranks a completed onboard — the repos wire carries no index-freshness field';
 
 export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate, ambientProject = null }: Props): React.ReactElement {
   const [repos, setRepos] = useState<RepoEntry[]>([]);
@@ -329,9 +347,17 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate, amb
     [repos, repoRuns, attachedAt, windowIds],
   );
   const activeRepoN = fleet.filter((m) => m.activeNow).length;
-  const readyN = fleet.filter((m) => m.onboard.state === 'ready').length;
-  const gapFailedN = fleet.filter((m) => m.onboard.state === 'failed').length;
-  const gapNeverN = fleet.filter((m) => m.onboard.state === 'never').length;
+  // F-2R2-003: READY means the onboard completed AND the engine names no live-graph gap; a
+  // repo whose findings say no live graph exists is an INDEX GAP whatever its run history says.
+  const readyN = fleet.filter((m) => graphReady(m)).length;
+  const gapMissingN = fleet.filter((m) => graphState(m) === 'missing').length;
+  const gapFailedN = fleet.filter((m) => m.onboard.state === 'failed' && graphState(m) !== 'missing').length;
+  const gapNeverN = fleet.filter((m) => m.onboard.state === 'never' && graphState(m) !== 'missing').length;
+  const gapWords = [
+    gapMissingN > 0 ? `${gapMissingN} graph missing` : null,
+    gapFailedN > 0 ? `${gapFailedN} onboard failed` : null,
+    gapNeverN > 0 ? `${gapNeverN} never onboarded` : null,
+  ].filter((w): w is string => w !== null);
 
   /** The gate jump: the run's thread AT the gate when its project is known;
    *  the flat run detail (where the approval dock lives) when unfiled. */
@@ -349,10 +375,10 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate, amb
   const visible = searched.filter((m) => matchesRepoChip(m, chip));
 
   const chipCounts = useMemo(() => {
-    const counts: Record<RepoChip, number> = { all: 0, 'needs-you': 0, active: 0, failing: 0, ready: 0, never: 0 };
+    const counts: Record<RepoChip, number> = { all: 0, 'needs-you': 0, active: 0, failing: 0, ready: 0, never: 0, 'graph-missing': 0 };
     for (const m of searched) {
       counts.all += 1;
-      for (const c of ['needs-you', 'active', 'failing', 'ready', 'never'] as const) {
+      for (const c of ['needs-you', 'active', 'failing', 'ready', 'never', 'graph-missing'] as const) {
         if (matchesRepoChip(m, c)) counts[c] += 1;
       }
     }
@@ -366,6 +392,10 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate, amb
     { id: 'failing', label: 'Failing', count: chipCounts.failing },
     { id: 'ready', label: 'Ready', count: chipCounts.ready },
     { id: 'never', label: 'Never onboarded', count: chipCounts.never },
+    // F-2R2-003: the engine's own "no live graph" — a chip only while some repo carries it.
+    ...(chipCounts['graph-missing'] > 0
+      ? [{ id: 'graph-missing', label: 'Graph missing', count: chipCounts['graph-missing'] } satisfies FilterChip]
+      : []),
   ];
 
   return (
@@ -439,8 +469,8 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate, amb
                 testId="stat-ready"
                 label="Graphs ready"
                 value={readyN}
-                context={`of ${repos.length} repo${repos.length === 1 ? '' : 's'} onboarded`}
-                title="Repos whose newest onboard run completed — filter to them"
+                context={`of ${repos.length} repo${repos.length === 1 ? '' : 's'} — live graph built`}
+                title="Repos whose newest onboard completed AND whose live graph the engine's checkout findings do not dispute — filter to them"
                 onOpen={() => setChip('ready')}
               />
             </KpiGroup>
@@ -459,15 +489,11 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate, amb
               <StatTile
                 testId="stat-gaps"
                 label="Index gaps"
-                value={gapFailedN + gapNeverN}
-                valueColor={gapFailedN > 0 ? 'var(--status-fail)' : undefined}
-                context={
-                  gapFailedN + gapNeverN === 0
-                    ? 'every graph ready'
-                    : `${gapFailedN} onboard failed · ${gapNeverN} never onboarded`
-                }
-                title="Repos without a completed onboard — the graph story is derived from the run history (the repos wire carries no index-freshness field)"
-                onOpen={() => setChip(gapFailedN > 0 ? 'failing' : 'never')}
+                value={gapMissingN + gapFailedN + gapNeverN}
+                valueColor={gapMissingN + gapFailedN > 0 ? 'var(--status-fail)' : undefined}
+                context={gapWords.length === 0 ? 'every graph ready' : gapWords.join(' · ')}
+                title="Repos without a live graph — a failed or never-run onboard, OR a completed onboard whose live graph the engine's checkout findings say was never built (in-tree graph ignored — re-run onboarding). The repos wire carries no index-freshness field; the findings are the engine's own word."
+                onOpen={() => setChip(gapMissingN > 0 ? 'graph-missing' : gapFailedN > 0 ? 'failing' : 'never')}
               />
             </KpiGroup>
           </KpiBand>
@@ -754,13 +780,13 @@ export function RepositoriesPanel({ onSelectRun, autoShowRegister, navigate, amb
                     {repo.root_path}
                   </p>
 
-                  {/* The graph state — derived from the run history, honestly */}
+                  {/* The graph state — the run history, corrected by the engine's findings (F-2R2-003) */}
                   <p
                     data-testid="repo-graph-state"
-                    data-state={m.onboard.state}
+                    data-state={graphState(m)}
                     className="text-[11px] font-mono truncate"
-                    style={{ color: GRAPH_STATE_COLOR[m.onboard.state] ?? 'var(--ink-dim)', margin: 0 }}
-                    title="Derived from the repo's newest onboarding run — the repos wire carries no index-freshness field"
+                    style={{ color: GRAPH_STATE_COLOR[graphState(m)] ?? 'var(--ink-dim)', margin: 0 }}
+                    title={GRAPH_STATE_TITLE}
                   >
                     {graphStateWord(m, attachedAt, now)}
                   </p>

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -10,9 +10,9 @@
   "version": 1,
   "studioVersion": "0.5.5",
   "counts": {
-    "files": 143,
-    "occurrences": 1237,
-    "static": 1063,
+    "files": 144,
+    "occurrences": 1242,
+    "static": 1068,
     "dynamic": 59,
     "computed": 7
   },
@@ -3428,6 +3428,36 @@
       "testId": "project-dashboard",
       "files": [
         "src/components/ProjectDashboard.tsx"
+      ]
+    },
+    {
+      "testId": "project-graph",
+      "files": [
+        "src/components/ProjectGraphAction.tsx"
+      ]
+    },
+    {
+      "testId": "project-graph-build",
+      "files": [
+        "src/components/ProjectGraphAction.tsx"
+      ]
+    },
+    {
+      "testId": "project-graph-error",
+      "files": [
+        "src/components/ProjectGraphAction.tsx"
+      ]
+    },
+    {
+      "testId": "project-graph-result",
+      "files": [
+        "src/components/ProjectGraphAction.tsx"
+      ]
+    },
+    {
+      "testId": "project-graph-state",
+      "files": [
+        "src/components/ProjectGraphAction.tsx"
       ]
     },
     {

--- a/tests/GroupChat.graphBuild.test.tsx
+++ b/tests/GroupChat.graphBuild.test.tsx
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ChatOpenBody, RosterSeat } from '../src/api/types.js';
+import { setCachedRoster } from '../src/store/rosterCache.js';
+import { REPO_CLEAN, REPO_INTREE_LIVE, SCOPE_PROJECT_DANGLING, SCOPE_REPOS_NO_GRAPH, chatOpened } from './fixtures/wave2.js';
+
+/**
+ * F-2R2-008 (studio half) on the chat scope card: the daemon's unbound-graph reason reads
+ * as customer copy (no raw POST; "repo-less" never over a scope that names repositories),
+ * and a project scope with no project graph carries "Build project graph" — crew's
+ * existing refresh route — whose result says it grounds the NEXT chats.
+ */
+
+const openChat = vi.fn();
+const getChat = vi.fn();
+const closeChat = vi.fn();
+const getRoster = vi.fn();
+const sendChatMessage = vi.fn();
+const listProjects = vi.fn();
+const listRepos = vi.fn();
+const refreshProjectGraph = vi.fn();
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    openChat: (...a: unknown[]) => openChat(...a),
+    getChat: (...a: unknown[]) => getChat(...a),
+    closeChat: (...a: unknown[]) => closeChat(...a),
+    getRoster: (...a: unknown[]) => getRoster(...a),
+    sendChatMessage: (...a: unknown[]) => sendChatMessage(...a),
+    listProjects: (...a: unknown[]) => listProjects(...a),
+    listRepos: (...a: unknown[]) => listRepos(...a),
+    refreshProjectGraph: (...a: unknown[]) => refreshProjectGraph(...a),
+  },
+  wsBase: () => 'ws://localhost',
+}));
+
+vi.mock('../src/hooks/useEventStream.js', () => ({ useEventStream: () => undefined }));
+
+const { GroupChat } = await import('../src/components/GroupChat.js');
+const { clearRepoCache } = await import('../src/store/repoCache.js');
+
+const ROSTER = [{ key: 'claude', enabled_for_council: true }] as unknown as RosterSeat[];
+
+/** The phase2-r2 scope, verbatim shape: nine repos, the raw daemon reason. */
+const PID = 'proj_178902523421000000';
+const SCOPE_NINE_NO_GRAPH = {
+  kind: 'project' as const, projectId: PID,
+  repos: Array.from({ length: 9 }, (_, i) => ({ id: `wicked-${i}`, name: `wicked-${i}`, rootPath: `/w5/repos/wicked-${i}` })),
+  cwd: '/w5/tmp/wicked-crew-chats/29858-7c851b82/d24853ca',
+  graph: {
+    bound: false,
+    reason: `Project ${PID} has 9 repo member(s) but no code graph yet. Build it with POST /api/v1/projects/${PID}/graph/refresh. This repo-less run gets no code graph.`,
+  },
+  dangling: [],
+};
+
+async function typeAndSend(text = 'hello there'): Promise<void> {
+  const user = userEvent.setup();
+  await user.type(screen.getByRole('textbox'), text);
+  await user.keyboard('{Enter}');
+}
+
+beforeEach(() => {
+  for (const m of [openChat, getChat, closeChat, getRoster, sendChatMessage, listProjects, listRepos, refreshProjectGraph]) m.mockReset();
+  getRoster.mockResolvedValue({ roster: ROSTER });
+  listProjects.mockResolvedValue({ projects: [] });
+  listRepos.mockResolvedValue({ repos: [REPO_INTREE_LIVE, REPO_CLEAN] });
+  sendChatMessage.mockResolvedValue({ seats: [] });
+  closeChat.mockResolvedValue({ ok: true });
+  sessionStorage.clear();
+  localStorage.clear();
+  clearRepoCache();
+  setCachedRoster(ROSTER);
+});
+afterEach(() => cleanup());
+
+describe('the scope card\'s graph copy + Build project graph (F-2R2-008)', () => {
+  it('a nine-repo project scope with no graph: customer copy (no POST, no "repo-less"), the raw reason on hover, and the Build control', async () => {
+    openChat.mockImplementation((body: ChatOpenBody) => Promise.resolve(chatOpened(body.chatId!, SCOPE_NINE_NO_GRAPH)));
+    refreshProjectGraph.mockResolvedValue({
+      status: { ...SCOPE_NINE_NO_GRAPH, state: 'ready', detail: 'ok', dbPath: '/w5/state/graph.db', repos: [], missingRepos: [], staleRepos: [], linkage: 'none', note: '', updatedAt: 1 },
+      indexed: SCOPE_NINE_NO_GRAPH.repos.map((r) => r.name), skipped: [], failed: [],
+    });
+    render(<GroupChat repoId={null} onBack={() => undefined} projectId={PID} />);
+    await typeAndSend('ground me');
+    await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
+    const line = await screen.findByTestId('chat-scope');
+    const graph = within(line).getByTestId('chat-scope-graph');
+    expect(graph.textContent).toBe(`no code graph — Project ${PID} has 9 repo member(s) but no code graph yet.`);
+    expect(graph.textContent).not.toMatch(/POST|repo-less/);
+    expect(graph).toHaveAttribute('title', SCOPE_NINE_NO_GRAPH.graph.reason);
+
+    const build = within(line).getByTestId('project-graph-build');
+    expect(build.textContent).toBe('Build project graph');
+    fireEvent.click(build);
+    expect(refreshProjectGraph).toHaveBeenCalledWith(PID);
+    expect(within(line).getByTestId('project-graph-build').textContent).toContain('indexing 9 repositories');
+    const res = await within(line).findByTestId('project-graph-result');
+    expect(res.textContent).toContain('project graph ready — 9 indexed');
+    expect(res.textContent).toContain('new chats in this project ground on it (this chat keeps the scope it opened with)');
+  });
+
+  it('a dangling-member project scope keeps its daemon sentence and gets the control; a repo scope with an unindexed repo gets none', async () => {
+    openChat.mockImplementation((body: ChatOpenBody) => Promise.resolve(chatOpened(body.chatId!, SCOPE_PROJECT_DANGLING)));
+    render(<GroupChat repoId={null} onBack={() => undefined} projectId="auth-refactor" />);
+    await typeAndSend('shell-bound');
+    const line = await screen.findByTestId('chat-scope');
+    expect(within(line).getByTestId('chat-scope-graph').textContent).toBe('no code graph — the project graph has never been built.');
+    expect(within(line).getByTestId('project-graph-build')).toBeInTheDocument();
+    cleanup();
+    sessionStorage.clear();
+
+    openChat.mockImplementation((body: ChatOpenBody) => Promise.resolve(chatOpened(body.chatId!, SCOPE_REPOS_NO_GRAPH)));
+    render(<GroupChat repoId={null} onBack={() => undefined} />);
+    fireEvent.click(screen.getByTestId('chat-scope-repos'));
+    const options = await screen.findAllByTestId('chat-scope-repo-option');
+    fireEvent.click(within(options[1]!).getByRole('checkbox'));
+    await typeAndSend('repo ask');
+    const line2 = await screen.findByTestId('chat-scope');
+    expect(within(line2).getByTestId('chat-scope-graph').textContent).toContain("'billing' has no resolvable code graph");
+    expect(within(line2).queryByTestId('project-graph-build')).toBeNull();
+  });
+});

--- a/tests/HealthRailSection.signin.test.tsx
+++ b/tests/HealthRailSection.signin.test.tsx
@@ -5,11 +5,13 @@ import type { RosterSeat } from '../src/api/types.js';
 import { useConnectionStore } from '../src/store/connection.js';
 
 /**
- * F-2R2-009 — the Health rail's seat rows say what a signed-out seat MEANS: councils bench
- * it. Pre-fix every unsigned seat wore a green ✓ with "active · signed out", as if nothing
- * followed. The roster wire carries no field that says whether the seat could still answer
- * without a sign-in (the rig saw opencode answer a chat on a provider free tier), so the
- * row states the one consequence that is known and puts the possibility on hover.
+ * F-2R2-009 — the Health rail's seat rows say what a signed-out seat MEANS, honestly. Pre-fix
+ * every unsigned seat wore a green ✓ with "active · signed out", as if nothing followed. The
+ * roster wire (api-types 0.33.0) carries no field that says whether a council would seat it —
+ * and the rig saw opencode answer a chat on a provider free tier while `signed_in:false` — so
+ * the row states the observation and HEDGES the consequence ("councils may bench this seat"),
+ * puts the free-tier possibility on hover, and never folds the heuristic into the heart. When a
+ * daemon sends crew#533's `auth` / `council_eligible` (0.35.0) the row believes those instead.
  */
 
 const getHealth = vi.fn(() => Promise.resolve({ status: 'ok', version: '0.7.29', ping: 'pong' }));
@@ -22,7 +24,7 @@ vi.mock('../src/api/client.js', () => ({
   apiFetch: (...a: unknown[]) => apiFetch(...(a as [])),
 }));
 
-const { HealthRailSection, SIGNED_OUT_DETAIL, SIGNED_OUT_TITLE } = await import('../src/components/HealthRailSection.js');
+const { HealthRailSection, SIGNED_OUT_DETAIL, SIGNED_OUT_TITLE, seatStandingWord } = await import('../src/components/HealthRailSection.js');
 const { clearCachedRoster } = await import('../src/store/rosterCache.js');
 
 const SINCE = '2026-09-11T05:00:00Z';
@@ -46,19 +48,50 @@ beforeEach(() => {
 afterEach(() => cleanup());
 
 describe('seat sign-in semantics on the rail (F-2R2-009)', () => {
-  it('an active, signed-out seat wears the amber "!" and says councils bench it — never a green ✓ over "signed out"', async () => {
+  it('an active, signed-out seat wears the amber "!" and HEDGES the consequence — never a green ✓, never an engine rule the wire does not carry', async () => {
     render(<Harness />);
     const rows = await screen.findAllByTestId('rail-seat-row');
     const opencode = rows.find((r) => r.getAttribute('data-seat') === 'opencode')!;
     expect(opencode).toHaveAttribute('data-signed-in', 'false');
+    expect(opencode).toHaveAttribute('data-standing', 'signed-out');
     expect(opencode).toHaveAttribute('data-health', 'active');
     expect(opencode.textContent).toContain('!');
     expect(opencode.textContent).not.toContain('✓');
     expect(opencode.textContent).toContain(`active · ${SIGNED_OUT_DETAIL}`);
+    expect(SIGNED_OUT_DETAIL).toBe('signed out — councils may bench this seat');
+    expect(opencode.textContent).not.toMatch(/councils bench this seat|will be benched/);
     expect(opencode).toHaveAttribute('title', SIGNED_OUT_TITLE);
     // The hover text names the possibility the wire cannot confirm, as a possibility.
     expect(SIGNED_OUT_TITLE).toContain('free tier');
     expect(SIGNED_OUT_TITLE).toContain('cannot tell');
+  });
+
+  it('reads crew#533\'s auth / council_eligible (api-types 0.35.0) when a daemon sends them — believed, never inferred', async () => {
+    rosterAnswer = [
+      { key: 'opencode', display_name: 'OpenCode', binary: 'opencode', enabled_for_council: true, health: { status: 'active', since: SINCE }, signed_in: false,
+        auth: 'not_required', free_tier: 'OpenCode Zen' } as RosterSeat,
+      { key: 'codex', display_name: 'Codex', binary: 'codex', enabled_for_council: true, health: { status: 'active', since: SINCE }, signed_in: false,
+        auth: 'signed_out', council_eligible: false, council_ineligible_reason: 'signed out — a council would bench it' } as RosterSeat,
+      { key: 'pi', display_name: 'pi', binary: 'pi', enabled_for_council: true, health: { status: 'active', since: SINCE }, signed_in: false,
+        auth: 'signed_out', council_eligible: true } as RosterSeat,
+    ];
+    render(<Harness />);
+    const rows = await screen.findAllByTestId('rail-seat-row');
+    const byKey = (k: string): HTMLElement => rows.find((r) => r.getAttribute('data-seat') === k)!;
+    // A free-tier seat: the daemon says no sign-in is needed — a green ✓, the tier named.
+    expect(byKey('opencode')).toHaveAttribute('data-standing', 'no-sign-in-needed');
+    expect(byKey('opencode')).toHaveAttribute('data-auth', 'not_required');
+    expect(byKey('opencode').textContent).toContain('✓');
+    expect(byKey('opencode').textContent).toContain('active · no sign-in needed (OpenCode Zen)');
+    // The daemon SAYS a council would not seat it — its reason, its words, the amber "!".
+    expect(byKey('codex')).toHaveAttribute('data-standing', 'ineligible');
+    expect(byKey('codex').textContent).toContain('!');
+    expect(byKey('codex').textContent).toContain('not council-eligible — signed out — a council would bench it');
+    // Signed out but declared eligible: said so.
+    expect(byKey('pi').textContent).toContain('signed out — still council-eligible');
+    // Only the daemon's own ineligibility degrades the heart.
+    expect(screen.getByTestId('rail-health-heart')).toHaveAttribute('data-health', 'degraded');
+    expect(seatStandingWord({ key: 'x', display_name: 'x', binary: 'x', enabled_for_council: true }).kind).toBe('unknown');
   });
 
   it('a signed-in seat is unchanged; an inactive seat keeps its error excerpt; unknown sign-in stays quiet', async () => {
@@ -77,7 +110,7 @@ describe('seat sign-in semantics on the rail (F-2R2-009)', () => {
     expect(agy.textContent).toBe('✓Antigravityactive');
   });
 
-  it('the heart reads degraded (amber) over a benched seat, unhealthy over an inactive one', async () => {
+  it('the heart is NOT folded on the sign-in heuristic: healthy over signed-out seats alone, unhealthy over an inactive one', async () => {
     render(<Harness />);
     await screen.findAllByTestId('rail-seat-row');
     // codex is inactive here — unhealthy wins.
@@ -87,7 +120,9 @@ describe('seat sign-in semantics on the rail (F-2R2-009)', () => {
     clearCachedRoster();
     render(<Harness />);
     await screen.findAllByTestId('rail-seat-row');
-    expect(screen.getByTestId('rail-health-heart')).toHaveAttribute('data-health', 'degraded');
+    // Two of three seats read signed_in:false (the rig's default roster shape) — a healthy daemon
+    // must not wear a permanently degraded heart over a heuristic; the rows carry the amber "!".
+    expect(screen.getByTestId('rail-health-heart')).toHaveAttribute('data-health', 'healthy');
     expect(screen.queryByTestId('rail-health-summary-dot')).toBeNull();
   });
 });

--- a/tests/HealthRailSection.signin.test.tsx
+++ b/tests/HealthRailSection.signin.test.tsx
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import type { RosterSeat } from '../src/api/types.js';
+import { useConnectionStore } from '../src/store/connection.js';
+
+/**
+ * F-2R2-009 — the Health rail's seat rows say what a signed-out seat MEANS: councils bench
+ * it. Pre-fix every unsigned seat wore a green ✓ with "active · signed out", as if nothing
+ * followed. The roster wire carries no field that says whether the seat could still answer
+ * without a sign-in (the rig saw opencode answer a chat on a provider free tier), so the
+ * row states the one consequence that is known and puts the possibility on hover.
+ */
+
+const getHealth = vi.fn(() => Promise.resolve({ status: 'ok', version: '0.7.29', ping: 'pong' }));
+let rosterAnswer: RosterSeat[] = [];
+const getRoster = vi.fn(() => Promise.resolve({ roster: rosterAnswer }));
+const apiFetch = vi.fn(() => Promise.resolve({}));
+
+vi.mock('../src/api/client.js', () => ({
+  api: { getHealth: () => getHealth(), getRoster: () => getRoster(), listRepos: () => Promise.resolve({ repos: [] }) },
+  apiFetch: (...a: unknown[]) => apiFetch(...(a as [])),
+}));
+
+const { HealthRailSection, SIGNED_OUT_DETAIL, SIGNED_OUT_TITLE } = await import('../src/components/HealthRailSection.js');
+const { clearCachedRoster } = await import('../src/store/rosterCache.js');
+
+const SINCE = '2026-09-11T05:00:00Z';
+const SEATS: RosterSeat[] = [
+  { key: 'claude', display_name: 'Claude Code', binary: 'claude', enabled_for_council: true, health: { status: 'active', since: SINCE }, signed_in: true },
+  { key: 'opencode', display_name: 'OpenCode', binary: 'opencode', enabled_for_council: true, health: { status: 'active', since: SINCE }, signed_in: false },
+  { key: 'codex', display_name: 'Codex', binary: 'codex', enabled_for_council: true, health: { status: 'inactive', message: 'quota exceeded', since: SINCE }, signed_in: false },
+  { key: 'agy', display_name: 'Antigravity', binary: 'agy', enabled_for_council: true, health: { status: 'active', since: SINCE }, signed_in: null },
+];
+
+function Harness(): React.ReactElement {
+  const [open, setOpen] = useState(true);
+  return <HealthRailSection open={open} onToggle={() => setOpen((v) => !v)} />;
+}
+
+beforeEach(() => {
+  rosterAnswer = SEATS;
+  clearCachedRoster();
+  useConnectionStore.setState({ status: 'connected' });
+});
+afterEach(() => cleanup());
+
+describe('seat sign-in semantics on the rail (F-2R2-009)', () => {
+  it('an active, signed-out seat wears the amber "!" and says councils bench it — never a green ✓ over "signed out"', async () => {
+    render(<Harness />);
+    const rows = await screen.findAllByTestId('rail-seat-row');
+    const opencode = rows.find((r) => r.getAttribute('data-seat') === 'opencode')!;
+    expect(opencode).toHaveAttribute('data-signed-in', 'false');
+    expect(opencode).toHaveAttribute('data-health', 'active');
+    expect(opencode.textContent).toContain('!');
+    expect(opencode.textContent).not.toContain('✓');
+    expect(opencode.textContent).toContain(`active · ${SIGNED_OUT_DETAIL}`);
+    expect(opencode).toHaveAttribute('title', SIGNED_OUT_TITLE);
+    // The hover text names the possibility the wire cannot confirm, as a possibility.
+    expect(SIGNED_OUT_TITLE).toContain('free tier');
+    expect(SIGNED_OUT_TITLE).toContain('cannot tell');
+  });
+
+  it('a signed-in seat is unchanged; an inactive seat keeps its error excerpt; unknown sign-in stays quiet', async () => {
+    render(<Harness />);
+    const rows = await screen.findAllByTestId('rail-seat-row');
+    const claude = rows.find((r) => r.getAttribute('data-seat') === 'claude')!;
+    expect(claude).toHaveAttribute('data-signed-in', 'true');
+    expect(claude.textContent).toContain('✓');
+    expect(claude.textContent).toContain('active · signed in');
+    const codex = rows.find((r) => r.getAttribute('data-seat') === 'codex')!;
+    expect(codex.textContent).toContain('✗');
+    expect(codex.textContent).toContain('quota exceeded');
+    expect(codex).toHaveAttribute('title', 'quota exceeded');
+    const agy = rows.find((r) => r.getAttribute('data-seat') === 'agy')!;
+    expect(agy).toHaveAttribute('data-signed-in', 'unknown');
+    expect(agy.textContent).toBe('✓Antigravityactive');
+  });
+
+  it('the heart reads degraded (amber) over a benched seat, unhealthy over an inactive one', async () => {
+    render(<Harness />);
+    await screen.findAllByTestId('rail-seat-row');
+    // codex is inactive here — unhealthy wins.
+    expect(screen.getByTestId('rail-health-heart')).toHaveAttribute('data-health', 'unhealthy');
+    cleanup();
+    rosterAnswer = SEATS.filter((s) => s.key !== 'codex');
+    clearCachedRoster();
+    render(<Harness />);
+    await screen.findAllByTestId('rail-seat-row');
+    expect(screen.getByTestId('rail-health-heart')).toHaveAttribute('data-health', 'degraded');
+    expect(screen.queryByTestId('rail-health-summary-dot')).toBeNull();
+  });
+});

--- a/tests/ProjectDashboard.graph.test.tsx
+++ b/tests/ProjectDashboard.graph.test.tsx
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import type { Project, ProjectMember } from '../src/api/types.js';
+
+/**
+ * F-2R2-008 on the project page: a project with repository members shows its graph's
+ * standing (`GET /projects/:id/graph`) and the Build control; a project without members
+ * reads nothing and shows nothing; a daemon without the route shows nothing loud.
+ */
+
+const listProjectMembers = vi.fn();
+const getProjectGraph = vi.fn();
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    listProjects: () => Promise.resolve({ projects: [] }),
+    listProjectMembers: (...a: unknown[]) => listProjectMembers(...a),
+    confirmGate: () => Promise.resolve({}),
+    listRepos: () => Promise.resolve({ repos: [] }),
+    getProjectGraph: (...a: unknown[]) => getProjectGraph(...a),
+    refreshProjectGraph: () => Promise.reject(new Error('not in this suite')),
+  },
+}));
+
+vi.mock('../src/api/interactive.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/api/interactive.js')>()),
+  listDocs: () => Promise.resolve([]),
+}));
+
+const { ProjectDashboard } = await import('../src/components/ProjectDashboard.js');
+const { useProjectsStore } = await import('../src/store/projects.js');
+const { clearRepoCache } = await import('../src/store/repoCache.js');
+
+const NOW = 1_757_300_000_000;
+const PROJECT: Project = {
+  id: 'proj-1', name: 'The proj-1 project', description: null, status: 'active',
+  scope: 'project:proj-1', created_at: NOW - 1000, updated_at: NOW - 1000,
+};
+
+function member(ref: string): ProjectMember {
+  return {
+    id: `proj-1:crew.repo:${ref}`, project_id: 'proj-1', member_kind: 'crew.repo',
+    member_ref: ref, meta: null, attached_at: NOW - 2000, attached_by: 'studio',
+  };
+}
+
+beforeEach(() => {
+  clearRepoCache();
+  listProjectMembers.mockReset();
+  getProjectGraph.mockReset();
+  useProjectsStore.setState({ projects: [PROJECT], loading: false, error: null });
+});
+afterEach(cleanup);
+
+describe('the project page\'s graph standing (F-2R2-008)', () => {
+  it('with repo members: reads the standing once and offers Build project graph when it is not built', async () => {
+    listProjectMembers.mockResolvedValue({ members: [member('wicked-studio'), member('wicked-core')] });
+    getProjectGraph.mockResolvedValue({
+      status: {
+        projectId: 'proj-1', state: 'not-indexed',
+        detail: 'Project proj-1 has 2 repo member(s) but no code graph yet. Build it with POST /api/v1/projects/proj-1/graph/refresh.',
+        dbPath: null, repos: [], missingRepos: ['wicked-studio', 'wicked-core'], staleRepos: [], linkage: 'none', note: '', updatedAt: null,
+      },
+    });
+    render(<ProjectDashboard projectId="proj-1" runs={[]} navigate={() => {}} />);
+    await waitFor(() => expect(getProjectGraph).toHaveBeenCalledWith('proj-1'));
+    const graph = await screen.findByTestId('project-graph');
+    await waitFor(() => expect(graph).toHaveAttribute('data-state', 'not-indexed'));
+    expect(screen.getByTestId('project-graph-state').textContent).toContain('not built');
+    expect(screen.getByTestId('project-graph-state').textContent).not.toContain('POST');
+    expect(screen.getByTestId('project-graph-build').textContent).toBe('Build project graph');
+    expect(getProjectGraph).toHaveBeenCalledTimes(1);
+  });
+
+  it('without repo members: no read, no control', async () => {
+    listProjectMembers.mockResolvedValue({ members: [] });
+    render(<ProjectDashboard projectId="proj-1" runs={[]} navigate={() => {}} />);
+    await waitFor(() => expect(listProjectMembers).toHaveBeenCalledTimes(1));
+    await new Promise((r) => setTimeout(r, 10));
+    expect(getProjectGraph).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('project-graph')).toBeNull();
+  });
+});

--- a/tests/ProjectDashboard.test.tsx
+++ b/tests/ProjectDashboard.test.tsx
@@ -313,7 +313,7 @@ describe('bound repos row (unchanged contract)', () => {
     expect(screen.getByTestId('dashboard-runs')).toHaveAttribute('data-count', '1');
   });
 
-  it('a cold cache renders the raw ref in --ink-dim — membership is the truth, still a link, still no fetch', async () => {
+  it('a cold cache renders the raw ref in --ink-dim — membership is the truth, still a link; the section warms the ONE cache once', async () => {
     listProjectMembers.mockResolvedValue({ members: [member('studio-api', 'crew.repo')] });
     render(<ProjectDashboard projectId="proj-1" runs={[]} navigate={() => {}} />);
 
@@ -322,7 +322,10 @@ describe('bound repos row (unchanged contract)', () => {
     expect(chip).toHaveTextContent('studio-api'); // the raw ref
     expect(chip).toHaveAttribute('href', '/repo-detail/studio-api');
     expect((chip as HTMLElement).style.color).toBe('var(--ink-dim)');
-    expect(listRepos).not.toHaveBeenCalled();
+    // F-2R2-004: the REPOSITORIES rows need the registry for their engine findings, so a
+    // project WITH repo members warms the one session cache on mount — exactly one GET
+    // /repos (the header chip never fetches on its own; it reads the same cache).
+    await waitFor(() => expect(listRepos).toHaveBeenCalledTimes(1));
   });
 
   it('with no crew.repo member the testid is ABSENT — the empty-state budget', async () => {

--- a/tests/ProjectDetailPage.repos.test.tsx
+++ b/tests/ProjectDetailPage.repos.test.tsx
@@ -100,8 +100,10 @@ describe('ProjectDetailPage — Repositories section (studio#207)', () => {
     // The run member is a Member, not a repository — and the generic list no longer double-lists repos.
     expect(within(section).queryByText('r-1')).toBeNull();
     expect(screen.getByText('Members (1)')).toBeInTheDocument();
-    // Nothing fetched the registry on mount — the picker warms the cache on its first gesture.
-    expect(listRepos).not.toHaveBeenCalled();
+    // F-2R2-004: a project WITH repo members warms the one session cache on mount (the rows'
+    // engine findings live on the registry record) — exactly once; the picker's gesture then
+    // finds it warm and fetches nothing more.
+    await waitFor(() => expect(listRepos).toHaveBeenCalledTimes(1));
   });
 
   it('the empty state names the consequence (a project-scoped test cannot launch)', async () => {

--- a/tests/ProjectGraphAction.test.tsx
+++ b/tests/ProjectGraphAction.test.tsx
@@ -107,14 +107,30 @@ describe('the control (row variant, with the standing read)', () => {
     expect(err.textContent).toContain('not built — the daemon refused this — the installed engine predates project graphs');
   });
 
-  it('renders nothing on a daemon without the route, and nothing for the Unfiled project', async () => {
+  it('renders nothing on a daemon without the route, and nothing — with NO read — for the Unfiled project', async () => {
     getProjectGraph.mockRejectedValue(new ApiError(404, 'Not Found'));
     render(<ProjectGraphAction projectId={PID} variant="row" fetchStatus />);
     await waitFor(() => expect(getProjectGraph).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(screen.queryByTestId('project-graph')).toBeNull());
     cleanup();
+    getProjectGraph.mockClear();
     render(<ProjectGraphAction projectId="default" variant="row" fetchStatus />);
+    await new Promise((r) => setTimeout(r, 10));
     expect(screen.queryByTestId('project-graph')).toBeNull();
+    expect(getProjectGraph).not.toHaveBeenCalled(); // the synthesized project pays no request it would ignore
+  });
+
+  it('a per-repo index error is one line on the result (first line, capped) with the whole text on hover', async () => {
+    getProjectGraph.mockResolvedValue({ status: status('not-indexed') });
+    const long = `estate index failed: ${'x'.repeat(200)}\nsecond line with /w5/state/paths`;
+    refreshProjectGraph.mockResolvedValueOnce(result(['repo-0'], [{ repoId: 'r1', label: 'repo-1', error: long }]));
+    render(<ProjectGraphAction projectId={PID} variant="row" fetchStatus />);
+    fireEvent.click(await screen.findByTestId('project-graph-build'));
+    const res = await screen.findByTestId('project-graph-result');
+    expect(res.textContent).not.toContain('second line');
+    expect(res.textContent!.length).toBeLessThan(long.length);
+    expect(res.textContent).toMatch(/…\)/);
+    expect(res.getAttribute('title')).toContain('second line with /w5/state/paths');
   });
 });
 

--- a/tests/ProjectGraphAction.test.tsx
+++ b/tests/ProjectGraphAction.test.tsx
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ApiError } from '../src/api/errors.js';
+import type { ProjectGraphRefreshResult, ProjectGraphStatus } from '../src/api/types.js';
+
+/**
+ * F-2R2-008 (studio half) — "Build project graph": the one control that calls crew's
+ * existing `POST /projects/:id/graph/refresh`, with honest pending / ready / failed state,
+ * and the customer copy for the daemon's graph reason (no raw POST, "repo-less" only when
+ * the scope names no repository).
+ */
+
+const getProjectGraph = vi.fn();
+const refreshProjectGraph = vi.fn();
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    getProjectGraph: (...a: unknown[]) => getProjectGraph(...a),
+    refreshProjectGraph: (...a: unknown[]) => refreshProjectGraph(...a),
+  },
+}));
+
+const { ProjectGraphAction, describeGraphStatus, humanizeGraphReason, reasonWantsProjectGraph } =
+  await import('../src/components/ProjectGraphAction.js');
+
+const PID = 'proj_178902523421000000';
+const RAW_REASON =
+  `Project ${PID} has 9 repo member(s) but no code graph yet. Build it with POST /api/v1/projects/${PID}/graph/refresh. This repo-less run gets no code graph.`;
+
+function status(state: ProjectGraphStatus['state'], indexed = 0): ProjectGraphStatus {
+  return {
+    projectId: PID, state, detail: state === 'not-indexed' ? RAW_REASON : 'ok', dbPath: null,
+    repos: Array.from({ length: 9 }, (_, i) => ({ repoId: `r${i}`, label: `repo-${i}`, rootPath: `/w5/repos/r${i}`, indexed: i < indexed })),
+    missingRepos: [], staleRepos: [], linkage: 'none' as never, note: '', updatedAt: state === 'ready' ? 1_757_300_000_000 : null,
+  };
+}
+
+function result(indexed: string[], failed: ProjectGraphRefreshResult['failed'] = []): ProjectGraphRefreshResult {
+  return { status: status('ready', 9), indexed, skipped: [], failed };
+}
+
+beforeEach(() => {
+  getProjectGraph.mockReset();
+  refreshProjectGraph.mockReset();
+});
+afterEach(cleanup);
+
+describe('the customer copy (humanizeGraphReason)', () => {
+  it('drops the raw POST sentence, says "repo-less" only over an empty scope, keeps the daemon\'s words', () => {
+    expect(humanizeGraphReason(RAW_REASON, 9)).toBe(`Project ${PID} has 9 repo member(s) but no code graph yet.`);
+    expect(humanizeGraphReason(RAW_REASON, 9)).not.toMatch(/POST|repo-less/);
+    expect(humanizeGraphReason('the project graph has never been built. POST /api/v1/projects/auth-refactor/graph/refresh fixes it.', 1))
+      .toBe('the project graph has never been built.');
+    expect(humanizeGraphReason("'billing' has no resolvable code graph (not indexed yet — onboard the repo); this chat gets none.", 1))
+      .toBe("'billing' has no resolvable code graph (not indexed yet — onboard the repo); this chat gets none.");
+    // A genuinely repo-less scope keeps the sentence; an empty remainder still says something true.
+    expect(humanizeGraphReason('This repo-less run gets no code graph.', 0)).toBe('This repo-less run gets no code graph.');
+    expect(humanizeGraphReason('Build it with POST /api/v1/projects/x/graph/refresh.', 3)).toBe('the project graph has not been built yet');
+    expect(reasonWantsProjectGraph(RAW_REASON)).toBe(true);
+    expect(reasonWantsProjectGraph("'billing' has no resolvable code graph (not indexed yet — onboard the repo)")).toBe(false);
+  });
+
+  it('describes the graph\'s standing in words', () => {
+    expect(describeGraphStatus(status('not-indexed'))).toBe('not built — the seats read files, not a code graph');
+    expect(describeGraphStatus(status('ready', 9), 1_757_300_000_000 + 7_200_000)).toContain('ready · 9 repositories indexed · refreshed');
+    expect(describeGraphStatus({ ...status('no-repo-members'), repos: [] })).toBe('no repositories attached — nothing to index');
+  });
+});
+
+describe('the control (row variant, with the standing read)', () => {
+  it('reads GET /projects/:id/graph on mount, offers Build, shows the synchronous wait, then the daemon\'s result', async () => {
+    getProjectGraph.mockResolvedValue({ status: status('not-indexed') });
+    let release: (v: ProjectGraphRefreshResult) => void = () => {};
+    refreshProjectGraph.mockImplementation(() => new Promise<ProjectGraphRefreshResult>((res) => { release = res; }));
+    render(<ProjectGraphAction projectId={PID} variant="row" repoCount={9} fetchStatus />);
+    await waitFor(() => expect(getProjectGraph).toHaveBeenCalledWith(PID));
+    const root = await screen.findByTestId('project-graph');
+    await waitFor(() => expect(root).toHaveAttribute('data-state', 'not-indexed'));
+    expect(screen.getByTestId('project-graph-state').textContent).toContain('not built');
+    const build = screen.getByTestId('project-graph-build');
+    expect(build.textContent).toBe('Build project graph');
+
+    fireEvent.click(build);
+    expect(refreshProjectGraph).toHaveBeenCalledWith(PID);
+    expect(screen.getByTestId('project-graph-build')).toBeDisabled();
+    expect(screen.getByTestId('project-graph-build').textContent).toContain('indexing 9 repositories');
+    expect(root).toHaveAttribute('data-build', 'building');
+
+    await act(async () => { release(result(['repo-0', 'repo-1'])); });
+    await waitFor(() => expect(root).toHaveAttribute('data-build', 'built'));
+    expect(screen.getByTestId('project-graph-result').textContent).toContain('project graph ready — 2 indexed');
+    expect(screen.getByTestId('project-graph-state').textContent).toContain('ready · 9 repositories indexed');
+    expect(screen.getByTestId('project-graph-build').textContent).toBe('Refresh project graph');
+  });
+
+  it('a build with failures says so, per repo; a refused build renders the daemon\'s sentence', async () => {
+    getProjectGraph.mockResolvedValue({ status: status('not-indexed') });
+    refreshProjectGraph.mockResolvedValueOnce(result(['repo-0'], [{ repoId: 'r1', label: 'repo-1', error: 'index timed out' }]));
+    render(<ProjectGraphAction projectId={PID} variant="row" fetchStatus />);
+    fireEvent.click(await screen.findByTestId('project-graph-build'));
+    const res = await screen.findByTestId('project-graph-result');
+    expect(res.textContent).toContain('built with failures — 1 indexed, 1 failed: repo-1 (index timed out)');
+
+    refreshProjectGraph.mockRejectedValueOnce(new ApiError(501, 'the installed engine predates project graphs'));
+    fireEvent.click(screen.getByTestId('project-graph-build'));
+    const err = await screen.findByTestId('project-graph-error');
+    expect(err.textContent).toContain('not built — the daemon refused this — the installed engine predates project graphs');
+  });
+
+  it('renders nothing on a daemon without the route, and nothing for the Unfiled project', async () => {
+    getProjectGraph.mockRejectedValue(new ApiError(404, 'Not Found'));
+    render(<ProjectGraphAction projectId={PID} variant="row" fetchStatus />);
+    await waitFor(() => expect(getProjectGraph).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.queryByTestId('project-graph')).toBeNull());
+    cleanup();
+    render(<ProjectGraphAction projectId="default" variant="row" fetchStatus />);
+    expect(screen.queryByTestId('project-graph')).toBeNull();
+  });
+});
+
+describe('the inline variant (the chat scope card)', () => {
+  it('reads nothing on mount, builds on click, and says what the build grounds', async () => {
+    refreshProjectGraph.mockResolvedValue(result(['repo-0']));
+    render(<ProjectGraphAction projectId={PID} variant="inline" repoCount={9} builtNote="new chats in this project ground on it" />);
+    expect(getProjectGraph).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('project-graph-state')).toBeNull();
+    fireEvent.click(screen.getByTestId('project-graph-build'));
+    const res = await screen.findByTestId('project-graph-result');
+    expect(res.textContent).toContain('new chats in this project ground on it');
+  });
+});

--- a/tests/ProjectRepositories.findings.test.tsx
+++ b/tests/ProjectRepositories.findings.test.tsx
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import type { ProjectMember } from '../src/api/types.js';
+import { REPO_CLEAN, REPO_INTREE_NO_LIVE } from './fixtures/wave2.js';
+
+/**
+ * F-2R2-004 — the project dashboard's REPOSITORIES rows render the engine's finding and
+ * "Re-run onboarding". The mount existed (`project-repo-findings`) but the row's registry
+ * lookup stayed undefined until the attach picker's gesture warmed the repo cache, so the
+ * checklist path "studio → project → repositories" showed nothing. A project WITH members
+ * now warms the one session cache on mount; a project without them still fetches nothing.
+ */
+
+const listRepos = vi.fn();
+const rerunOnboarding = vi.fn();
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    listRepos: (...a: unknown[]) => listRepos(...a),
+    rerunOnboarding: (...a: unknown[]) => rerunOnboarding(...a),
+    attachProjectMember: () => Promise.reject(new Error('not in this suite')),
+    detachProjectMember: () => Promise.reject(new Error('not in this suite')),
+  },
+}));
+
+const { ProjectRepositories } = await import('../src/components/ProjectRepositories.js');
+const { clearRepoCache } = await import('../src/store/repoCache.js');
+
+const NOW = 1_757_300_000_000;
+
+function member(ref: string): ProjectMember {
+  return {
+    id: `proj-1:crew.repo:${ref}`, project_id: 'proj-1', member_kind: 'crew.repo',
+    member_ref: ref, meta: null, attached_at: NOW - 2000, attached_by: 'studio',
+  };
+}
+
+beforeEach(() => {
+  clearRepoCache();
+  listRepos.mockReset();
+  rerunOnboarding.mockReset();
+  listRepos.mockResolvedValue({ repos: [REPO_INTREE_NO_LIVE, REPO_CLEAN] });
+  rerunOnboarding.mockResolvedValue({ runId: 'run-reonboard' });
+});
+afterEach(cleanup);
+
+describe('ProjectRepositories — the rows carry the engine\'s findings (F-2R2-004)', () => {
+  it('a project with repo members warms the registry on mount and renders the finding + Re-run onboarding', async () => {
+    render(<ProjectRepositories projectId="proj-1" members={[member('wicked-studio'), member('billing')]} onMembersChange={() => {}} />);
+    await waitFor(() => expect(listRepos).toHaveBeenCalledTimes(1));
+    const rows = await screen.findAllByTestId('project-repo-row');
+    expect(rows).toHaveLength(2);
+    const findings = await screen.findByTestId('project-repo-findings');
+    expect(findings).toHaveAttribute('data-count', '1');
+    const row = within(findings).getByTestId('project-repo-findings-row');
+    expect(row).toHaveAttribute('data-code', 'in_tree_code_graph_ignored');
+    expect(row).toHaveAttribute('data-reonboard', 'true');
+    // The clean repo's row shows no finding block.
+    expect(screen.getAllByTestId('project-repo-findings')).toHaveLength(1);
+
+    fireEvent.click(within(findings).getByTestId('project-repo-findings-reonboard'));
+    await waitFor(() => expect(rerunOnboarding).toHaveBeenCalledWith('wicked-studio'));
+    expect((await screen.findByTestId('project-repo-reonboard-note')).textContent).toContain('onboarding run run-reonboard started');
+  });
+
+  it('a project with NO repo members fetches nothing on mount (the picker gesture still owns that read)', async () => {
+    render(<ProjectRepositories projectId="proj-1" members={[]} onMembersChange={() => {}} />);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(listRepos).not.toHaveBeenCalled();
+    expect(screen.getByTestId('project-repos-empty')).toBeInTheDocument();
+  });
+
+  it('a failed registry read on mount stays silent — the picker gesture retries and reports it', async () => {
+    listRepos.mockRejectedValueOnce(new Error('offline'));
+    render(<ProjectRepositories projectId="proj-1" members={[member('wicked-studio')]} onMembersChange={() => {}} />);
+    await waitFor(() => expect(listRepos).toHaveBeenCalledTimes(1));
+    expect(screen.queryByTestId('project-repo-findings')).toBeNull();
+    fireEvent.focus(screen.getByTestId('project-repo-search'));
+    await waitFor(() => expect(listRepos).toHaveBeenCalledTimes(2));
+    await screen.findByTestId('project-repo-findings');
+  });
+});

--- a/tests/RepositoriesPanel.graphMissing.test.tsx
+++ b/tests/RepositoriesPanel.graphMissing.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
-import { REPO_CLEAN, REPO_INTREE_NO_LIVE, REPO_PREDATES_FINDINGS, REPO_ROOT_UNRESOLVABLE } from './fixtures/wave2.js';
+import { REPO_CLEAN, REPO_INTREE_LIVE, REPO_INTREE_NO_LIVE, REPO_PREDATES_FINDINGS, REPO_ROOT_UNRESOLVABLE } from './fixtures/wave2.js';
 import { makeView } from './factories.js';
 
 /**
@@ -14,9 +14,11 @@ const RUNS = [
   makeView({ id: 'o-studio', repo_ref: 'wicked-studio', workflow_id: 'onboarding', status: 'completed', problem: 'Onboard wicked-studio' }),
   makeView({ id: 'o-billing', repo_ref: 'billing', workflow_id: 'onboarding', status: 'completed', problem: 'Onboard billing' }),
   makeView({ id: 'o-orphan', repo_ref: 'orphan', workflow_id: 'onboarding', status: 'completed', problem: 'Onboard orphan' }),
+  // studio-api: the in-tree graph beside a LIVE one — the downgraded warning after a re-onboard.
+  makeView({ id: 'o-api', repo_ref: 'studio-api', workflow_id: 'onboarding', status: 'completed', problem: 'Onboard studio-api' }),
 ];
 
-const listRepos = vi.fn(() => Promise.resolve({ repos: [REPO_INTREE_NO_LIVE, REPO_CLEAN, REPO_ROOT_UNRESOLVABLE] }));
+const listRepos = vi.fn(() => Promise.resolve({ repos: [REPO_INTREE_NO_LIVE, REPO_CLEAN, REPO_ROOT_UNRESOLVABLE, REPO_INTREE_LIVE] }));
 const listRuns = vi.fn(() => Promise.resolve({ runs: RUNS }));
 const rerunOnboarding = vi.fn<(id: string) => Promise<{ runId: string }>>(() => Promise.resolve({ runId: 'r-new' }));
 
@@ -47,12 +49,16 @@ describe('the fold (repoStats)', () => {
     expect(repoGraphGap(REPO_PREDATES_FINDINGS)).toBeNull(); // an older daemon: no field, no gap invented
     expect(repoGraphGap(REPO_INTREE_NO_LIVE)?.kind).toBe('no-live-graph');
     expect(repoGraphGap(REPO_ROOT_UNRESOLVABLE)?.kind).toBe('no-graph-root');
-    const fleet = repoFleetModels([REPO_INTREE_NO_LIVE, REPO_CLEAN], RUNS, {}, new Set(RUNS.map((v) => v.session.id)));
+    expect(repoGraphGap(REPO_INTREE_LIVE)).toBeNull(); // a live graph beside the ignored in-tree one: no gap
+    const fleet = repoFleetModels([REPO_INTREE_NO_LIVE, REPO_CLEAN, REPO_INTREE_LIVE], RUNS, {}, new Set(RUNS.map((v) => v.session.id)));
     const studio = fleet.find((m) => m.repo.id === 'wicked-studio')!;
     const billing = fleet.find((m) => m.repo.id === 'billing')!;
+    const api = fleet.find((m) => m.repo.id === 'studio-api')!;
     expect(studio.onboard.state).toBe('ready');           // the run history alone says ready…
     expect(graphReady(studio)).toBe(false);               // …the engine says otherwise
     expect(graphReady(billing)).toBe(true);
+    expect(graphReady(api)).toBe(true);
+    expect(matchesRepoChip(api, 'ready')).toBe(true);
     expect(matchesRepoChip(studio, 'ready')).toBe(false);
     expect(matchesRepoChip(studio, 'graph-missing')).toBe(true);
     expect(matchesRepoChip(billing, 'graph-missing')).toBe(false);
@@ -65,8 +71,8 @@ describe('the /repos surface', () => {
     const band = screen.getByTestId('repos-kpis');
     const value = (tid: string): string | null =>
       band.querySelector(`[data-testid="${tid}"]`)?.getAttribute('data-value') ?? null;
-    expect(value('stat-ready')).toBe('1');   // billing only — three onboards completed
-    expect(value('stat-gaps')).toBe('2');    // wicked-studio (no live graph) + orphan (no graph root)
+    expect(value('stat-ready')).toBe('2');   // billing + studio-api (in-tree beside a LIVE graph = ready) — four onboards completed
+    expect(value('stat-gaps')).toBe('2');    // wicked-studio (no live graph) + orphan (no graph root); studio-api is NOT a gap
     expect(screen.getByTestId('stat-gaps').textContent).toContain('2 graph missing');
     expect(screen.getByTestId('stat-gaps').textContent).not.toContain('every graph ready');
     expect(screen.getByTestId('stat-gaps').getAttribute('title')).toContain('checkout findings');
@@ -89,6 +95,14 @@ describe('the /repos surface', () => {
 
     const billing = cards.find((c) => c.getAttribute('data-repo-id') === 'billing')!;
     expect(within(billing).getByTestId('repo-graph-state')).toHaveAttribute('data-state', 'ready');
+    // The second half of the daemon's semantics: an in-tree graph beside a LIVE graph (the finding
+    // downgraded to a tidy-up warning after the re-onboard) reads READY — the warning chip stays,
+    // no re-onboard action, no gap.
+    const api = cards.find((c) => c.getAttribute('data-repo-id') === 'studio-api')!;
+    expect(within(api).getByTestId('repo-graph-state')).toHaveAttribute('data-state', 'ready');
+    expect(within(api).getByTestId('repo-graph-state').textContent).toContain('graph ready — onboard completed');
+    expect(within(api).getByTestId('repo-card-findings')).toHaveAttribute('data-count', '1');
+    expect(within(api).queryByTestId('repo-card-findings-reonboard')).toBeNull();
   });
 
   it('the gaps tile doors into the Graph missing chip, which filters to the graph-less repos', async () => {
@@ -96,5 +110,9 @@ describe('the /repos surface', () => {
     fireEvent.click(screen.getByTestId('stat-gaps'));
     expect(screen.getByTestId('repos-filter').getAttribute('data-filter')).toBe('graph-missing');
     expect(screen.getAllByTestId('repo-card').map((c) => c.getAttribute('data-repo-id')).sort()).toEqual(['orphan', 'wicked-studio']);
+    // …and the Ready chip holds the two with a live graph, the live-in-tree repo included.
+    fireEvent.click(screen.getByTestId('stat-ready'));
+    expect(screen.getByTestId('repos-filter').getAttribute('data-filter')).toBe('ready');
+    expect(screen.getAllByTestId('repo-card').map((c) => c.getAttribute('data-repo-id')).sort()).toEqual(['billing', 'studio-api']);
   });
 });

--- a/tests/RepositoriesPanel.graphMissing.test.tsx
+++ b/tests/RepositoriesPanel.graphMissing.test.tsx
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { REPO_CLEAN, REPO_INTREE_NO_LIVE, REPO_PREDATES_FINDINGS, REPO_ROOT_UNRESOLVABLE } from './fixtures/wave2.js';
+import { makeView } from './factories.js';
+
+/**
+ * F-2R2-003 — /repos KPIs and the card's status line derive graph readiness from the
+ * engine's checkout findings, not from the newest onboarding run alone. The phase2-r2
+ * rig: two in-tree repos read "graph ready — onboard completed" and the tiles said
+ * "GRAPHS READY 9 of 9 · INDEX GAPS 0" while their findings said no live graph existed.
+ */
+
+const RUNS = [
+  makeView({ id: 'o-studio', repo_ref: 'wicked-studio', workflow_id: 'onboarding', status: 'completed', problem: 'Onboard wicked-studio' }),
+  makeView({ id: 'o-billing', repo_ref: 'billing', workflow_id: 'onboarding', status: 'completed', problem: 'Onboard billing' }),
+  makeView({ id: 'o-orphan', repo_ref: 'orphan', workflow_id: 'onboarding', status: 'completed', problem: 'Onboard orphan' }),
+];
+
+const listRepos = vi.fn(() => Promise.resolve({ repos: [REPO_INTREE_NO_LIVE, REPO_CLEAN, REPO_ROOT_UNRESOLVABLE] }));
+const listRuns = vi.fn(() => Promise.resolve({ runs: RUNS }));
+const rerunOnboarding = vi.fn<(id: string) => Promise<{ runId: string }>>(() => Promise.resolve({ runId: 'r-new' }));
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    listRepos: () => listRepos(),
+    listRuns: () => listRuns(),
+    rerunOnboarding: (id: string) => rerunOnboarding(id),
+    listProjects: () => Promise.resolve({ projects: [] }),
+  },
+}));
+
+const { RepositoriesPanel } = await import('../src/components/RepositoriesPanel.js');
+const { graphReady, matchesRepoChip, repoFleetModels, repoGraphGap } = await import('../src/board/repoStats.js');
+
+async function panel(): Promise<void> {
+  render(<RepositoriesPanel navigate={() => {}} />);
+  await screen.findByTestId('repos-kpis');
+  await screen.findByTestId('repos-list');
+}
+
+beforeEach(() => { listRepos.mockClear(); listRuns.mockClear(); rerunOnboarding.mockClear(); });
+afterEach(() => cleanup());
+
+describe('the fold (repoStats)', () => {
+  it('reads the engine\'s gap off the findings and outranks a completed onboard', () => {
+    expect(repoGraphGap(REPO_CLEAN)).toBeNull();
+    expect(repoGraphGap(REPO_PREDATES_FINDINGS)).toBeNull(); // an older daemon: no field, no gap invented
+    expect(repoGraphGap(REPO_INTREE_NO_LIVE)?.kind).toBe('no-live-graph');
+    expect(repoGraphGap(REPO_ROOT_UNRESOLVABLE)?.kind).toBe('no-graph-root');
+    const fleet = repoFleetModels([REPO_INTREE_NO_LIVE, REPO_CLEAN], RUNS, {}, new Set(RUNS.map((v) => v.session.id)));
+    const studio = fleet.find((m) => m.repo.id === 'wicked-studio')!;
+    const billing = fleet.find((m) => m.repo.id === 'billing')!;
+    expect(studio.onboard.state).toBe('ready');           // the run history alone says ready…
+    expect(graphReady(studio)).toBe(false);               // …the engine says otherwise
+    expect(graphReady(billing)).toBe(true);
+    expect(matchesRepoChip(studio, 'ready')).toBe(false);
+    expect(matchesRepoChip(studio, 'graph-missing')).toBe(true);
+    expect(matchesRepoChip(billing, 'graph-missing')).toBe(false);
+  });
+});
+
+describe('the /repos surface', () => {
+  it('the KPI tiles count a graph-less repo as an INDEX GAP, not as ready — and name the kind', async () => {
+    await panel();
+    const band = screen.getByTestId('repos-kpis');
+    const value = (tid: string): string | null =>
+      band.querySelector(`[data-testid="${tid}"]`)?.getAttribute('data-value') ?? null;
+    expect(value('stat-ready')).toBe('1');   // billing only — three onboards completed
+    expect(value('stat-gaps')).toBe('2');    // wicked-studio (no live graph) + orphan (no graph root)
+    expect(screen.getByTestId('stat-gaps').textContent).toContain('2 graph missing');
+    expect(screen.getByTestId('stat-gaps').textContent).not.toContain('every graph ready');
+    expect(screen.getByTestId('stat-gaps').getAttribute('title')).toContain('checkout findings');
+  });
+
+  it('the card says "graph missing — re-run onboarding", never "graph ready", for the in-tree repo', async () => {
+    await panel();
+    const cards = screen.getAllByTestId('repo-card');
+    const studio = cards.find((c) => c.getAttribute('data-repo-id') === 'wicked-studio')!;
+    const state = within(studio).getByTestId('repo-graph-state');
+    expect(state).toHaveAttribute('data-state', 'missing');
+    expect(state.textContent).toContain('graph missing — re-run onboarding');
+    expect(state.textContent).not.toContain('graph ready');
+    expect(state.getAttribute('title')).toContain('checkout findings');
+    // The finding row with its action still rides the card (studio#253).
+    expect(within(studio).getByTestId('repo-card-findings-reonboard')).toBeInTheDocument();
+
+    const orphan = cards.find((c) => c.getAttribute('data-repo-id') === 'orphan')!;
+    expect(within(orphan).getByTestId('repo-graph-state').textContent).toContain('graph missing — no graph root resolves');
+
+    const billing = cards.find((c) => c.getAttribute('data-repo-id') === 'billing')!;
+    expect(within(billing).getByTestId('repo-graph-state')).toHaveAttribute('data-state', 'ready');
+  });
+
+  it('the gaps tile doors into the Graph missing chip, which filters to the graph-less repos', async () => {
+    await panel();
+    fireEvent.click(screen.getByTestId('stat-gaps'));
+    expect(screen.getByTestId('repos-filter').getAttribute('data-filter')).toBe('graph-missing');
+    expect(screen.getAllByTestId('repo-card').map((c) => c.getAttribute('data-repo-id')).sort()).toEqual(['orphan', 'wicked-studio']);
+  });
+});


### PR DESCRIPTION
## Wave 5 — repo readiness honesty + the project graph control (phase2-r2 re-check findings)

Branched from `main` (independent of #259 — disjoint files; either can land first).

| Finding | What the customer saw | Fix |
|---|---|---|
| **F-2R2-003** (MEDIUM) | "GRAPHS READY 9 of 9 · INDEX GAPS 0 — every graph ready" and "graph ready — onboard completed" on two repos whose card finding said *no live graph* | The graph story was the newest onboarding run alone. It is now the run history **corrected by the engine's checkout findings** (`RepoEntry.findings`, wicked-core#406 — derived on every read): `repoGraphGap()` in `board/repoStats.ts` reads `in_tree_code_graph_ignored` with the re-onboard remedy as `no-live-graph` and `code_graph_root_unresolvable` as `no-graph-root`. Such a repo reads **"graph missing — re-run onboarding"** (`repo-graph-state[data-state=missing]`, fail-red), is excluded from *Graphs ready* (`graphReady()` = onboard completed AND no gap), counted on *Index gaps* ("2 graph missing · 1 onboard failed …"), and filters under a new **Graph missing** chip (only while some repo carries it). Tile and card tooltips say what the reading derives from. |
| **F-2R2-004** (MEDIUM) | The project dashboard's REPOSITORIES rows showed no finding and no Re-run onboarding (`project-repo-findings` ×0) though the mount existed | The row's registry lookup (`repoOf(ref, repos)`) stayed `undefined` until the attach picker's focus gesture warmed the repo cache. A project **with** repo members now warms the one session cache on mount (`fetchReposCached` — still at most one `GET /repos` per session, shared with the palette/rail); a project without members fetches nothing, and a failed mount read stays silent (the picker gesture retries and reports it). Two pre-existing "no fetch on mount" assertions were updated to the new contract (exactly one call). |
| **F-2R2-008** (MEDIUM, studio half) | Scope card: "…no code graph yet. Build it with POST /api/v1/projects/<id>/graph/refresh. This repo-less run gets no code graph." over a 9-repo scope; no control anywhere called the route | New `ProjectGraphAction` calls crew's existing **`POST /api/v1/projects/:id/graph/refresh`** (verified read-only in `wicked-crew/packages/crew/src/projects/routes.ts` — synchronous, body optional, 409 for `default`, 501 engine-too-old) via `api.refreshProjectGraph`, with the standing from `GET /projects/:id/graph` (`api.getProjectGraph`). Honest state: "Building… indexing 9 repositories — this can take a few minutes" while the daemon indexes; the result is the daemon's indexed / skipped / failed labels (`project-graph-result`, failures per repo); a refusal renders the daemon's sentence. On the **project dashboard** (standing + control when the project has repo members; hidden on a daemon without the route) and on the **chat scope card** for a project scope whose reason names an unbuilt graph — the result there says it grounds **new** chats (the open chat's scope was decided at `POST /chats`). Copy: `humanizeGraphReason` drops the raw `POST …` sentence and says "repo-less" only when the scope names no repository; the daemon's own words stay, raw sentence on hover. |
| **F-2R2-009** (LOW) | Health rail: green ✓ with "active · signed out" for all four unsigned seats — while councils benched them and a chat still seated opencode on a free tier | The row now says the one consequence that is known: amber **`!`** + **"signed out — councils bench this seat"** (`rail-seat-row[data-signed-in=false]`), degrades the heart, and puts the free-tier possibility on hover *as a possibility*. |

### Wire gap recorded (F-2R2-009)
The roster carries nothing that distinguishes "signed out — a council benches it" from "no sign-in needed — a provider free tier answers": crew's `GET /roster` adds `health` + `signed_in` (the file/env heuristic, `seat-signin.ts`) over the engine's `AgenticCli` (`key, display_name, binary, headless_invocation, category, input_mode, version_probe, trust_flags, alt_binaries, confidence, enabled_for_council, acp, capabilities, login_invocation` — read-only in `wicked-core/crates/wicked-council/src/types.rs`). A per-seat `auth_required` / `free_tier` (or a council-admission preview) on the roster would let the rail say "no sign-in — free tier available" honestly; until then the rail says only what it knows.

### Tests
`tests/RepositoriesPanel.graphMissing.test.tsx` (the fold + KPIs + card + chip), `tests/ProjectRepositories.findings.test.tsx` (mount warm, finding row + Re-run onboarding, no-members budget, failed read), `tests/ProjectGraphAction.test.tsx` (copy, standing, build pending → built / failures / refusal, route-absent, inline variant), `tests/GroupChat.graphBuild.test.tsx` (the nine-repo scope verbatim: copy, hover, Build, result note; dangling/repos scopes), `tests/HealthRailSection.signin.test.tsx`, `tests/ProjectDashboard.graph.test.tsx`. `testid-inventory.json` regenerated.

Gates, each on its own: `npm run lint` ✓ · `npm run typecheck` ✓ · `npm test` ✓ · `npm run build` ✓.

No version bump; CHANGELOG bullets under Unreleased. Does not touch the Skills surface (#257 stays disjoint).

### Independent review (verdict: REVISE — all findings addressed in the bundled follow-up commit)
- **F1 (MEDIUM) "councils bench this seat" asserts an engine rule no wire field carries** — the row now states the observation and hedges the consequence: **"signed out — councils may bench this seat"** (`SIGNED_OUT_DETAIL`), hover "the daemon's file/env check saw no sign-in … a provider free tier may still answer; the roster cannot tell yet". New `seatStandingWord()` reads crew#533's `auth` / `free_tier` / `council_eligible` / `council_ineligible_reason` (api-types 0.35.0) off the seat when a daemon sends them — `not_required` → "no sign-in needed (<tier>)" with a ✓; `council_eligible: false` → "not council-eligible — <the daemon's reason>"; `signed_out` + `council_eligible: true` → "signed out — still council-eligible" — and falls back to the hedged words otherwise. `data-standing` / `data-auth` on the row. The same words ride #261's picker.
- **F2 (LOW) heart amber whenever any seat lacks a sign-in** — the heuristic is no longer folded into the heart (row-level `!` only); only a daemon-declared `council_eligible: false` degrades it. Test updated: signed-out seats alone → `healthy`.
- **F3 (LOW) wasted `GET /projects/default/graph`** — the effect returns before the read for `default` (and when `fetchStatus` is off); pinned: no call for the Unfiled project.
- **F4 (LOW) contract (f) second half not pinned** — `RepositoriesPanel.graphMissing.test.tsx` now carries `REPO_INTREE_LIVE` with a completed onboard: `repo-graph-state[data-state=ready]`, "graph ready — onboard completed", the warning chip present, no re-onboard action, Graphs ready 2 / Index gaps 2 unchanged, the Ready chip holds it.
- **F5 (NIT)** — the duplicated `engine-too-old` branch folded into `default`; comments name the crew sentences the prose keys mirror (`projects/graph.ts`, the seams' "This repo-less run gets no code graph.") and that both fail closed; a per-repo index error renders as its first line capped at 160 chars with the whole text on hover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
