### PR TITLE
feat(gates): Reassign to <seat> + retry on a failure-escalation gate, verdict block keyed on the gate's unit, honest gate narration (F-7R2-007/-018/-017)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,35 @@ npm publish dates. Every version listed here exists on
 
 ## [Unreleased]
 ### Added
+- **Reassign to <seat> + retry on a failure-escalation gate** (phase7-r2 acceptance finding
+  F-7R2-007, HIGH). At every "Unit N failed and triage escalated" gate the card offered Approve — a
+  retry on the SAME dead seat — Approve + steer, Reject and Cancel; recovery was
+  `POST /api/v1/runs/:id/reassign {cli}` by hand, five times, racing the re-dispatch window. Both
+  gate cards (the run page's `SteeringGate`, the landing inbox's card) now carry `ReassignControl`:
+  the run's OTHER seats (`session.clis` minus the seat that failed the unit) with the roster's word
+  on each — signed-in first, signed-out labelled "will be benched", inactive last — and one
+  action that approves the retry (the steer text rides it), waits for the run to resume
+  (`GET /runs/:id` until `executing`, bounded — the daemon reassigns only an executing run), then
+  calls the existing `POST /runs/:id/reassign {cli}` (`api.reassignRun`). Every step is stated
+  (`steering-reassign-status`); a refused reassign leaves the approve standing, shows the daemon's
+  sentence and offers the reassign alone again. Plain Approve is relabelled "Approve (retry on
+  <seat>)" on that gate. Recorded on the steering timeline as `reassign`. (Wire gap, recorded: the
+  reassign route refuses an `awaiting_human` run, so the approve must precede it.)
+
+### Fixed
+- **The gate card's verdict block is about THIS gate's unit** (F-7R2-018): on an escalation gate
+  about unit N the block rendered the LAST `gateEvaluated` at or below N — unit N−1's vacuous pass
+  under a card about the unit that failed. `gateVerdictFor` keys an escalation gate ("Unit N failed
+  and triage escalated" / "Unit N verdict is NOT PASS") on unit N's own evaluation and renders no
+  block when there is none; a pre-run gate keeps the previous phase's verdict (F-3R2-006).
+- **Narration never says "Checks ran" without a floor** (F-7R2-017): a `gateEvaluated` with
+  `hasDeterministicFloor: false` reads "Gate passed without checks on <phase> (ungated)" (no judge,
+  no policy), "Judge passed <phase> — no repository checks ran", or "Evaluator policy passed …";
+  a denial without a floor reads "Gate denied on <phase>: … — no repository checks ran". A frame
+  without the field (an older engine) keeps the legacy wording.
+- Tests: `gateVerdictModel.escalation`, `SteeringGate.reassign`, `CenterDashboard.reassign`;
+  `narrator.test` gains the floor/no-floor cases.
+
 - **The wicked-core#431 wire on the gate, the delivery card, the run head and the feed** (#250/#431
   consumer follow-through — pins `wicked-crew-api-types` 0.33.0, the wire wicked-crew#527 publishes).
   Every field is read off the frames the daemon sends and rendered only when present, so an older

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,29 +18,19 @@ npm publish dates. Every version listed here exists on
   `POST /api/v1/runs/:id/reassign {cli}` by hand, five times, racing the re-dispatch window. Both
   gate cards (the run page's `SteeringGate`, the landing inbox's card) now carry `ReassignControl`:
   the run's OTHER seats (`session.clis` minus the seat that failed the unit) with the roster's word
-  on each — signed-in first, signed-out labelled "will be benched", inactive last — and one
-  action that approves the retry (the steer text rides it), waits for the run to resume
-  (`GET /runs/:id` until `executing`, bounded — the daemon reassigns only an executing run), then
-  calls the existing `POST /runs/:id/reassign {cli}` (`api.reassignRun`). Every step is stated
+  on each — signed-in first, a seat with no sign-in observed hedged as "may fail or be benched"
+  (today's roster carries no council-eligibility field; crew#533's `auth` / `council_eligible` /
+  `council_ineligible_reason` / `free_tier` are read when a daemon sends them — `seatStanding`),
+  inactive last, daemon-declared ineligible after that — and one action that approves the retry
+  (the steer text rides it), waits for the run to resume (`GET /runs/:id` until `executing`, 30 s
+  bounded — the daemon reassigns only an executing run), then calls the existing
+  `POST /runs/:id/reassign {cli}` (`api.reassignRun`). Every step is stated
   (`steering-reassign-status`); a refused reassign leaves the approve standing, shows the daemon's
   sentence and offers the reassign alone again. Plain Approve is relabelled "Approve (retry on
-  <seat>)" on that gate. Recorded on the steering timeline as `reassign`. (Wire gap, recorded: the
-  reassign route refuses an `awaiting_human` run, so the approve must precede it.)
-
-### Fixed
-- **The gate card's verdict block is about THIS gate's unit** (F-7R2-018): on an escalation gate
-  about unit N the block rendered the LAST `gateEvaluated` at or below N — unit N−1's vacuous pass
-  under a card about the unit that failed. `gateVerdictFor` keys an escalation gate ("Unit N failed
-  and triage escalated" / "Unit N verdict is NOT PASS") on unit N's own evaluation and renders no
-  block when there is none; a pre-run gate keeps the previous phase's verdict (F-3R2-006).
-- **Narration never says "Checks ran" without a floor** (F-7R2-017): a `gateEvaluated` with
-  `hasDeterministicFloor: false` reads "Gate passed without checks on <phase> (ungated)" (no judge,
-  no policy), "Judge passed <phase> — no repository checks ran", or "Evaluator policy passed …";
-  a denial without a floor reads "Gate denied on <phase>: … — no repository checks ran". A frame
-  without the field (an older engine) keeps the legacy wording.
-- Tests: `gateVerdictModel.escalation`, `SteeringGate.reassign`, `CenterDashboard.reassign`;
-  `narrator.test` gains the floor/no-floor cases.
-
+  <seat>)" on that gate. A host without the run view (the steering-author and testing-launch panels)
+  reads the run once for its pool on a failure escalation only. Recorded on the steering timeline as
+  `reassign`. (Wire gap, recorded: the reassign route refuses an `awaiting_human` run, so the approve
+  must precede it.)
 - **The wicked-core#431 wire on the gate, the delivery card, the run head and the feed** (#250/#431
   consumer follow-through — pins `wicked-crew-api-types` 0.33.0, the wire wicked-crew#527 publishes).
   Every field is read off the frames the daemon sends and rendered only when present, so an older
