### PR TITLE
chore(release): 0.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ npm publish dates. Every version listed here exists on
 [npm](https://www.npmjs.com/package/wicked-studio?activeTab=versions).
 
 ## [Unreleased]
+
+## [0.5.6] — 2026-09-11
+_The published bundle is built against `wicked-crew-api-types` **0.34.0** — the exact
+devDependency pin on this cut, and the wire the bundle's mirrors and `satisfies` checks are typed
+against. The crew#533 roster fields named below (`auth` / `free_tier` / `council_eligible` /
+`council_ineligible_reason`, api-types 0.35.0) are read defensively when a daemon sends them;
+the pin itself moves in a later release._
 ### Added
 - **Reassign to <seat> + retry on a failure-escalation gate** (phase7-r2 acceptance finding
   F-7R2-007, HIGH). At every "Unit N failed and triage escalated" gate the card offered Approve — a
@@ -841,7 +848,8 @@ The merged interactive layer: wicked-interactive's UI moved into this skin (DES-
   `git subtree split` (92 commits).
 - The SPA as a pure HTTP/WS client of the wicked-crew daemon: runs, gates, live CoreEvents.
 
-[Unreleased]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.5...HEAD
+[Unreleased]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.6...HEAD
+[0.5.6]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.5...v0.5.6
 [0.5.5]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.4...v0.5.5
 [0.5.4]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.3...v0.5.4
 [0.5.3]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.2...v0.5.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-studio",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-studio",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "^5.56.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-studio",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "The coder-facing skin of the wicked experience plane — a pure HTTP/WS client of the wicked-crew daemon's /api/v1",
   "type": "module",
   "repository": {

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -8,7 +8,7 @@
     "Entry kinds: `static` values appear verbatim in the DOM; `dynamic` are template-literal testids with each ${expr} normalised to '*'; `computed` carry the raw JSX expression — dynamic/computed resolve only against a live DOM."
   ],
   "version": 1,
-  "studioVersion": "0.5.5",
+  "studioVersion": "0.5.6",
   "counts": {
     "files": 144,
     "occurrences": 1259,


### PR DESCRIPTION
Version PR for the operator-approved wave-4/5 release train (2026-09-11). On merge, `v0.5.6` is tagged on the merge commit and `release.yml` publishes to npm and creates the GitHub Release.

## What ships (`main` @ 89214f6 since 0.5.5)

- #255 — the wicked-core#431 wire on the gate card (judge seat / `judgeDistinct`), the denial card (restored tree + copyable `git show refs/wicked/suggestions/…`), the delivery card / deliver gate (lift outcomes, red-check stderr/stdout tails), the run head (`base`) and the feed.
- #257 — Skills page: a badge per KIND of portability reason (`skills-not-portable-badge` / `skills-needs-claude-badge`) and the claude-only KPI split (F-079; reads `SkillEntry.portability` from api-types 0.34.0, crew#531).
- #261 — Reassign to <seat> + retry on a failure-escalation gate (F-7R2-007); the gate card's verdict block keyed on THIS gate's unit (F-7R2-018); narration never says "Checks ran" without a floor (F-7R2-017).
- #260 — repo readiness honesty (graph missing → re-run onboarding, F-2R2-003 / -004), Build project graph (F-2R2-008), honest signed-out seats in the Health rail (F-2R2-009).
- #259 — document thread hardening: per-format export readiness (F-4R2-016), folded heartbeats (-005), reload restore (-006), a human floor-failure card with Retry (-014), a name field before Create (-003).

## Changes in this PR

- `package.json` 0.5.5 → 0.5.6 (`npm version --no-git-tag-version`); `package-lock.json` — the two root `version` fields only, every dependency resolution unchanged.
- `testid-inventory.json` re-stamped with `npm run manifest:testids` — `studioVersion` 0.5.5 → 0.5.6 is the only change (1082 static · 59 dynamic · 7 computed testids across 144 files, 1259 declaration sites — exactly as #259 left it). TH-13 asserts the stamp equals the package version, so the bump alone fails `npm test`; the regenerated artifact rides here as the inventory's own drift rule requires.
- `CHANGELOG.md`: `[Unreleased]` → `[0.5.6] — 2026-09-11` (an empty `[Unreleased]` kept above) with every bullet kept — Added (reassign control; judge seat / restored tree / lift / run base wire), Changed (skills badges per reason), Fixed (document thread hardening, repo readiness, gate attribution, narrator) — plus a note under the heading naming the api-types version the bundle is built against, the `[0.5.6]` link-ref, and the `[Unreleased]` compare base retargeted to `v0.5.6`. The entries were authored in their PRs; this PR only cuts the heading.

## Contract pin — unchanged by this PR

`wicked-crew-api-types` stays the exact `0.34.0` that #257 pinned. The crew#533 roster fields (`auth` / `free_tier` / `council_eligible` / `council_ineligible_reason`, api-types 0.35.0) are read defensively by #260 / #261 when a daemon sends them; the pin itself moves in a later cut once that wire is published.

## Gates (fresh clone of `main` @ 89214f6 + this commit)

- `npm ci` — ok (installed `wicked-crew-api-types` 0.34.0); tree clean afterwards
- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm test` — 282 files, 3035 tests passed, 0 errors
- `npm run build` — ok (the pre-existing chunk-size warning); `dist/index.html` present, `dist/assets/index-*.js` carries the `0.5.6` marker
- `python3 scripts/changelog-section.py v0.5.6` — exit 0, a 195-line body, so the release workflow's GitHub Release step will find the section
- Playwright e2e rigs not run (operator-run; host under heavy load) — CI's lint · typecheck · test · build is the gate on this PR
- privacy scrub of the commit and this body — 0 hits

## Downstream

Tag `v0.5.6` on the merge commit → `release.yml` publishes `wicked-studio@0.5.6` (tokenless OIDC, provenance, registry probe) and cuts the GitHub Release from the CHANGELOG section; wicked-crew 0.7.30 then bumps its `wicked-studio` devDependency to `^0.5.6` so `build:with-studio` bundles this skin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