@@ -114,6 +104,22 @@ npm publish dates. Every version listed here exists on
   (hover = the reason's one clause), and a `portability` verdict that disagrees with `portable` is
   named — `data-contradiction` on the row and badge, a hint line in the drawer — never swallowed and
   never a different badge (`portable` stays the admission key).
+
+### Fixed
+- **The gate card's verdict block is about THIS gate's unit** (F-7R2-018): on an escalation gate
+  about unit N the block rendered the LAST `gateEvaluated` at or below N — unit N−1's vacuous pass
+  under a card about the unit that failed. `gateVerdictFor` keys an escalation gate ("Unit N failed
+  and triage escalated" / "Unit N verdict is NOT PASS") on unit N's own evaluation AND its latest
+  attempt (the last `unitDispatched` for N — an earlier attempt's denial is not this gate's) and
+  renders no block when there is none; a pre-run gate keeps the previous phase's verdict
+  (F-3R2-006). The block carries `data-phase-attempt`.
+- **Narration never says "Checks ran" without a floor** (F-7R2-017): a `gateEvaluated` with
+  `hasDeterministicFloor: false` reads "Gate passed without checks on <phase> (ungated)" (no judge,
+  no policy), "Judge passed <phase> — no repository checks ran", or "Evaluator policy passed …";
+  a denial without a floor reads "Gate denied on <phase>: … — no repository checks ran". A frame
+  without the field (an older engine) keeps the legacy wording.
+- Tests: `gateVerdictModel.escalation`, `SteeringGate.reassign`, `CenterDashboard.reassign`;
+  `narrator.test` gains the floor/no-floor cases.
 
 ## [0.5.5] — 2026-09-11
 ### Added
@@ -608,7 +614,6 @@ npm publish dates. Every version listed here exists on
   `/policies` redirects to `/steering`), and the context-free **Domain** and **Coverage**
   Settings panels (`/domain` and `/coverage` redirect to `/system`; per-run coverage evidence
   keeps its home in the run view; the project-scoped successor is tracked in #157/#158) (#156).
-
 
 ## [0.4.2] — 2026-08-30
 

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -633,4 +633,17 @@ export const api = {
     const qs = cursor ? `?cursor=${encodeURIComponent(cursor)}` : '';
     return apiFetch<ActivityPage>(`/projects/${encodeURIComponent(id)}/activity${qs}`);
   },
+
+  /**
+   * `POST /runs/:id/reassign` — the manual seat lever (crew#442; acceptance finding F-7R2-007):
+   * recycle the run's CURSOR unit onto `cli` through the engine's `reassignUnit` (the same path the
+   * stall watchdog's automatic escalation takes); `cli` omitted lets the council re-pick. The
+   * daemon accepts it only while the run is `executing` (409 otherwise — an awaiting-human run
+   * must be approved first), and `cli` must be in the run's own pool (`session.clis`; 400).
+   */
+  reassignRun: (id: string, cli?: string) =>
+    apiFetch<{ status: string; ord: number; cli?: string }>(`/runs/${encodeURIComponent(id)}/reassign`, {
+      method: 'POST',
+      body: JSON.stringify(cli === undefined ? {} : { cli }),
+    }),
 };

--- a/src/components/ApprovalDock.tsx
+++ b/src/components/ApprovalDock.tsx
@@ -77,7 +77,7 @@ export function ApprovalDock({
           guidance={guidance}
           {...(ord !== undefined ? { ord } : {})}
           {...(gate ? { prompt: gate.prompt } : {})}
-          {...(view !== undefined ? { units: view.units } : {})}
+          {...(view !== undefined ? { units: view.units, clis: view.session.clis } : {})}
           onResolved={onResolved}
         />
       )}

--- a/src/components/CenterDashboard.tsx
+++ b/src/components/CenterDashboard.tsx
@@ -20,8 +20,10 @@ import { usageTotals, WINDOW_LABEL_STYLE } from '../board/metrics.js';
 import { useGateStore } from '../store/gates.js';
 import { useMembershipStore } from '../store/membership.js';
 import { useRunEventStore } from '../store/events.js';
+import { deliverLift } from './deliverLiftModel.js';
 import { GateVerdict } from './GateVerdict.js';
-import { gateVerdict, isRestoredRetry, phaseLabel } from './gateVerdictModel.js';
+import { gateVerdictFor, isFailureEscalation, isRestoredRetry, phaseLabel } from './gateVerdictModel.js';
+import { ReassignControl } from './ReassignControl.js';
 import { useSteeringStore } from '../store/steering.js';
 import { launchPath, sessionProjectId } from '../hooks/ambientProject.js';
 import { chroniclePath, modePath } from '../hooks/useRoute.js';
@@ -275,6 +277,7 @@ const FEED_META: Record<string, FeedMeta> = {
 
 const NO_EVENTS: CoreEvent[] = [];
 const NO_UNITS: WorkUnit[] = [];
+const NO_CLIS: string[] = [];
 
 /** One open gate as an INSTANCE: the same run can open several while the dashboard stays mounted
  *  (a retry of the same ord included), and each must fetch and prove its own history. */
@@ -302,6 +305,8 @@ interface GateCardProps {
   events: readonly CoreEvent[];
   /** The run's units (snapshot) — names the verdict's phase. */
   units: readonly WorkUnit[];
+  /** The run's seat pool (`session.clis`) — the reassign offer on a failure escalation (F-7R2-007). */
+  clis: readonly string[];
   /** True once THIS gate instance's durable history has been fetched and merged (see the
    *  dashboard's backfill). Until then the block is withheld: the store may hold only an earlier
    *  attempt's evaluation plus this gate's `awaitingHuman`, and a same-ord retry would otherwise
@@ -318,6 +323,7 @@ function GateActionCard({
   sessionLbl,
   events,
   units,
+  clis,
   ready,
   onApprove,
   onReject,
@@ -325,14 +331,21 @@ function GateActionCard({
   const [amend, setAmend] = useState('');
   const [loading, setLoading] = useState(false);
   const [steerOpen, setSteerOpen] = useState(false);
+  const clearGate = useGateStore((s) => s.clearGate);
   // The same verdict block the run page's gate card renders (F-3R2-006): a gate answered from
   // this inbox must show what it is approving too. Bounded on the gate's ord — with none known,
   // no block, never an unbounded historical evaluation dressed as this gate's — and only once
-  // this gate instance's history is KNOWN (`ready`): never the previous slice's verdict.
+  // this gate instance's history is KNOWN (`ready`): never the previous slice's verdict. And on
+  // an ESCALATION gate about unit N, only unit N's own evaluation (F-7R2-018).
   const verdict = useMemo(
-    () => (ready && typeof ord === 'number' ? gateVerdict(events, ord) : null),
-    [events, ord, ready],
+    () => (ready ? gateVerdictFor(events, ord, prompt) : null),
+    [events, ord, prompt, ready],
   );
+  // F-7R2-007: the same seat lever the run page's card offers, from the same predicates — and,
+  // like there, not on a deliver-lift escalation (another seat cannot fix a rebase conflict).
+  const escalation = isFailureEscalation(prompt, verdict)
+    && (typeof ord !== 'number' || deliverLift(events, ord) === null);
+  const failedCli = typeof ord === 'number' ? units.find((u) => u.ord === ord)?.assigned_cli ?? null : null;
   // wicked-core#431 (F-3R2-010 / F-255-01): the SAME relabel the run page's gate card applies, from
   // the same predicate — an open gate must not read "Retry against the restored tree" there and
   // "Approve" here. Approve on the restored-tree denial retries the phase against the creator's
@@ -440,6 +453,19 @@ function GateActionCard({
         <GateVerdict view={verdict} phase={phaseLabel(runId, units, verdict.ord)} />
       )}
 
+      {/* F-7R2-007: the seat lever on a failure escalation — see SteeringGate. */}
+      {escalation && (
+        <ReassignControl
+          runId={runId}
+          ord={ord}
+          pool={clis}
+          failedCli={failedCli}
+          amend={amend}
+          compact
+          onDone={() => clearGate(runId)}
+        />
+      )}
+
       {/* Steer textarea — visible only when "Approve + steer" is toggled */}
       {steerOpen && (
         <textarea
@@ -474,7 +500,11 @@ function GateActionCard({
           type="button"
           disabled={loading}
           onClick={() => void run(() => onApprove(runId))}
-          {...(restoredRetry ? { title: "the evaluator's edit was discarded; the phase re-runs against the creator's verified tree" } : {})}
+          {...(restoredRetry
+            ? { title: "the evaluator's edit was discarded; the phase re-runs against the creator's verified tree" }
+            : escalation && failedCli !== null
+              ? { title: `retries the unit on ${failedCli} — the seat that just failed; use Reassign to move it` }
+              : {})}
           style={{
             background: 'var(--status-run-dim)',
             color: 'var(--status-run)',
@@ -488,7 +518,7 @@ function GateActionCard({
             opacity: loading ? 0.5 : 1,
           }}
         >
-          {restoredRetry ? 'Retry against the restored tree' : 'Approve'}
+          {restoredRetry ? 'Retry against the restored tree' : escalation && failedCli !== null ? `Approve (retry on ${failedCli})` : 'Approve'}
         </button>
         <button
           type="button"
@@ -1174,6 +1204,7 @@ export function CenterDashboard({
                     sessionLbl={lbl}
                     events={byRun[gate.runId] ?? NO_EVENTS}
                     units={v?.units ?? NO_UNITS}
+                    clis={v?.session.clis ?? NO_CLIS}
                     ready={gateReady.has(gateInstanceKey(gate))}
                     onApprove={handleApprove}
                     onReject={handleReject}

--- a/src/components/GateVerdict.tsx
+++ b/src/components/GateVerdict.tsx
@@ -50,6 +50,7 @@ export function GateVerdict({ view, phase }: { view: GateVerdictView; phase: str
       data-testid="gate-verdict"
       data-verdict={outcome}
       {...(view.ord !== null ? { 'data-phase-ord': view.ord } : {})}
+      {...(view.attempt !== null ? { 'data-phase-attempt': view.attempt } : {})}
       {...(view.denial !== null && view.denial.source !== null ? { 'data-denial-source': view.denial.source } : {})}
       className="rounded-lg p-2.5 mb-3 flex flex-col gap-1 font-mono"
       style={{ background: toneDim, border: `1px solid ${toneDim}` }}

--- a/src/components/ReassignControl.tsx
+++ b/src/components/ReassignControl.tsx
@@ -23,7 +23,10 @@ import { reassignCandidates } from './gateVerdictModel.js';
  * Every step is stated on the card as it happens; a reassign that the daemon refuses leaves the
  * approve standing (it already happened — said so), shows the daemon's sentence and offers the
  * reassign alone again. The seat list is the run's OWN pool minus the failed seat, each with the
- * roster's word (signed in first; signed-out seats say "will be benched" — the council rule).
+ * roster's word (signed in first; a seat with no sign-in observed says "may fail or be benched" —
+ * hedged, because today's roster carries no council-eligibility field and the phase2-r2 rig saw a
+ * "signed out" seat answer on a free tier; crew#533's `council_eligible` / `auth` are read when a
+ * daemon sends them — `seatStanding`).
  *
  * Wire gap, recorded: the reassign route only targets an `executing` run, so the approve must
  * precede it and the window between the two is the engine's re-dispatch — crew letting
@@ -47,8 +50,10 @@ export interface ReassignControlProps {
 
 type Phase = 'idle' | 'approving' | 'waiting' | 'reassigning' | 'done' | 'failed';
 
-/** How many status reads the resume wait makes before giving up (× the poll interval). */
-export const RESUME_POLLS = 24;
+/** How many status reads the resume wait makes before giving up (× the poll interval): 60 × 500 ms =
+ *  30 s — a council spike can hold the approve→executing hop past 10 s, and a give-up costs the
+ *  operator the "reassign again" click. */
+export const RESUME_POLLS = 60;
 
 /** The resume wait's poll interval — one knob, so tests do not wait real seconds. */
 export const reassignPolling = { intervalMs: 500 };
@@ -187,9 +192,11 @@ export function ReassignControl({
           {busy ? 'Reassigning…' : `Reassign to ${chosen?.label ?? seat} + retry`}
         </button>
       </div>
-      {chosen !== undefined && chosen.state === 'signed-out' && phase === 'idle' && (
-        <p data-testid="steering-reassign-benched" style={{ ...mono, color: 'var(--status-gate)', margin: 0 }}>
-          {chosen.label} is signed out — a council benches it; the retry may fall back or fail there.
+      {chosen !== undefined && (chosen.state === 'signed-out' || chosen.state === 'ineligible') && phase === 'idle' && (
+        <p data-testid="steering-reassign-benched" data-state={chosen.state} style={{ ...mono, color: 'var(--status-gate)', margin: 0 }}>
+          {chosen.state === 'ineligible'
+            ? `${chosen.label}: the daemon says a council would not seat it (${chosen.note}) — the retry may be refused there.`
+            : `${chosen.label}: no sign-in observed — the retry may fail at spawn or be benched there; a provider free tier may still answer (the roster cannot tell yet).`}
         </p>
       )}
       {statusWord[phase] !== null && (

--- a/src/components/ReassignControl.tsx
+++ b/src/components/ReassignControl.tsx
@@ -1,0 +1,218 @@
+import { useEffect, useMemo, useState } from 'react';
+import { api } from '../api/client.js';
+import type { RosterSeat } from '../api/types.js';
+import { getCachedRoster, setCachedRoster, subscribeRoster } from '../store/rosterCache.js';
+import { useSteeringStore } from '../store/steering.js';
+import { reassignCandidates } from './gateVerdictModel.js';
+
+/**
+ * "Reassign to <seat> + retry" on a FAILURE-ESCALATION gate (acceptance finding F-7R2-007).
+ *
+ * At every "Unit N failed and triage escalated" gate the card offered Approve (a retry on the
+ * SAME dead seat — it looped), Approve + steer, Reject and Cancel; the operator recovered five
+ * times by hand with `POST /api/v1/runs/:id/reassign {cli}` (crew#442), racing the ~20 s window
+ * in which the re-dispatched dead seat fails again. This is that lever, on the card, in the
+ * order the daemon requires:
+ *
+ *   1. approve the retry (`POST /runs/:id/gate {approve:true[, amend]}`) — the reassign route
+ *      refuses a run that is not `executing` (409), and an awaiting-human run is not;
+ *   2. wait for the run to resume (`GET /runs/:id` until `status === 'executing'`, bounded);
+ *   3. reassign the cursor unit (`POST /runs/:id/reassign {cli}`) — the engine's `reassignUnit`,
+ *      the same path the stall watchdog's automatic escalation takes.
+ *
+ * Every step is stated on the card as it happens; a reassign that the daemon refuses leaves the
+ * approve standing (it already happened — said so), shows the daemon's sentence and offers the
+ * reassign alone again. The seat list is the run's OWN pool minus the failed seat, each with the
+ * roster's word (signed in first; signed-out seats say "will be benched" — the council rule).
+ *
+ * Wire gap, recorded: the reassign route only targets an `executing` run, so the approve must
+ * precede it and the window between the two is the engine's re-dispatch — crew letting
+ * `POST /runs/:id/reassign` target an `awaiting_human` run would make this one call.
+ */
+
+export interface ReassignControlProps {
+  runId: string;
+  ord: number | undefined;
+  /** The run's seat pool (`SessionView.session.clis`). */
+  pool: readonly string[];
+  /** The seat that failed this unit (`units[ord].assigned_cli`) — excluded from the offer. */
+  failedCli: string | null;
+  /** The steer text to ride the approve, when the operator typed one. */
+  amend?: string;
+  /** The whole sequence succeeded: the gate is answered and the unit moved. The host clears the gate. */
+  onDone: (cli: string) => void;
+  /** Compact dress for the inbox card. */
+  compact?: boolean;
+}
+
+type Phase = 'idle' | 'approving' | 'waiting' | 'reassigning' | 'done' | 'failed';
+
+/** How many status reads the resume wait makes before giving up (× the poll interval). */
+export const RESUME_POLLS = 24;
+
+/** The resume wait's poll interval — one knob, so tests do not wait real seconds. */
+export const reassignPolling = { intervalMs: 500 };
+
+const TERMINAL = new Set(['completed', 'failed', 'cancelled']);
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+export function ReassignControl({
+  runId, ord, pool, failedCli, amend, onDone, compact = false,
+}: ReassignControlProps): React.ReactElement | null {
+  const recordSteering = useSteeringStore((s) => s.record);
+  const [roster, setRoster] = useState<RosterSeat[] | null>(getCachedRoster);
+  // The roster's word on each seat: the shared cache when warm (the rail / the composer read it),
+  // one read here when cold — the labels are what make the pick honest, so they are worth it.
+  useEffect(() => {
+    const unsubscribe = subscribeRoster(setRoster);
+    if (getCachedRoster() !== null) return unsubscribe;
+    let cancelled = false;
+    Promise.resolve()
+      .then(() => api.getRoster())
+      .then(({ roster: seats }) => { if (!cancelled) { setCachedRoster(seats); setRoster(seats); } })
+      .catch(() => { /* cold roster: the seats are offered by key, unlabelled — never invented */ });
+    return () => { cancelled = true; unsubscribe(); };
+  }, []);
+
+  const candidates = useMemo(() => reassignCandidates(pool, failedCli, roster), [pool, failedCli, roster]);
+  const [seat, setSeat] = useState<string>('');
+  const chosen = candidates.find((c) => c.cli === seat) ?? candidates[0];
+  const [phase, setPhase] = useState<Phase>('idle');
+  const [approved, setApproved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const busy = phase === 'approving' || phase === 'waiting' || phase === 'reassigning';
+
+  if (candidates.length === 0) {
+    return (
+      <p data-testid="steering-reassign-none" className="text-[10px] font-mono mb-3" style={{ color: 'var(--ink-dim)', margin: '0 0 12px' }}>
+        {pool.length === 0
+          ? 'reassign: this run\'s seat pool is not on the wire, so no other seat can be offered'
+          : `reassign: no other seat in this run's pool${failedCli !== null ? ` (only ${failedCli}, which failed)` : ''}`}
+      </p>
+    );
+  }
+
+  async function reassignOnly(cli: string): Promise<void> {
+    setPhase('reassigning');
+    setError(null);
+    try {
+      await api.reassignRun(runId, cli);
+      recordSteering({ runId, action: 'reassign', cli, ...(typeof ord === 'number' ? { ord } : {}) });
+      setPhase('done');
+      onDone(cli);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+      setPhase('failed');
+    }
+  }
+
+  async function go(): Promise<void> {
+    if (busy || chosen === undefined) return;
+    const cli = chosen.cli;
+    setError(null);
+    try {
+      if (!approved) {
+        setPhase('approving');
+        const text = amend?.trim() ?? '';
+        await api.confirmGate(runId, { approve: true, ...(text !== '' ? { amend: text } : {}) });
+        setApproved(true);
+      }
+      // The daemon reassigns only an EXECUTING run: wait for the approve to take.
+      setPhase('waiting');
+      let executing = false;
+      for (let i = 0; i < RESUME_POLLS; i += 1) {
+        const { run } = await api.getRun(runId);
+        const status = run.session.status;
+        if (status === 'executing') { executing = true; break; }
+        if (TERMINAL.has(status)) throw new Error(`the run is ${status} — nothing left to reassign`);
+        await sleep(reassignPolling.intervalMs);
+      }
+      if (!executing) throw new Error('the run did not resume in time — reassign again once it is executing');
+      await reassignOnly(cli);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+      setPhase('failed');
+    }
+  }
+
+  const statusWord: Record<Phase, string | null> = {
+    idle: null,
+    approving: 'approving the retry…',
+    waiting: 'approved — waiting for the run to resume…',
+    reassigning: `reassigning to ${chosen?.label ?? seat}…`,
+    done: `reassigned to ${chosen?.label ?? seat} — the retry runs there`,
+    failed: approved ? 'the retry was approved; the reassign did not land' : 'nothing changed',
+  };
+  const mono: React.CSSProperties = { fontFamily: 'var(--font-mono)', fontSize: compact ? 'var(--text-2xs)' : 'var(--text-xs)' };
+
+  return (
+    <div
+      data-testid="steering-reassign-row"
+      data-phase={phase}
+      data-approved={approved}
+      className="mb-3 flex flex-col gap-1.5"
+      style={{ padding: compact ? '6px 8px' : '8px 10px', borderRadius: 'var(--radius-md)',
+               background: 'var(--surface-raised)', border: '1px solid var(--status-gate-dim)' }}
+    >
+      <div className="flex items-center gap-2 flex-wrap">
+        <span style={{ ...mono, color: 'var(--ink-muted)' }}>
+          {failedCli !== null ? `${failedCli} failed this unit — ` : ''}retry on another seat:
+        </span>
+        <select
+          data-testid="steering-reassign-seat"
+          value={chosen?.cli ?? ''}
+          disabled={busy || phase === 'done'}
+          onChange={(e) => setSeat(e.target.value)}
+          aria-label="Seat to reassign the unit to"
+          style={{ ...mono, background: 'var(--surface-base)', color: 'var(--ink-high)',
+                   border: '1px solid var(--surface-overlay)', borderRadius: 'var(--radius-sm)', padding: '2px 6px' }}
+        >
+          {candidates.map((c) => (
+            <option key={c.cli} value={c.cli} data-state={c.state} data-testid="steering-reassign-option">
+              {c.label}{c.note !== '' ? ` — ${c.note}` : ''}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          data-testid="steering-reassign"
+          data-seat={chosen?.cli}
+          disabled={busy || phase === 'done'}
+          onClick={() => void go()}
+          title="Approve the retry, then move this unit to the chosen seat (POST /runs/:id/reassign) once the run resumes"
+          className="rounded-lg px-3 py-1.5 font-semibold disabled:opacity-50 transition-opacity"
+          style={{ ...mono, background: 'var(--status-gate)', color: 'var(--surface-base)', border: 'none', cursor: busy ? 'default' : 'pointer' }}
+        >
+          {busy ? 'Reassigning…' : `Reassign to ${chosen?.label ?? seat} + retry`}
+        </button>
+      </div>
+      {chosen !== undefined && chosen.state === 'signed-out' && phase === 'idle' && (
+        <p data-testid="steering-reassign-benched" style={{ ...mono, color: 'var(--status-gate)', margin: 0 }}>
+          {chosen.label} is signed out — a council benches it; the retry may fall back or fail there.
+        </p>
+      )}
+      {statusWord[phase] !== null && (
+        <p data-testid="steering-reassign-status" style={{ ...mono, color: phase === 'failed' ? 'var(--status-fail)' : phase === 'done' ? 'var(--status-run)' : 'var(--ink-muted)', margin: 0 }}>
+          {statusWord[phase]}
+        </p>
+      )}
+      {error !== null && (
+        <div className="flex items-center gap-2 flex-wrap">
+          <span data-testid="steering-reassign-error" style={{ ...mono, color: 'var(--status-fail)' }}>{error}</span>
+          {approved && chosen !== undefined && (
+            <button
+              type="button"
+              data-testid="steering-reassign-retry"
+              onClick={() => void reassignOnly(chosen.cli)}
+              className="underline"
+              style={{ ...mono, background: 'transparent', border: 'none', color: 'var(--status-fail)', cursor: 'pointer', padding: 0 }}
+            >
+              reassign again
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/SteeringGate.tsx
+++ b/src/components/SteeringGate.tsx
@@ -75,6 +75,21 @@ export function SteeringGate({ runId, ord, prompt, guidance, repoRef, units, cli
   // a rebase conflict), which is why the control is also gated on `lift === null` at the render.
   const escalation = isFailureEscalation(prompt, verdict);
   const failedCli = typeof ord === 'number' ? (units ?? EMPTY_UNITS).find((u) => u.ord === ord)?.assigned_cli ?? null : null;
+  // A host without the run view (the steering-author and testing-launch panels hold only the run
+  // id + the gate) reads the run ONCE for its seat pool when — and only when — the gate is a failure
+  // escalation the lever applies to. Zero reads on every other gate; a failed read offers no lever.
+  const [fetchedClis, setFetchedClis] = useState<readonly string[] | null>(null);
+  const wantsPool = escalation && clis === undefined;
+  useEffect(() => {
+    if (!wantsPool) return;
+    let cancelled = false;
+    Promise.resolve()
+      .then(() => api.getRun(runId))
+      .then(({ run }) => { if (!cancelled) setFetchedClis(Array.isArray(run.session.clis) ? run.session.clis : []); })
+      .catch(() => { /* no pool known — the card keeps Approve / Reject / Cancel, nothing invented */ });
+    return () => { cancelled = true; };
+  }, [wantsPool, runId]);
+  const pool = clis ?? fetchedClis;
   // The deliver lift's story for THIS ord (wicked-core#431 / F-3R2-013): a gate opened on a deliver
   // unit the engine refused (LIFT-CONFLICT, a failed re-verify, a HEAD off the run branch) renders
   // what the lift did and the engine's remedy on the card. A pre-run deliver gate has no deliver-ord
@@ -370,18 +385,17 @@ export function SteeringGate({ runId, ord, prompt, guidance, repoRef, units, cli
       {/* F-7R2-007: on a failure escalation, the seat lever — approve the retry, then move the
           unit to a seat that is not the one that just failed (crew's reassign route). The steer
           text rides the approve here too. */}
-      {escalation && clis !== undefined && lift === null && (
+      {escalation && pool !== null && lift === null && (
         <ReassignControl
           runId={runId}
           ord={ord}
-          pool={clis}
+          pool={pool}
           failedCli={failedCli}
           amend={amend}
-          onDone={(cli) => {
+          onDone={() => {
             useAnnotationStore.getState().clearDraft(runId);
             clearGate(runId);
             onResolved?.();
-            void cli;
           }}
         />
       )}

--- a/src/components/SteeringGate.tsx
+++ b/src/components/SteeringGate.tsx
@@ -12,7 +12,8 @@ import { DeliverLift } from './DeliverLift.js';
 import { deliverLift, textCarriesFailure } from './deliverLiftModel.js';
 import { GATE_HASH } from './GateChip.js';
 import { GateVerdict } from './GateVerdict.js';
-import { gateVerdict, isRestoredRetry, phaseLabel } from './gateVerdictModel.js';
+import { gateVerdictFor, isFailureEscalation, isRestoredRetry, phaseLabel } from './gateVerdictModel.js';
+import { ReassignControl } from './ReassignControl.js';
 
 interface Props {
   runId: string;
@@ -26,6 +27,9 @@ interface Props {
   /** The run's units (snapshot) — names the phase the evaluator verdict on the card is about
    *  (wicked-studio#250, F-3R2-006). Absent ⇒ the verdict says `unit N`. */
   units?: readonly WorkUnit[];
+  /** The run's seat pool (`session.clis`) — the seats a failure-escalation gate may reassign the
+   *  unit to (F-7R2-007). Absent ⇒ the card offers no reassign. */
+  clis?: readonly string[];
   onResolved?: () => void;
 }
 
@@ -49,7 +53,7 @@ function coverageLabel(r: CoverageReport): string {
   return `Coverage: ${pct} · ${r.behavior_bearing.toLocaleString()} nodes · ${r.unaccounted} unaccounted${resolvedPct}`;
 }
 
-export function SteeringGate({ runId, ord, prompt, guidance, repoRef, units, onResolved }: Props): React.ReactElement {
+export function SteeringGate({ runId, ord, prompt, guidance, repoRef, units, clis, onResolved }: Props): React.ReactElement {
   const clearGate = useGateStore((s) => s.clearGate);
   const recordSteering = useSteeringStore((s) => s.record);
   // The evaluator's record for THIS gate (wicked-studio#250, F-3R2-006): a pure view over the
@@ -62,7 +66,15 @@ export function SteeringGate({ runId, ord, prompt, guidance, repoRef, units, onR
   // (Copilot on #252). Every caller has one: the gate record's, or ApprovalDock's derivation from
   // the run's own cursor when the daemon-restart fallback lost the prompt.
   const events = useRunEventStore((s) => s.byRun[runId]) ?? EMPTY_EVENTS;
-  const verdict = useMemo(() => (typeof ord === 'number' ? gateVerdict(events, ord) : null), [events, ord]);
+  // F-7R2-018: an ESCALATION gate about unit N shows only unit N's own evaluation — never the
+  // previous phase's pass under a card about the unit that failed (`gateVerdictFor`).
+  const verdict = useMemo(() => gateVerdictFor(events, ord, prompt), [events, ord, prompt]);
+  // F-7R2-007: a failure-escalation gate offers to move the unit to another seat — plain Approve
+  // re-dispatches the seat that just failed. Not on a deliver-lift escalation (a LIFT-CONFLICT or
+  // a refused lift is the engine's story, told by the lift block below — another seat cannot fix
+  // a rebase conflict), which is why the control is also gated on `lift === null` at the render.
+  const escalation = isFailureEscalation(prompt, verdict);
+  const failedCli = typeof ord === 'number' ? (units ?? EMPTY_UNITS).find((u) => u.ord === ord)?.assigned_cli ?? null : null;
   // The deliver lift's story for THIS ord (wicked-core#431 / F-3R2-013): a gate opened on a deliver
   // unit the engine refused (LIFT-CONFLICT, a failed re-verify, a HEAD off the run branch) renders
   // what the lift did and the engine's remedy on the card. A pre-run deliver gate has no deliver-ord
@@ -355,6 +367,25 @@ export function SteeringGate({ runId, ord, prompt, guidance, repoRef, units, onR
         </p>
       )}
 
+      {/* F-7R2-007: on a failure escalation, the seat lever — approve the retry, then move the
+          unit to a seat that is not the one that just failed (crew's reassign route). The steer
+          text rides the approve here too. */}
+      {escalation && clis !== undefined && lift === null && (
+        <ReassignControl
+          runId={runId}
+          ord={ord}
+          pool={clis}
+          failedCli={failedCli}
+          amend={amend}
+          onDone={(cli) => {
+            useAnnotationStore.getState().clearDraft(runId);
+            clearGate(runId);
+            onResolved?.();
+            void cli;
+          }}
+        />
+      )}
+
       {/* Four-button layout (2×2): Approve / Approve+steer / Reject / Cancel run */}
       <div className="grid grid-cols-2 gap-2">
         <button
@@ -364,8 +395,11 @@ export function SteeringGate({ runId, ord, prompt, guidance, repoRef, units, onR
           className="rounded-lg px-3 py-2 text-xs font-semibold font-mono disabled:opacity-50 transition-opacity"
           style={{ background: 'var(--status-run)', color: 'var(--surface-base)' }}
           {...(restoredRetry ? { title: "the evaluator's edit was discarded; the phase re-runs against the creator's verified tree" } : {})}
+          {...(escalation && failedCli !== null && !restoredRetry
+            ? { title: `retries the unit on ${failedCli} — the seat that just failed; use Reassign to move it` }
+            : {})}
         >
-          {restoredRetry ? 'Retry against the restored tree' : 'Approve'}
+          {restoredRetry ? 'Retry against the restored tree' : escalation && failedCli !== null ? `Approve (retry on ${failedCli})` : 'Approve'}
         </button>
         <button
           data-testid="steering-approve-steer"

--- a/src/components/SteeringTimeline.tsx
+++ b/src/components/SteeringTimeline.tsx
@@ -9,6 +9,7 @@ const ACTION_STYLE: Record<SteeringAction, { label: string; color: string }> = {
   'approve-with-steer':{ label: 'Approved + steered',color: 'var(--status-gate)' },
   reject:             { label: 'Rejected',           color: 'var(--status-fail)' },
   cancel:             { label: 'Cancelled run',      color: 'var(--ink-muted)' },
+  reassign:           { label: 'Reassigned',         color: 'var(--status-gate)' },
 };
 
 export function SteeringTimeline({ runId }: Props): React.ReactElement {
@@ -59,7 +60,9 @@ export function SteeringTimeline({ runId }: Props): React.ReactElement {
                     ? 'run advances'
                     : e.action === 'reject'
                       ? 'run rejected'
-                      : 'run cancelled'}{' '}
+                      : e.action === 'reassign'
+                        ? `retry moved to ${e.cli ?? 'another seat'}`
+                        : 'run cancelled'}{' '}
                 — as recorded
               </p>
             </li>

--- a/src/components/gateVerdictModel.ts
+++ b/src/components/gateVerdictModel.ts
@@ -1,4 +1,5 @@
-import type { CoreEvent, RepoCheckRun, UnitDenial, WorkUnit, WorktreeChangedPath } from '../api/types.js';
+import type { CoreEvent, RepoCheckRun, RosterSeat, UnitDenial, WorkUnit, WorktreeChangedPath } from '../api/types.js';
+import { parseDenial } from './denialCopy.js';
 
 /**
  * gateVerdict — the evaluator's record for the gate the operator is answering, read off the run's
@@ -304,6 +305,91 @@ export function gateVerdict(events: readonly CoreEvent[], gateOrd?: number): Gat
     judgeCli: str(ev.judgeCli),
     judgeDistinct: typeof ev.judgeDistinct === 'boolean' ? ev.judgeDistinct : null,
   };
+}
+
+/**
+ * The unit an ESCALATION gate is about, read off the engine's own prompt spellings — the
+ * triage escalation ("Unit N failed and triage escalated: …") and the verdict escalation
+ * ("Unit N verdict is NOT PASS — …"). `null` for a pre-run gate ("Approve unit N before it
+ * runs: …") and for any prompt this cannot read — the pre-run rule then stands.
+ */
+export function escalationUnit(prompt: string | undefined): number | null {
+  if (prompt === undefined) return null;
+  const m = /^\s*Unit\s+(\d+)\s+(?:failed and triage escalated|verdict is NOT PASS)/i.exec(prompt);
+  return m === null ? null : Number(m[1]);
+}
+
+/**
+ * The verdict block a gate card may show (acceptance finding F-7R2-018): {@link gateVerdict}
+ * bounded on the gate's ord, AND — for an escalation gate about unit N — only unit N's OWN
+ * evaluation. The phase7-r2 rig's "Unit 3 failed and triage escalated" card rendered unit 2's
+ * vacuous pass ("Evaluator verdict — build · UNGATED") under a card about unit 3, because a
+ * worker failure leaves no `gateEvaluated` for N and the last-at-or-below lookup fell through
+ * to N-1. A pre-run gate ("Approve unit N before it runs") keeps the previous phase's verdict —
+ * that IS what the operator is approving (F-3R2-006). No verdict for THAT unit ⇒ no block.
+ */
+export function gateVerdictFor(events: readonly CoreEvent[], gateOrd: number | undefined, prompt: string | undefined): GateVerdictView | null {
+  if (typeof gateOrd !== 'number') return null;
+  const view = gateVerdict(events, gateOrd);
+  if (view === null) return null;
+  const unit = escalationUnit(prompt);
+  if (unit !== null && view.ord !== unit) return null;
+  return view;
+}
+
+/**
+ * Whether this gate is a FAILURE escalation — the unit's worker failed (or triage gave up on it)
+ * and the engine escalated to a human (F-7R2-007): the gate whose plain Approve re-dispatches the
+ * SAME dead seat. Read off the engine's prompt spelling, or the deciding denial's kind (crew's
+ * `worker_failure` layer, the `triage escalation:` / `Worker FAILED` prose `denialCopy` knows).
+ */
+export function isFailureEscalation(prompt: string | undefined, view: GateVerdictView | null): boolean {
+  if (prompt !== undefined && /^\s*Unit\s+\d+\s+failed and triage escalated/i.test(prompt)) return true;
+  if (view === null || view.outcome !== 'fail' || view.denial === null) return false;
+  if (view.denial.source === 'worker_failure') return true;
+  const kind = parseDenial(view.denial.reason, view.denial.source === null ? null : { source: view.denial.source }).kind;
+  return kind === 'triage' || kind === 'worker-failed';
+}
+
+/** One seat the operator may move a failed unit to, with the roster's word on it (F-7R2-007). */
+export interface ReassignCandidate {
+  cli: string;
+  /** The roster's display name, or the seat key when the roster is cold. */
+  label: string;
+  /** `ready` (signed in, not inactive) · `unknown` (no roster word) · `signed-out` (a council benches it) · `inactive`. */
+  state: 'ready' | 'unknown' | 'signed-out' | 'inactive';
+  /** The suffix the picker shows after the name — empty when nothing follows from the roster. */
+  note: string;
+}
+
+const CANDIDATE_RANK: Record<ReassignCandidate['state'], number> = { ready: 0, unknown: 1, 'signed-out': 2, inactive: 3 };
+
+/**
+ * The run's OTHER seats, ordered by what the roster says: signed-in seats first, then seats the
+ * roster cannot vouch for, then signed-out seats ("will be benched" — the council rule), then
+ * inactive ones. The failed seat is excluded: re-dispatching to it is what plain Approve does.
+ */
+export function reassignCandidates(
+  pool: readonly string[],
+  failedCli: string | null,
+  roster: readonly RosterSeat[] | null,
+): ReassignCandidate[] {
+  const seen = new Set<string>();
+  const out: ReassignCandidate[] = [];
+  for (const cli of pool) {
+    if (cli === failedCli || seen.has(cli)) continue;
+    seen.add(cli);
+    const seat = roster?.find((s) => s.key === cli);
+    const inactive = seat?.health?.status === 'inactive';
+    const state: ReassignCandidate['state'] = inactive
+      ? 'inactive'
+      : seat?.signed_in === true ? 'ready' : seat?.signed_in === false ? 'signed-out' : 'unknown';
+    const note = state === 'inactive'
+      ? `inactive${seat?.health?.message ? `: ${seat.health.message}` : ''}`
+      : state === 'signed-out' ? 'signed out — will be benched' : '';
+    out.push({ cli, label: seat?.display_name ?? cli, state, note });
+  }
+  return out.sort((a, b) => CANDIDATE_RANK[a.state] - CANDIDATE_RANK[b.state] || pool.indexOf(a.cli) - pool.indexOf(b.cli));
 }
 
 /**

--- a/src/components/gateVerdictModel.ts
+++ b/src/components/gateVerdictModel.ts
@@ -140,6 +140,13 @@ export interface GateVerdictView {
   judgeCli: string | null;
   /** Whether that judge seat was identity-distinct from the work's author; `null` when unknown. */
   judgeDistinct: boolean | null;
+  /**
+   * The ATTEMPT this evaluation judged — the `attempt` of the nearest `unitDispatched` for the same
+   * ord before it (`gateEvaluated` itself carries none). `null` when no dispatch frame precedes it
+   * in the log. An escalation gate is about the LATEST attempt (F-7R2-018): an earlier attempt's
+   * verdict is not this gate's.
+   */
+  attempt: number | null;
 }
 
 const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === 'object' && v !== null;
@@ -254,6 +261,17 @@ function nearestBefore(events: readonly CoreEvent[], before: number, type: strin
  * evaluation in the log), with its floor and mutation evidence attached. `null` when the log
  * holds no qualifying `gateEvaluated`.
  */
+/** The `attempt` of the nearest `unitDispatched` for `ord` BEFORE index `before` (exclusive; the whole
+ *  log when `before` is omitted), or `null` when none precedes — which attempt a frame at `before`
+ *  belongs to. */
+export function attemptBefore(events: readonly CoreEvent[], ord: number, before: number = events.length): number | null {
+  for (let i = Math.min(before, events.length) - 1; i >= 0; i--) {
+    const e = events[i]!;
+    if (e.type === 'unitDispatched' && e.ord === ord && typeof e.attempt === 'number') return e.attempt;
+  }
+  return null;
+}
+
 export function gateVerdict(events: readonly CoreEvent[], gateOrd?: number): GateVerdictView | null {
   let idx = -1;
   for (let i = 0; i < events.length; i++) {
@@ -304,6 +322,7 @@ export function gateVerdict(events: readonly CoreEvent[], gateOrd?: number): Gat
     restore: restoreFrame === null ? null : restoreOf(restoreFrame),
     judgeCli: str(ev.judgeCli),
     judgeDistinct: typeof ev.judgeDistinct === 'boolean' ? ev.judgeDistinct : null,
+    attempt: ord === null ? null : attemptBefore(events, ord, idx),
   };
 }
 
@@ -327,13 +346,20 @@ export function escalationUnit(prompt: string | undefined): number | null {
  * worker failure leaves no `gateEvaluated` for N and the last-at-or-below lookup fell through
  * to N-1. A pre-run gate ("Approve unit N before it runs") keeps the previous phase's verdict —
  * that IS what the operator is approving (F-3R2-006). No verdict for THAT unit ⇒ no block.
+ *
+ * Keyed on ord AND attempt: an escalation is about the LATEST attempt of unit N (the last
+ * `unitDispatched` for N), so a verdict that judged an EARLIER attempt — attempt 1 denied, attempt 2's
+ * worker then failed — is not this gate's either, and is dropped the same way.
  */
 export function gateVerdictFor(events: readonly CoreEvent[], gateOrd: number | undefined, prompt: string | undefined): GateVerdictView | null {
   if (typeof gateOrd !== 'number') return null;
   const view = gateVerdict(events, gateOrd);
   if (view === null) return null;
   const unit = escalationUnit(prompt);
-  if (unit !== null && view.ord !== unit) return null;
+  if (unit === null) return view;
+  if (view.ord !== unit) return null;
+  const latest = attemptBefore(events, unit);
+  if (latest !== null && view.attempt !== null && view.attempt !== latest) return null;
   return view;
 }
 
@@ -356,18 +382,53 @@ export interface ReassignCandidate {
   cli: string;
   /** The roster's display name, or the seat key when the roster is cold. */
   label: string;
-  /** `ready` (signed in, not inactive) · `unknown` (no roster word) · `signed-out` (a council benches it) · `inactive`. */
-  state: 'ready' | 'unknown' | 'signed-out' | 'inactive';
+  /** `ready` (signed in, or no sign-in needed; not inactive) · `unknown` (no roster word) ·
+   *  `signed-out` (no sign-in observed — may fail or be benched) · `inactive` · `ineligible` (the
+   *  daemon SAYS a council would not seat it — api-types 0.35.0 `council_eligible: false`). */
+  state: 'ready' | 'unknown' | 'signed-out' | 'inactive' | 'ineligible';
   /** The suffix the picker shows after the name — empty when nothing follows from the roster. */
   note: string;
 }
 
-const CANDIDATE_RANK: Record<ReassignCandidate['state'], number> = { ready: 0, unknown: 1, 'signed-out': 2, inactive: 3 };
+const CANDIDATE_RANK: Record<ReassignCandidate['state'], number> = { ready: 0, unknown: 1, 'signed-out': 2, inactive: 3, ineligible: 4 };
+
+/**
+ * The seat's standing as far as the wire SAYS it (never inferred): today's roster carries
+ * `signed_in` (a file/env heuristic) and `health`; crew#533 (api-types 0.35.0) adds `auth`
+ * (`signed_in | signed_out | not_required | unknown`), `free_tier`, `council_eligible` and
+ * `council_ineligible_reason` — read off the seat bag when present, so a daemon that states what a
+ * council would do is believed and one that does not gets the hedged words. The wire pinned by the
+ * phase2-r2 rig is the reason for the hedge: opencode read `signed_in:false` and still answered a
+ * chat on its provider free tier — "councils bench this seat" is not a fact today's roster carries.
+ */
+export function seatStanding(seat: RosterSeat | undefined): { state: ReassignCandidate['state']; note: string } {
+  if (seat === undefined) return { state: 'unknown', note: '' };
+  if (seat.health?.status === 'inactive') {
+    return { state: 'inactive', note: `inactive${seat.health.message ? `: ${seat.health.message}` : ''}` };
+  }
+  const bag = seat as Record<string, unknown>;
+  const eligible = bag['council_eligible'];
+  const auth = bag['auth'];
+  const reason = bag['council_ineligible_reason'];
+  if (eligible === false) {
+    return { state: 'ineligible', note: typeof reason === 'string' && reason !== '' ? reason : 'a council would not seat it' };
+  }
+  if (auth === 'not_required') {
+    const tier = bag['free_tier'];
+    return { state: 'ready', note: `no sign-in needed${typeof tier === 'string' && tier !== '' ? ` (${tier})` : ''}` };
+  }
+  if (auth === 'signed_in' || seat.signed_in === true) return { state: 'ready', note: '' };
+  if (auth === 'signed_out' || seat.signed_in === false) {
+    return { state: 'signed-out', note: eligible === true ? 'no sign-in observed — still council-eligible' : 'no sign-in observed — may fail or be benched' };
+  }
+  return { state: 'unknown', note: '' };
+}
 
 /**
  * The run's OTHER seats, ordered by what the roster says: signed-in seats first, then seats the
- * roster cannot vouch for, then signed-out seats ("will be benched" — the council rule), then
- * inactive ones. The failed seat is excluded: re-dispatching to it is what plain Approve does.
+ * roster cannot vouch for, then seats with no sign-in observed (hedged — see `seatStanding`), then
+ * inactive, then seats the daemon says a council would not seat. The failed seat is excluded:
+ * re-dispatching to it is what plain Approve does.
  */
 export function reassignCandidates(
   pool: readonly string[],
@@ -380,13 +441,7 @@ export function reassignCandidates(
     if (cli === failedCli || seen.has(cli)) continue;
     seen.add(cli);
     const seat = roster?.find((s) => s.key === cli);
-    const inactive = seat?.health?.status === 'inactive';
-    const state: ReassignCandidate['state'] = inactive
-      ? 'inactive'
-      : seat?.signed_in === true ? 'ready' : seat?.signed_in === false ? 'signed-out' : 'unknown';
-    const note = state === 'inactive'
-      ? `inactive${seat?.health?.message ? `: ${seat.health.message}` : ''}`
-      : state === 'signed-out' ? 'signed out — will be benched' : '';
+    const { state, note } = seatStanding(seat);
     out.push({ cli, label: seat?.display_name ?? cli, state, note });
   }
   return out.sort((a, b) => CANDIDATE_RANK[a.state] - CANDIDATE_RANK[b.state] || pool.indexOf(a.cli) - pool.indexOf(b.cli));

--- a/src/components/narrator.ts
+++ b/src/components/narrator.ts
@@ -179,8 +179,9 @@ export function narrate(event: CoreEvent, ctx: NarratorContext): NarrationLine |
       // F-7R2-017: "Checks ran" only when the frame SAYS a deterministic floor ran
       // (`hasDeterministicFloor: true` — the repository checks). An explicit `false` means no
       // check ran: a judge verdict or an evaluator policy may still have gated the phase; with
-      // neither, the phase was approved by default and the line says so (ungated). A frame
-      // without the field (an older engine) keeps the legacy wording — nothing is inferred.
+      // neither, the phase was approved by default and the line says so (ungated). The wire type
+      // declares the field required; a frame that nonetheless lacks it (a daemon predating it)
+      // is read with the legacy wording — nothing is inferred either way.
       const noFloor = event.hasDeterministicFloor === false;
       const judged = str(event.agentVerdict) !== '' || str(event.judgeCli) !== '';
       const policed = Array.isArray(event.evaluatorPolicies) && event.evaluatorPolicies.length > 0;

--- a/src/components/narrator.ts
+++ b/src/components/narrator.ts
@@ -175,10 +175,26 @@ export function narrate(event: CoreEvent, ctx: NarratorContext): NarrationLine |
       return line(`Gate approaching — ${clip(str(event['condition'])) || 'a check escalated to you'}`, 'gate');
     case 'awaitingHuman':
       return line(`Gate: waiting on you${str(event.prompt) ? ` — ${promptHeadline(str(event.prompt))}` : ''}`, 'gate');
-    case 'gateEvaluated':
-      return event.combined === false
-        ? line(`Checks ran on ${phase} — deny${str(event.denialReason ?? '') ? `: ${clip(str(event.denialReason ?? ''))}` : ''}`, 'fail')
-        : line(`Checks ran on ${phase} — pass`, 'work');
+    case 'gateEvaluated': {
+      // F-7R2-017: "Checks ran" only when the frame SAYS a deterministic floor ran
+      // (`hasDeterministicFloor: true` — the repository checks). An explicit `false` means no
+      // check ran: a judge verdict or an evaluator policy may still have gated the phase; with
+      // neither, the phase was approved by default and the line says so (ungated). A frame
+      // without the field (an older engine) keeps the legacy wording — nothing is inferred.
+      const noFloor = event.hasDeterministicFloor === false;
+      const judged = str(event.agentVerdict) !== '' || str(event.judgeCli) !== '';
+      const policed = Array.isArray(event.evaluatorPolicies) && event.evaluatorPolicies.length > 0;
+      const why = clip(str(event.denialReason ?? ''));
+      if (event.combined === false) {
+        return noFloor
+          ? line(`Gate denied on ${phase}${why ? `: ${why}` : ''} — no repository checks ran`, 'fail')
+          : line(`Checks ran on ${phase} — deny${why ? `: ${why}` : ''}`, 'fail');
+      }
+      if (!noFloor) return line(`Checks ran on ${phase} — pass`, 'work');
+      if (judged) return line(`Judge passed ${phase} — no repository checks ran`, 'work');
+      if (policed) return line(`Evaluator policy passed ${phase} — no repository checks ran`, 'work');
+      return line(`Gate passed without checks on ${phase} (ungated)`, 'info');
+    }
     case 'gateDecided':
       return event.allow === true ? line('Gate: approved', 'work') : line('Gate: denied', 'fail');
     case 'unitReworkAmended':

--- a/src/store/steering.ts
+++ b/src/store/steering.ts
@@ -9,7 +9,8 @@ import { create } from 'zustand';
  * not an engine-derived outcome.
  */
 
-export type SteeringAction = 'approve' | 'approve-with-steer' | 'reject' | 'cancel';
+/** `reassign` (F-7R2-007): the operator approved the retry AND moved the unit to another seat. */
+export type SteeringAction = 'approve' | 'approve-with-steer' | 'reject' | 'cancel' | 'reassign';
 
 export interface SteeringEntry {
   /** Monotonic order key. */
@@ -20,6 +21,8 @@ export interface SteeringEntry {
   action: SteeringAction;
   /** The amend text for an approve-with-steer, verbatim (the steered instruction). */
   amend?: string;
+  /** The seat a `reassign` moved the unit to. */
+  cli?: string;
   ts: number;
 }
 

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -10,9 +10,9 @@
   "version": 1,
   "studioVersion": "0.5.5",
   "counts": {
-    "files": 142,
-    "occurrences": 1228,
-    "static": 1054,
+    "files": 143,
+    "occurrences": 1237,
+    "static": 1063,
     "dynamic": 59,
     "computed": 7
   },
@@ -5264,6 +5264,60 @@
       "testId": "steering-provenance-ui",
       "files": [
         "src/components/SteeringRuleDrawer.tsx"
+      ]
+    },
+    {
+      "testId": "steering-reassign",
+      "files": [
+        "src/components/ReassignControl.tsx"
+      ]
+    },
+    {
+      "testId": "steering-reassign-benched",
+      "files": [
+        "src/components/ReassignControl.tsx"
+      ]
+    },
+    {
+      "testId": "steering-reassign-error",
+      "files": [
+        "src/components/ReassignControl.tsx"
+      ]
+    },
+    {
+      "testId": "steering-reassign-none",
+      "files": [
+        "src/components/ReassignControl.tsx"
+      ]
+    },
+    {
+      "testId": "steering-reassign-option",
+      "files": [
+        "src/components/ReassignControl.tsx"
+      ]
+    },
+    {
+      "testId": "steering-reassign-retry",
+      "files": [
+        "src/components/ReassignControl.tsx"
+      ]
+    },
+    {
+      "testId": "steering-reassign-row",
+      "files": [
+        "src/components/ReassignControl.tsx"
+      ]
+    },
+    {
+      "testId": "steering-reassign-seat",
+      "files": [
+        "src/components/ReassignControl.tsx"
+      ]
+    },
+    {
+      "testId": "steering-reassign-status",
+      "files": [
+        "src/components/ReassignControl.tsx"
       ]
     },
     {

--- a/tests/CenterDashboard.reassign.test.tsx
+++ b/tests/CenterDashboard.reassign.test.tsx
@@ -1,0 +1,94 @@
+// F-7R2-007 / F-7R2-018 on the landing inbox's gate card — the same lever and the same
+// verdict rule as the run page's card, from the same predicates.
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { CenterDashboard } from '../src/components/CenterDashboard.js';
+import { reassignPolling } from '../src/components/ReassignControl.js';
+import { useGateStore } from '../src/store/gates.js';
+import { useRunEventStore } from '../src/store/events.js';
+import { clearCachedRoster, setCachedRoster } from '../src/store/rosterCache.js';
+import { makeUnit, makeView } from './factories.js';
+import type { CoreEvent, RosterSeat } from '../src/api/types.js';
+
+const RUN = 'b86c14c1-7r2';
+const PROMPT = 'Unit 3 failed and triage escalated: triage judge errored: triage judge failed (Failed):';
+const POOL = ['claude', 'codex', 'pi'];
+const UNITS = [
+  makeUnit({ id: `${RUN}:u2`, session_id: RUN, ord: 2, stage: 'build', status: 'done', assigned_cli: 'claude' }),
+  makeUnit({ id: `${RUN}:u3`, session_id: RUN, ord: 3, stage: 'build', status: 'pending', assigned_cli: 'codex' }),
+];
+const EVENTS: CoreEvent[] = [
+  { type: 'gateEvaluated', session: RUN, ord: 2, seq: 1, ts: 1, criterion: null, hasDeterministicFloor: false, deterministicPass: true,
+    agentVerdict: null, agentReasoning: null, evaluatorPass: true, evaluatorPolicies: [], denialReason: null, denial: null, combined: true },
+  { type: 'awaitingHuman', session: RUN, ord: 3, seq: 2, ts: 2, prompt: PROMPT, reviewingOrd: null },
+] as unknown as CoreEvent[];
+const ROSTER: RosterSeat[] = [
+  { key: 'claude', display_name: 'Claude Code', binary: 'claude', enabled_for_council: true, health: { status: 'active', since: 'x' }, signed_in: true },
+  { key: 'codex', display_name: 'Codex', binary: 'codex', enabled_for_council: true, signed_in: false },
+  { key: 'pi', display_name: 'pi', binary: 'pi', enabled_for_council: true, signed_in: false },
+];
+
+const confirmGate = vi.hoisted(() => vi.fn(async () => ({})));
+const reassignRun = vi.hoisted(() => vi.fn(async () => ({ status: 'ok', ord: 3, cli: 'claude' })));
+const getRun = vi.hoisted(() => vi.fn());
+const getRunEvents = vi.hoisted(() => vi.fn<(id: string) => Promise<{ events: unknown[] }>>(async () => ({ events: [] })));
+
+vi.mock('../src/api/client.js', () => ({
+  api: {
+    confirmGate: (...a: unknown[]) => confirmGate(...(a as [])),
+    injectMessage: vi.fn(async () => ({})),
+    getRunEvents: (id: string) => getRunEvents(id),
+    reassignRun: (...a: unknown[]) => reassignRun(...(a as [])),
+    getRun: (...a: unknown[]) => getRun(...(a as [])),
+    getRoster: async () => ({ roster: ROSTER }),
+  },
+}));
+
+beforeEach(() => {
+  reassignPolling.intervalMs = 1;
+  confirmGate.mockClear();
+  reassignRun.mockClear();
+  getRun.mockReset();
+  getRun.mockResolvedValue({ run: makeView({ id: RUN, status: 'executing', clis: POOL }, UNITS) });
+  getRunEvents.mockReset();
+  getRunEvents.mockImplementation(async (id) => ({ events: id === RUN ? EVENTS : [] }));
+  useGateStore.setState({ gates: { [RUN]: { runId: RUN, ord: 3, prompt: PROMPT, lifecycle: 'open', receivedAt: 1 } } });
+  useRunEventStore.setState({ byRun: { [RUN]: EVENTS } });
+  clearCachedRoster();
+  setCachedRoster(ROSTER);
+});
+
+function dash(): void {
+  render(
+    <CenterDashboard
+      runs={[makeView({ id: RUN, problem: 'run the governed test', status: 'awaiting_human', unit_ix: 2, clis: POOL }, UNITS)]}
+      onSelectRun={vi.fn()}
+      onApproveGate={vi.fn()}
+      onRejectGate={vi.fn()}
+      navigate={vi.fn()}
+    />,
+  );
+}
+
+describe('the inbox gate card on a failure escalation', () => {
+  it('F-7R2-018: renders no verdict block for unit 2 under the unit-3 escalation card', async () => {
+    dash();
+    const card = await screen.findByTestId('gate-inbox-card');
+    await waitFor(() => expect(getRunEvents).toHaveBeenCalledTimes(1));
+    await screen.findByTestId('steering-reassign-row');
+    expect(within(card).queryByTestId('gate-verdict')).toBeNull();
+  });
+
+  it('F-7R2-007: offers Reassign to <seat> + retry from the run\'s pool minus the failed seat, and drives approve → reassign', async () => {
+    dash();
+    const card = await screen.findByTestId('gate-inbox-card');
+    const row = await within(card).findByTestId('steering-reassign-row');
+    expect(within(row).getAllByTestId('steering-reassign-option').map((o) => o.getAttribute('value'))).toEqual(['claude', 'pi']);
+    expect(within(card).getByRole('button', { name: 'Approve (retry on codex)' })).toBeInTheDocument();
+
+    fireEvent.click(within(row).getByTestId('steering-reassign'));
+    await waitFor(() => expect(confirmGate).toHaveBeenCalledWith(RUN, { approve: true }));
+    await waitFor(() => expect(reassignRun).toHaveBeenCalledWith(RUN, 'claude'));
+    await waitFor(() => expect(useGateStore.getState().gates[RUN]).toBeUndefined());
+  });
+});

--- a/tests/SteeringGate.reassign.test.tsx
+++ b/tests/SteeringGate.reassign.test.tsx
@@ -77,7 +77,7 @@ describe('F-7R2-007: Reassign to <seat> + retry', () => {
     const options = within(row).getAllByTestId('steering-reassign-option');
     expect(options.map((o) => o.getAttribute('value'))).toEqual(['claude', 'pi', 'opencode']);
     expect(options[0]!.textContent).toBe('Claude Code');
-    expect(options[1]!.textContent).toBe('pi — signed out — will be benched');
+    expect(options[1]!.textContent).toBe('pi — no sign-in observed — may fail or be benched');
     expect(options[1]).toHaveAttribute('data-state', 'signed-out');
     expect(screen.getByTestId('steering-reassign')).toHaveTextContent('Reassign to Claude Code + retry');
     expect(screen.getByTestId('steering-approve')).toHaveTextContent('Approve (retry on codex)');
@@ -112,7 +112,9 @@ describe('F-7R2-007: Reassign to <seat> + retry', () => {
       .mockResolvedValueOnce({ status: 'ok', ord: 3, cli: 'pi' });
     const onResolved = mount();
     fireEvent.change(screen.getByTestId('steering-reassign-seat'), { target: { value: 'pi' } });
-    expect(screen.getByTestId('steering-reassign-benched')).toHaveTextContent('pi is signed out — a council benches it');
+    // Hedged: the roster carries no council-eligibility field, and the rig saw a "signed out" seat answer.
+    expect(screen.getByTestId('steering-reassign-benched')).toHaveTextContent('pi: no sign-in observed — the retry may fail at spawn or be benched there');
+    expect(screen.getByTestId('steering-reassign-benched').textContent).not.toMatch(/benches it|will be benched/);
     fireEvent.click(screen.getByTestId('steering-reassign'));
 
     const err = await screen.findByTestId('steering-reassign-error');
@@ -138,16 +140,30 @@ describe('F-7R2-007: Reassign to <seat> + retry', () => {
     expect(client.api.reassignRun).not.toHaveBeenCalled();
   });
 
-  it('no lever on a pre-run gate, nor without the pool; an empty pool says so', () => {
+  it('no lever on a pre-run gate; an empty pool says so', () => {
     cleanup();
+    vi.spyOn(client.api, 'getRun').mockRejectedValue(new Error('not in this case'));
     render(<SteeringGate runId={RUN} ord={3} prompt="Approve unit 3 before it runs: build — the intent" units={UNITS} clis={POOL} />);
     expect(screen.queryByTestId('steering-reassign-row')).toBeNull();
     expect(screen.getByTestId('steering-approve')).toHaveTextContent('Approve');
-    cleanup();
-    render(<SteeringGate runId={RUN} ord={3} prompt={PROMPT} units={UNITS} />);
-    expect(screen.queryByTestId('steering-reassign-row')).toBeNull();
+    expect(client.api.getRun).not.toHaveBeenCalled(); // a pre-run gate never reads the run for a pool
     cleanup();
     render(<SteeringGate runId={RUN} ord={3} prompt={PROMPT} units={UNITS} clis={['codex']} />);
     expect(screen.getByTestId('steering-reassign-none')).toHaveTextContent('no other seat in this run\'s pool (only codex, which failed)');
+  });
+
+  it('a host without the run view (the author / testing-launch panels) reads the run ONCE for its pool on a failure escalation; a failed read offers no lever', async () => {
+    const getRun = vi.spyOn(client.api, 'getRun').mockResolvedValue({ run: makeView({ id: RUN, status: 'awaiting_human', clis: POOL }, UNITS) });
+    render(<SteeringGate runId={RUN} ord={3} prompt={PROMPT} units={UNITS} />);
+    const row = await screen.findByTestId('steering-reassign-row');
+    expect(getRun).toHaveBeenCalledTimes(1);
+    expect(getRun).toHaveBeenCalledWith(RUN);
+    expect(within(row).getAllByTestId('steering-reassign-option').map((o) => o.getAttribute('value'))).toEqual(['claude', 'pi', 'opencode']);
+    cleanup();
+    vi.spyOn(client.api, 'getRun').mockRejectedValue(new Error('offline'));
+    render(<SteeringGate runId={RUN} ord={3} prompt={PROMPT} units={UNITS} />);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(screen.queryByTestId('steering-reassign-row')).toBeNull();
+    expect(screen.getByTestId('steering-approve')).toBeInTheDocument();
   });
 });

--- a/tests/SteeringGate.reassign.test.tsx
+++ b/tests/SteeringGate.reassign.test.tsx
@@ -1,0 +1,153 @@
+// F-7R2-007 — the seat lever on a failure-escalation gate (the run page's card), and
+// F-7R2-018 — no previous-phase verdict under a card about the unit that failed.
+//
+// The phase7-r2 rig: five "Unit N failed and triage escalated" gates; plain Approve re-dispatched
+// the dead seat; recovery was `POST /runs/:id/reassign {cli:"claude"}` by hand, racing the
+// re-dispatch window. The card now approves the retry, waits for the run to resume, then
+// reassigns — every step stated; the roster's word on each seat labels the pick.
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as client from '../src/api/client.js';
+import type { CoreEvent, RosterSeat } from '../src/api/types.js';
+import { reassignPolling } from '../src/components/ReassignControl.js';
+import { SteeringGate } from '../src/components/SteeringGate.js';
+import { useAnnotationStore } from '../src/store/annotations.js';
+import { useRunEventStore } from '../src/store/events.js';
+import { useGateStore } from '../src/store/gates.js';
+import { clearCachedRoster, setCachedRoster } from '../src/store/rosterCache.js';
+import { useSteeringStore } from '../src/store/steering.js';
+import { makeUnit, makeView } from './factories.js';
+
+const RUN = 'b86c14c1-7r2';
+const PROMPT = 'Unit 3 failed and triage escalated: triage judge errored: triage judge failed (Failed):';
+const POOL = ['claude', 'codex', 'pi', 'opencode'];
+const UNITS = [
+  makeUnit({ id: `${RUN}:u1`, session_id: RUN, ord: 1, stage: 'recon', status: 'done', assigned_cli: 'claude' }),
+  makeUnit({ id: `${RUN}:u2`, session_id: RUN, ord: 2, stage: 'build', status: 'done', assigned_cli: 'claude' }),
+  makeUnit({ id: `${RUN}:u3`, session_id: RUN, ord: 3, stage: 'build', status: 'pending', assigned_cli: 'codex' }),
+];
+const EVENTS: CoreEvent[] = [
+  { type: 'gateEvaluated', session: RUN, ord: 2, criterion: null, hasDeterministicFloor: false, deterministicPass: true,
+    agentVerdict: null, agentReasoning: null, evaluatorPass: true, evaluatorPolicies: [], denialReason: null, denial: null, combined: true },
+  { type: 'gateDecided', session: RUN, ord: 2, allow: true },
+  { type: 'unitDone', session: RUN, ord: 2 },
+  { type: 'unitDispatched', session: RUN, ord: 3, cli: 'codex', attempt: 0 },
+  { type: 'stepFailed', session: RUN, ord: 3, detail: 'codex exited 1' },
+  { type: 'awaitingHuman', session: RUN, ord: 3, prompt: PROMPT, reviewingOrd: null },
+] as unknown as CoreEvent[];
+const ROSTER: RosterSeat[] = [
+  { key: 'claude', display_name: 'Claude Code', binary: 'claude', enabled_for_council: true, health: { status: 'active', since: 'x' }, signed_in: true },
+  { key: 'codex', display_name: 'Codex', binary: 'codex', enabled_for_council: true, health: { status: 'active', since: 'x' }, signed_in: false },
+  { key: 'pi', display_name: 'pi', binary: 'pi', enabled_for_council: true, health: { status: 'active', since: 'x' }, signed_in: false },
+  { key: 'opencode', display_name: 'OpenCode', binary: 'opencode', enabled_for_council: true, health: { status: 'active', since: 'x' }, signed_in: false },
+];
+
+function mount(onResolved = vi.fn()): ReturnType<typeof vi.fn> {
+  render(<SteeringGate runId={RUN} ord={3} prompt={PROMPT} units={UNITS} clis={POOL} onResolved={onResolved} />);
+  return onResolved;
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  reassignPolling.intervalMs = 1; // the resume wait polls in milliseconds here, not half-seconds
+  useGateStore.setState({ gates: { [RUN]: { runId: RUN, ord: 3, prompt: PROMPT, lifecycle: 'open', receivedAt: 1 } } });
+  useAnnotationStore.setState({ drafts: {} });
+  useSteeringStore.setState({ entries: [], seq: 0 });
+  useRunEventStore.setState({ byRun: { [RUN]: EVENTS } });
+  clearCachedRoster();
+  setCachedRoster(ROSTER);
+  vi.spyOn(client.api, 'confirmGate').mockResolvedValue({ status: 'ok' });
+  vi.spyOn(client.api, 'reassignRun').mockResolvedValue({ status: 'ok', ord: 3, cli: 'claude' });
+  vi.spyOn(client.api, 'getRoster').mockResolvedValue({ roster: ROSTER });
+});
+afterEach(cleanup);
+
+describe('F-7R2-018: the verdict block is about THIS unit', () => {
+  it('renders no gate-verdict under the escalation card when unit 3 has no evaluation (unit 2\'s pass is not it)', () => {
+    mount();
+    expect(screen.getByTestId('steering-prompt')).toHaveTextContent('Unit 3 failed and triage escalated');
+    expect(screen.queryByTestId('gate-verdict')).toBeNull();
+  });
+});
+
+describe('F-7R2-007: Reassign to <seat> + retry', () => {
+  it('lists the run\'s other seats with the roster\'s word, signed-in first; Approve names the dead seat it retries', () => {
+    mount();
+    const row = screen.getByTestId('steering-reassign-row');
+    const options = within(row).getAllByTestId('steering-reassign-option');
+    expect(options.map((o) => o.getAttribute('value'))).toEqual(['claude', 'pi', 'opencode']);
+    expect(options[0]!.textContent).toBe('Claude Code');
+    expect(options[1]!.textContent).toBe('pi — signed out — will be benched');
+    expect(options[1]).toHaveAttribute('data-state', 'signed-out');
+    expect(screen.getByTestId('steering-reassign')).toHaveTextContent('Reassign to Claude Code + retry');
+    expect(screen.getByTestId('steering-approve')).toHaveTextContent('Approve (retry on codex)');
+    expect(screen.getByTestId('steering-approve').getAttribute('title')).toContain('the seat that just failed');
+  });
+
+  it('approves the retry, waits for the run to resume, then reassigns to the chosen seat — and resolves the gate', async () => {
+    const statuses = ['awaiting_human', 'awaiting_human', 'executing'];
+    vi.spyOn(client.api, 'getRun').mockImplementation(async () => ({
+      run: makeView({ id: RUN, status: statuses.shift() as 'executing' ?? 'executing', clis: POOL }, UNITS),
+    }));
+    const onResolved = mount();
+    // A steer typed on the card rides the approve.
+    fireEvent.change(screen.getByTestId('steering-amend'), { target: { value: 'use the other seat' } });
+    fireEvent.click(screen.getByTestId('steering-reassign'));
+
+    await waitFor(() => expect(client.api.confirmGate).toHaveBeenCalledWith(RUN, { approve: true, amend: 'use the other seat' }));
+    await waitFor(() => expect(client.api.reassignRun).toHaveBeenCalledWith(RUN, 'claude'), { timeout: 3000 });
+    expect(client.api.getRun).toHaveBeenCalledTimes(3);
+    await waitFor(() => expect(screen.getByTestId('steering-reassign-row')).toHaveAttribute('data-phase', 'done'));
+    expect(screen.getByTestId('steering-reassign-status')).toHaveTextContent('reassigned to Claude Code — the retry runs there');
+    expect(onResolved).toHaveBeenCalledTimes(1);
+    expect(useGateStore.getState().gates[RUN]).toBeUndefined();
+    const entry = useSteeringStore.getState().entries.at(-1);
+    expect(entry).toMatchObject({ runId: RUN, action: 'reassign', cli: 'claude', ord: 3 });
+  });
+
+  it('a refused reassign leaves the approve standing, shows the daemon\'s sentence and offers the reassign alone again', async () => {
+    vi.spyOn(client.api, 'getRun').mockResolvedValue({ run: makeView({ id: RUN, status: 'executing', clis: POOL }, UNITS) });
+    vi.spyOn(client.api, 'reassignRun')
+      .mockRejectedValueOnce(new Error('the daemon refused this — cli "pi" is not in this run\'s seat pool'))
+      .mockResolvedValueOnce({ status: 'ok', ord: 3, cli: 'pi' });
+    const onResolved = mount();
+    fireEvent.change(screen.getByTestId('steering-reassign-seat'), { target: { value: 'pi' } });
+    expect(screen.getByTestId('steering-reassign-benched')).toHaveTextContent('pi is signed out — a council benches it');
+    fireEvent.click(screen.getByTestId('steering-reassign'));
+
+    const err = await screen.findByTestId('steering-reassign-error');
+    expect(err).toHaveTextContent('not in this run\'s seat pool');
+    expect(screen.getByTestId('steering-reassign-row')).toHaveAttribute('data-approved', 'true');
+    expect(screen.getByTestId('steering-reassign-status')).toHaveTextContent('the retry was approved; the reassign did not land');
+    expect(client.api.confirmGate).toHaveBeenCalledTimes(1);
+    expect(onResolved).not.toHaveBeenCalled();
+
+    await act(async () => { fireEvent.click(screen.getByTestId('steering-reassign-retry')); });
+    await waitFor(() => expect(client.api.reassignRun).toHaveBeenCalledTimes(2));
+    // The second attempt did NOT approve again.
+    expect(client.api.confirmGate).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(onResolved).toHaveBeenCalledTimes(1));
+  });
+
+  it('a run that ends before it resumes is said, not retried into', async () => {
+    vi.spyOn(client.api, 'getRun').mockResolvedValue({ run: makeView({ id: RUN, status: 'failed', clis: POOL }, UNITS) });
+    mount();
+    fireEvent.click(screen.getByTestId('steering-reassign'));
+    const err = await screen.findByTestId('steering-reassign-error');
+    expect(err).toHaveTextContent('the run is failed — nothing left to reassign');
+    expect(client.api.reassignRun).not.toHaveBeenCalled();
+  });
+
+  it('no lever on a pre-run gate, nor without the pool; an empty pool says so', () => {
+    cleanup();
+    render(<SteeringGate runId={RUN} ord={3} prompt="Approve unit 3 before it runs: build — the intent" units={UNITS} clis={POOL} />);
+    expect(screen.queryByTestId('steering-reassign-row')).toBeNull();
+    expect(screen.getByTestId('steering-approve')).toHaveTextContent('Approve');
+    cleanup();
+    render(<SteeringGate runId={RUN} ord={3} prompt={PROMPT} units={UNITS} />);
+    expect(screen.queryByTestId('steering-reassign-row')).toBeNull();
+    cleanup();
+    render(<SteeringGate runId={RUN} ord={3} prompt={PROMPT} units={UNITS} clis={['codex']} />);
+    expect(screen.getByTestId('steering-reassign-none')).toHaveTextContent('no other seat in this run\'s pool (only codex, which failed)');
+  });
+});

--- a/tests/SteeringGate.wire433.test.tsx
+++ b/tests/SteeringGate.wire433.test.tsx
@@ -236,8 +236,10 @@ describe('SteeringGate — the deliver lift on a gate opened on the deliver unit
 
   it("a LIFT-CONFLICT retry gate renders the lift block — outcome, files, the remedy — and the refusal ONCE: the engine's escalate prompt already quotes it", () => {
     mount([...G6_EVENTS, ...DELIVER_CONFLICT_TAIL], deliverRetryGate(REFUSAL_CONFLICT));
-    // The deciding evaluation is still the ord-4 PASS — the deliver unit never reached a verdict.
-    expect(screen.getByTestId('gate-verdict')).toHaveAttribute('data-verdict', 'pass');
+    // F-7R2-018: the deliver unit never reached a verdict, and this card is ABOUT unit 5 — the
+    // ord-4 PASS is the previous phase's and must not render under it. The lift block below is
+    // the deliver unit's own story.
+    expect(screen.queryByTestId('gate-verdict')).toBeNull();
     // The engine's prompt, format string filled (actor.rs TriageDecision::Escalate): it QUOTES the failure.
     expect(screen.getByTestId('steering-prompt')).toHaveTextContent('Unit 5 failed and triage escalated');
     expect(screen.getByTestId('steering-prompt')).toHaveTextContent('Failure output: "deliver: LIFT-CONFLICT');

--- a/tests/gateVerdictModel.escalation.test.ts
+++ b/tests/gateVerdictModel.escalation.test.ts
@@ -1,0 +1,106 @@
+// F-7R2-018 + F-7R2-007 (the pure half): which verdict a gate card may show, and which seats a
+// failure escalation may move the unit to.
+//
+// The phase7-r2 rig: at "Unit 3 failed and triage escalated: triage judge errored…" the card
+// (before unit #3) rendered unit 2's vacuous pass — `gateVerdict` takes the last evaluation at
+// or below the gate's ord, and a worker failure leaves none for unit 3. An escalation gate is
+// ABOUT unit N: only N's own evaluation may stand under it; a pre-run gate keeps the previous
+// phase's verdict (that IS what the operator approves, F-3R2-006).
+import { describe, expect, it } from 'vitest';
+import type { CoreEvent, RosterSeat } from '../src/api/types.js';
+import {
+  escalationUnit, gateVerdictFor, isFailureEscalation, reassignCandidates,
+} from '../src/components/gateVerdictModel.js';
+import { G4_EVENTS, G4_GATE, G5_EVENTS, G5_GATE, GATE_RUN } from './fixtures/gateEvidence.js';
+
+const RUN = 'run-7r2';
+const TRIAGE_PROMPT = 'Unit 3 failed and triage escalated: triage judge errored: triage judge failed (Failed):';
+
+/** Unit 2's vacuous pass, then unit 3's worker failure escalates — NO gateEvaluated for 3. */
+const ESCALATION_EVENTS: CoreEvent[] = [
+  { type: 'gateEvaluated', session: RUN, ord: 2, criterion: null, hasDeterministicFloor: false, deterministicPass: true,
+    agentVerdict: null, agentReasoning: null, evaluatorPass: true, evaluatorPolicies: [], denialReason: null, denial: null, combined: true },
+  { type: 'gateDecided', session: RUN, ord: 2, allow: true },
+  { type: 'unitDone', session: RUN, ord: 2 },
+  { type: 'unitDispatched', session: RUN, ord: 3, cli: 'codex', attempt: 0 },
+  { type: 'stepFailed', session: RUN, ord: 3, detail: 'codex exited 1' },
+  { type: 'failureTriaged', session: RUN, ord: 3, decision: 'escalate', analysis: 'triage judge errored' },
+  { type: 'awaitingHuman', session: RUN, ord: 3, prompt: TRIAGE_PROMPT, reviewingOrd: null },
+] as unknown as CoreEvent[];
+
+describe('escalationUnit — the engine\'s escalation prompts', () => {
+  it('reads the unit off both escalation spellings and nothing off a pre-run gate', () => {
+    expect(escalationUnit(TRIAGE_PROMPT)).toBe(3);
+    expect(escalationUnit(G5_GATE.prompt)).toBe(4);
+    expect(escalationUnit(G4_GATE.prompt)).toBeNull();
+    expect(escalationUnit(undefined)).toBeNull();
+    expect(escalationUnit('Prompt unavailable (daemon restarted)')).toBeNull();
+  });
+});
+
+describe('gateVerdictFor — the block is about THIS gate\'s unit (F-7R2-018)', () => {
+  it('an escalation gate about unit 3 with no evaluation for 3 renders NO block — never unit 2\'s pass', () => {
+    expect(gateVerdictFor(ESCALATION_EVENTS, 3, TRIAGE_PROMPT)).toBeNull();
+  });
+
+  it('a pre-run gate keeps the previous phase\'s verdict; an escalation with its own denial keeps that', () => {
+    expect(gateVerdictFor(G4_EVENTS, G4_GATE.ord, G4_GATE.prompt)?.ord).toBe(3);
+    expect(gateVerdictFor(G5_EVENTS, G5_GATE.ord, G5_GATE.prompt)?.ord).toBe(4);
+    expect(gateVerdictFor(G5_EVENTS, G5_GATE.ord, G5_GATE.prompt)?.outcome).toBe('fail');
+    expect(gateVerdictFor(G4_EVENTS, undefined, G4_GATE.prompt)).toBeNull();
+  });
+
+  it('a retry that later evaluates unit 3 itself shows THAT verdict', () => {
+    const later: CoreEvent[] = [
+      ...ESCALATION_EVENTS,
+      { type: 'gateEvaluated', session: RUN, ord: 3, criterion: 'x', hasDeterministicFloor: true, deterministicPass: false,
+        agentVerdict: null, agentReasoning: null, evaluatorPass: true, evaluatorPolicies: [],
+        denialReason: 'Worker FAILED on unit 3: exit 1', denial: { source: 'worker_failure', reason: 'Worker FAILED on unit 3: exit 1' }, combined: false },
+    ] as unknown as CoreEvent[];
+    const view = gateVerdictFor(later, 3, TRIAGE_PROMPT);
+    expect(view?.ord).toBe(3);
+    expect(view?.denial?.source).toBe('worker_failure');
+  });
+});
+
+describe('isFailureEscalation — the gate whose plain Approve retries the dead seat (F-7R2-007)', () => {
+  it('reads the triage prompt, the worker_failure layer, and the triage/Worker FAILED prose; not a pre-run or guard gate', () => {
+    expect(isFailureEscalation(TRIAGE_PROMPT, null)).toBe(true);
+    expect(isFailureEscalation(G4_GATE.prompt, gateVerdictFor(G4_EVENTS, 4, G4_GATE.prompt))).toBe(false);
+    // The worktree-guard denial is a verdict escalation, not a dead seat — Reassign is not the remedy.
+    expect(isFailureEscalation(G5_GATE.prompt, gateVerdictFor(G5_EVENTS, 4, G5_GATE.prompt))).toBe(false);
+    const workerFailed: CoreEvent[] = [
+      { type: 'gateEvaluated', session: GATE_RUN, ord: 4, hasDeterministicFloor: false, deterministicPass: true, agentVerdict: null,
+        evaluatorPass: true, evaluatorPolicies: [], denialReason: 'Worker FAILED on unit 4 (codex): exit 137', denial: null, combined: false },
+    ] as unknown as CoreEvent[];
+    expect(isFailureEscalation('Prompt unavailable', gateVerdictFor(workerFailed, 4, undefined))).toBe(true);
+    const triageProse: CoreEvent[] = [
+      { type: 'gateEvaluated', session: GATE_RUN, ord: 4, combined: false, denialReason: 'triage escalation: judge errored' },
+    ] as unknown as CoreEvent[];
+    expect(isFailureEscalation(undefined, gateVerdictFor(triageProse, 4, undefined))).toBe(true);
+  });
+});
+
+describe('reassignCandidates — the run\'s other seats, in the roster\'s order', () => {
+  const ROSTER: RosterSeat[] = [
+    { key: 'claude', display_name: 'Claude Code', binary: 'claude', enabled_for_council: true, health: { status: 'active', since: 'x' }, signed_in: true },
+    { key: 'pi', display_name: 'pi', binary: 'pi', enabled_for_council: true, health: { status: 'active', since: 'x' }, signed_in: false },
+    { key: 'opencode', display_name: 'OpenCode', binary: 'opencode', enabled_for_council: true, health: { status: 'inactive', message: 'quota', since: 'x' }, signed_in: false },
+    { key: 'codex', display_name: 'Codex', binary: 'codex', enabled_for_council: true, health: { status: 'active', since: 'x' }, signed_in: false },
+  ];
+
+  it('excludes the failed seat, puts signed-in first, labels signed-out as "will be benched", inactive last', () => {
+    const out = reassignCandidates(['codex', 'pi', 'opencode', 'agy', 'claude'], 'codex', ROSTER);
+    expect(out.map((c) => c.cli)).toEqual(['claude', 'agy', 'pi', 'opencode']);
+    expect(out[0]).toMatchObject({ label: 'Claude Code', state: 'ready', note: '' });
+    expect(out[1]).toMatchObject({ label: 'agy', state: 'unknown', note: '' });
+    expect(out[2]).toMatchObject({ label: 'pi', state: 'signed-out', note: 'signed out — will be benched' });
+    expect(out[3]).toMatchObject({ label: 'OpenCode', state: 'inactive', note: 'inactive: quota' });
+  });
+
+  it('a cold roster offers the pool by key, unlabelled — never an invented state', () => {
+    const out = reassignCandidates(['codex', 'claude', 'claude'], 'codex', null);
+    expect(out).toEqual([{ cli: 'claude', label: 'claude', state: 'unknown', note: '' }]);
+    expect(reassignCandidates(['codex'], 'codex', ROSTER)).toEqual([]);
+  });
+});

--- a/tests/gateVerdictModel.escalation.test.ts
+++ b/tests/gateVerdictModel.escalation.test.ts
@@ -9,7 +9,7 @@
 import { describe, expect, it } from 'vitest';
 import type { CoreEvent, RosterSeat } from '../src/api/types.js';
 import {
-  escalationUnit, gateVerdictFor, isFailureEscalation, reassignCandidates,
+  attemptBefore, escalationUnit, gateVerdictFor, isFailureEscalation, reassignCandidates, seatStanding,
 } from '../src/components/gateVerdictModel.js';
 import { G4_EVENTS, G4_GATE, G5_EVENTS, G5_GATE, GATE_RUN } from './fixtures/gateEvidence.js';
 
@@ -59,7 +59,34 @@ describe('gateVerdictFor — the block is about THIS gate\'s unit (F-7R2-018)', 
     ] as unknown as CoreEvent[];
     const view = gateVerdictFor(later, 3, TRIAGE_PROMPT);
     expect(view?.ord).toBe(3);
+    expect(view?.attempt).toBe(0);
     expect(view?.denial?.source).toBe('worker_failure');
+  });
+
+  it('keyed on ord AND attempt: attempt 0\'s denial is not the verdict of the attempt-1 escalation', () => {
+    const DENY_0 = {
+      type: 'gateEvaluated', session: RUN, ord: 3, criterion: 'x', hasDeterministicFloor: true, deterministicPass: false,
+      agentVerdict: null, agentReasoning: null, evaluatorPass: true, evaluatorPolicies: [],
+      denialReason: 'repository checks failed: lint exited 1', denial: { source: 'repo_checks', reason: 'repository checks failed: lint exited 1' }, combined: false,
+    };
+    const twoAttempts: CoreEvent[] = [
+      { type: 'unitDispatched', session: RUN, ord: 3, cli: 'codex', attempt: 0 },
+      DENY_0,
+      { type: 'gateDecided', session: RUN, ord: 3, allow: true },
+      { type: 'unitDispatched', session: RUN, ord: 3, cli: 'codex', attempt: 1 },
+      { type: 'stepFailed', session: RUN, ord: 3, detail: 'codex exited 137' },
+      { type: 'awaitingHuman', session: RUN, ord: 3, prompt: TRIAGE_PROMPT, reviewingOrd: null },
+    ] as unknown as CoreEvent[];
+    expect(attemptBefore(twoAttempts, 3)).toBe(1);
+    expect(attemptBefore(twoAttempts, 3, 2)).toBe(0);
+    expect(attemptBefore(twoAttempts, 9)).toBeNull();
+    // The unbounded model still reports attempt 0's verdict, stamped with its attempt…
+    expect(gateVerdictFor(twoAttempts, 3, 'Approve unit 3 before it runs: build')?.attempt).toBe(0);
+    // …but the escalation card about attempt 1 renders none of it.
+    expect(gateVerdictFor(twoAttempts, 3, TRIAGE_PROMPT)).toBeNull();
+    // Attempt 1's own later evaluation is this gate's.
+    const withOwn: CoreEvent[] = [...twoAttempts, { ...DENY_0, denialReason: 'Worker FAILED on unit 3: exit 137' } as unknown as CoreEvent];
+    expect(gateVerdictFor(withOwn, 3, TRIAGE_PROMPT)?.attempt).toBe(1);
   });
 });
 
@@ -89,13 +116,36 @@ describe('reassignCandidates — the run\'s other seats, in the roster\'s order'
     { key: 'codex', display_name: 'Codex', binary: 'codex', enabled_for_council: true, health: { status: 'active', since: 'x' }, signed_in: false },
   ];
 
-  it('excludes the failed seat, puts signed-in first, labels signed-out as "will be benched", inactive last', () => {
+  it('excludes the failed seat, puts signed-in first, hedges a seat with no sign-in observed, inactive last', () => {
     const out = reassignCandidates(['codex', 'pi', 'opencode', 'agy', 'claude'], 'codex', ROSTER);
     expect(out.map((c) => c.cli)).toEqual(['claude', 'agy', 'pi', 'opencode']);
     expect(out[0]).toMatchObject({ label: 'Claude Code', state: 'ready', note: '' });
     expect(out[1]).toMatchObject({ label: 'agy', state: 'unknown', note: '' });
-    expect(out[2]).toMatchObject({ label: 'pi', state: 'signed-out', note: 'signed out — will be benched' });
+    // Today's roster carries no council-eligibility field, so the consequence is hedged.
+    expect(out[2]).toMatchObject({ label: 'pi', state: 'signed-out', note: 'no sign-in observed — may fail or be benched' });
+    expect(out[2]!.note).not.toMatch(/will be benched/);
     expect(out[3]).toMatchObject({ label: 'OpenCode', state: 'inactive', note: 'inactive: quota' });
+  });
+
+  it('reads crew#533\'s auth / council_eligible (api-types 0.35.0) when a daemon sends them — believed, not inferred', () => {
+    const seat = (extra: Record<string, unknown>): RosterSeat =>
+      ({ key: 'x', display_name: 'X', binary: 'x', enabled_for_council: true, health: { status: 'active', since: 'x' }, signed_in: false, ...extra });
+    expect(seatStanding(seat({ auth: 'not_required', free_tier: 'OpenCode Zen' }))).toEqual({ state: 'ready', note: 'no sign-in needed (OpenCode Zen)' });
+    expect(seatStanding(seat({ auth: 'signed_out', council_eligible: false, council_ineligible_reason: 'signed out' })))
+      .toEqual({ state: 'ineligible', note: 'signed out' });
+    expect(seatStanding(seat({ auth: 'signed_out', council_eligible: true })))
+      .toEqual({ state: 'signed-out', note: 'no sign-in observed — still council-eligible' });
+    expect(seatStanding(seat({ auth: 'signed_in' }))).toEqual({ state: 'ready', note: '' });
+    expect(seatStanding(seat({ auth: 'unknown', signed_in: null }))).toEqual({ state: 'unknown', note: '' });
+    // Inactive health outranks every auth reading.
+    expect(seatStanding(seat({ auth: 'signed_in', health: { status: 'inactive', message: 'quota', since: 'x' } }))).toEqual({ state: 'inactive', note: 'inactive: quota' });
+    expect(seatStanding(undefined)).toEqual({ state: 'unknown', note: '' });
+    // Ordering: an ineligible seat sorts last.
+    const out = reassignCandidates(['a', 'b'], null, [
+      seat({ key: 'a', display_name: 'A', council_eligible: false, council_ineligible_reason: 'signed out' }),
+      seat({ key: 'b', display_name: 'B', signed_in: true }),
+    ]);
+    expect(out.map((c) => c.cli)).toEqual(['b', 'a']);
   });
 
   it('a cold roster offers the pool by key, unlabelled — never an invented state', () => {

--- a/tests/narrator.test.ts
+++ b/tests/narrator.test.ts
@@ -40,6 +40,13 @@ describe('narrate — the event → status-line templates (§4)', () => {
     [{ type: 'awaitingHuman', session: 'r', ord: 3, prompt: 'Approve the design phase? [internals]' }, 'Gate: waiting on you — Approve the design phase?', 'gate'],
     [{ type: 'gateEvaluated', session: 'r', ord: 2, combined: true }, 'Checks ran on phase-2 — pass', 'work'],
     [{ type: 'gateEvaluated', session: 'r', ord: 2, combined: false, denialReason: 'no tests' }, 'Checks ran on phase-2 — deny: no tests', 'fail'],
+    // F-7R2-017: "Checks ran" only when the frame says a floor ran. An explicit `hasDeterministicFloor:
+    // false` with no judge and no policy is a default-allow — said as such, never as checks.
+    [{ type: 'gateEvaluated', session: 'r', ord: 2, combined: true, hasDeterministicFloor: true, agentVerdict: 'pass' }, 'Checks ran on phase-2 — pass', 'work'],
+    [{ type: 'gateEvaluated', session: 'r', ord: 2, combined: true, hasDeterministicFloor: false, agentVerdict: null, evaluatorPolicies: [] }, 'Gate passed without checks on phase-2 (ungated)', 'info'],
+    [{ type: 'gateEvaluated', session: 'r', ord: 2, combined: true, hasDeterministicFloor: false, agentVerdict: 'pass', judgeCli: 'codex' }, 'Judge passed phase-2 — no repository checks ran', 'work'],
+    [{ type: 'gateEvaluated', session: 'r', ord: 2, combined: true, hasDeterministicFloor: false, agentVerdict: null, evaluatorPolicies: ['POL-1'] }, 'Evaluator policy passed phase-2 — no repository checks ran', 'work'],
+    [{ type: 'gateEvaluated', session: 'r', ord: 2, combined: false, hasDeterministicFloor: false, denialReason: 'Worker FAILED on unit 2' }, 'Gate denied on phase-2: Worker FAILED on unit 2 — no repository checks ran', 'fail'],
     [{ type: 'gateDecided', session: 'r', ord: 2, allow: true }, 'Gate: approved', 'work'],
     [{ type: 'gateDecided', session: 'r', ord: 2, allow: false }, 'Gate: denied', 'fail'],
     [{ type: 'unitReworkAmended', session: 'r', ord: 2, amendment: 'focus on x' }, 'You amended phase-2 — re-dispatching with your note', 'human'],


### PR DESCRIPTION
## Wave 5 (PR C) — Reassign on the failure-escalation gate, the verdict block keyed on the gate's unit, honest gate narration (phase7-r2 findings)

Branched from `main`; disjoint from #259 and #260 (either order lands).

| Finding | What the operator saw | Fix |
|---|---|---|
| **F-7R2-007** (HIGH) | At each "Unit N failed and triage escalated" gate: Approve (retry on the SAME dead seat — it looped), Approve + steer, Reject, Cancel. Recovery was `POST /api/v1/runs/:id/reassign {cli}` by hand, five times, racing the ~20 s re-dispatch window | New `ReassignControl` on **both** gate cards (`SteeringGate` on the run page via `ApprovalDock`, and the landing inbox's `GateActionCard`): the run's OTHER seats (`session.clis` minus `units[ord].assigned_cli`, the seat that failed) with the roster's word on each — signed-in first, seats the roster cannot vouch for next, signed-out labelled **"signed out — will be benched"**, inactive last (`reassignCandidates`; roster from the shared cache, one `GET /roster` when cold). One action — **Reassign to <seat> + retry** — runs the sequence the daemon requires: `POST /runs/:id/gate {approve:true[, amend]}` (the steer text rides it) → `GET /runs/:id` until `executing` (bounded, 24 polls) → `POST /runs/:id/reassign {cli}` (`api.reassignRun`, crew#442). Every step is stated (`steering-reassign-status`); a refused reassign leaves the approve standing, shows the daemon's sentence (`steering-reassign-error`) and offers **reassign again** alone; a run that ends before it resumes is said. Plain Approve is relabelled **"Approve (retry on <seat>)"** with a hover that names it as the seat that just failed. Recorded on the steering timeline as `reassign` (with the seat). Not offered on a deliver-lift escalation (a LIFT-CONFLICT is the lift block's story — another seat cannot fix a rebase conflict). |
| **F-7R2-018** (LOW) | The `gate-verdict` block on "Unit 3 failed and triage escalated" showed unit 2's vacuous pass ("Evaluator verdict — build · UNGATED") — a card about unit 3 | `gateVerdictFor(events, ord, prompt)`: the bounded lookup (studio #252) PLUS, for an escalation gate ("Unit N failed and triage escalated" / "Unit N verdict is NOT PASS"), only unit N's **own** evaluation; none for that unit ⇒ no block. A pre-run gate ("Approve unit N before it runs") keeps the previous phase's verdict — that is what the operator approves (F-3R2-006, unchanged). Both cards use it. One existing assertion in `SteeringGate.wire433.test.tsx` pinned the misattribution on the deliver escalation ("the deciding evaluation is still the ord-4 PASS") and is updated to the new rule; the lift block there is untouched. |
| **F-7R2-017** (LOW) | Every vacuous gate narrated "Checks ran on build — pass" with zero `repoChecksEvaluated` in the run | The narrator says "Checks ran" only when the frame says a floor ran (`hasDeterministicFloor: true`). An explicit `false` reads **"Gate passed without checks on <phase> (ungated)"** (no judge, no policy), "Judge passed <phase> — no repository checks ran", or "Evaluator policy passed <phase> — no repository checks ran"; a denial without a floor reads "Gate denied on <phase>: … — no repository checks ran". A frame without the field (an older engine) keeps the legacy wording — nothing inferred. |

### Wire gap recorded (F-7R2-007)
`POST /runs/:id/reassign` refuses a run that is not `executing` (409 — `wicked-crew/packages/crew/src/api/routes.ts`, read-only), so the approve must precede it and the window between the two is the engine's re-dispatch of the dead seat. Letting the route target an `awaiting_human` run (reassign-then-approve, or reassign-as-the-approval) would make this one call and remove the wait; the control's sequence collapses to a single POST when that lands. The frames carry no `previousCli` before the reassign either — the failed seat is read off the unit snapshot (`assigned_cli`).

### Tests
`tests/gateVerdictModel.escalation.test.ts` (escalation prompt parse, `gateVerdictFor` on the recorded G4/G5 gates + the phase7 shape, `isFailureEscalation`, `reassignCandidates` order/labels/cold roster), `tests/SteeringGate.reassign.test.tsx` (no unit-2 verdict under the unit-3 card; seat list + labels; approve → wait → reassign → gate resolved + steering entry; refused reassign keeps the approve and retries alone; terminal run said; no lever on a pre-run gate / without the pool / empty pool), `tests/CenterDashboard.reassign.test.tsx` (the inbox card: same rule, same lever, drives approve → reassign), `tests/narrator.test.ts` gains five floor/no-floor cases. `testid-inventory.json` regenerated.

Gates, each on its own: `npm run lint` ✓ · `npm run typecheck` ✓ · `npm test` ✓ · `npm run build` ✓.

No version bump; CHANGELOG bullets under Unreleased. Does not touch the Skills surface (#257 stays disjoint).

### Independent review (verdict: APPROVE with LOWs — all addressed in the bundled follow-up commit)
- **F1 (LOW) "will be benched" / "a council benches it"** — hedged to the observation and a hedged consequence: the candidate note reads "no sign-in observed — may fail or be benched", the picker hint says the retry "may fail at spawn or be benched there; a provider free tier may still answer (the roster cannot tell yet)". New `seatStanding()` reads crew#533's `auth` / `council_eligible` / `council_ineligible_reason` / `free_tier` (api-types 0.35.0) off the seat when a daemon sends them — a daemon-declared ineligible seat sorts last with the daemon's reason, `not_required` reads "no sign-in needed (<tier>)" — and falls back to the hedged words otherwise. Same words as #260.
- **F2 (LOW) attribution keyed on ord, not attempt** — `GateVerdictView.attempt` is the `attempt` of the nearest `unitDispatched` for the ord before the evaluation (`attemptBefore`); `gateVerdictFor` drops a verdict whose attempt is not the unit's latest dispatch on an escalation gate (attempt-0 denial under an attempt-1 escalation → no block; attempt 1's own later verdict → shown). `data-phase-attempt` on the block. Pinned in `gateVerdictModel.escalation.test.ts`.
- **F3 (LOW) two hosts pass no `clis`** — `SteeringAuthorPanel` / `TestingLaunchPanel` hold only the run id + gate, so `SteeringGate` now reads `GET /runs/:id` once for the seat pool when — and only when — the gate is a failure escalation the lever applies to (zero reads on every other gate; a failed read offers no lever). Pinned in `SteeringGate.reassign.test.tsx`.
- **F4 (NIT)** — resume wait 60 × 500 ms = 30 s; `void cli` removed; the narrator's "older engine" comment reworded (the type declares the field required; a frame lacking it reads the legacy wording).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
