### PR TITLE
chore(wire): pin wicked-crew-api-types 0.36.0 and re-vendor the skills + wave-6 mirrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,27 @@ npm publish dates. Every version listed here exists on
     accept `PLAYWRIGHT_CHANNEL` (e.g. `chrome`) to run on an installed browser when the Playwright
     cache is absent (review R2-6 — a rig never installs anything); testid inventory regenerated.
 
+### Changed
+- **Pin `wicked-crew-api-types` 0.36.0** (the wave-6 wire, crew#536; `skills.stale-rules`, crew#535) and
+  re-vendor BOTH wire mirrors from the installed `index.d.ts`. The skills mirror + fixture
+  (`tests/fixtures/api-types-0.36.0-skills.d.ts`, `index.d.ts:1969-2419` / `4682-4741`) carry the
+  ADDITIVE block: `SkillsManifestResponse.current.rules` / `drift`, `PortabilityRulesIdentity`,
+  `SnapshotRowDrift`, the `skills.stale-rules` finding kind. The wave-6 mirror (`src/api/wave6-wire.ts`)
+  drops its PROVISIONAL declarations for 14 VERBATIM regions byte-pinned by `tests/wave6Wire.test.ts`
+  against the installed package: `POST /testing/author` (`TestingAuthorBody` / `TestingAuthorResponse`
+  with `runs[]`, `plan`, `gate`, `scope`; the registered `TestSet`), `CampaignsListResponse.test_sets`,
+  `RunDiff.source` / `branch` / `base`, `gateEvaluated.ungated` / `ungatedReason` / `floorNote` /
+  `judgeSkippedReason`, `repoChecksEvaluated.sandboxLevel` / `sandboxError` / `detectError`,
+  `unitDistributed` camelCase (`seatConstraint` included), `workerToolCallDenied` (`carrier` / `role` /
+  `tool`), the `acpFallback` auth kinds, `runBaseResolved.runBranch`, the roster's `auth` /
+  `auth_source` / `free_tier_source` / `council_eligible` / `council_bench`, chat `refused[]`, the
+  `GET /interactive/docs` rows. The `unitDistributed` snake_case fallbacks (`agreement_pct`,
+  `degraded_reason`) are dropped — 0.36.0 declares them `@deprecated`; the engine never emitted them.
+  Two WIRE GAPS stay studio-worded and test-guarded: a row-level `Campaign.test_set` /
+  `RunGroup.test_set` join (0.36.0 serves the sets as top-level `test_sets: TestSet[]`, so the Test
+  landing's per-card counts render only when a daemon joins the row) and `TestingReconBody.workflow`
+  (the launch ladder's middle rung; a 0.36.0 daemon answers the first rung, `POST /testing/author`).
+
 ## [0.5.6] — 2026-09-11
 _The published bundle is built against `wicked-crew-api-types` **0.34.0** — the exact
 devDependency pin on this cut, and the wire the bundle's mirrors and `satisfies` checks are typed

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "typescript-eslint": "^8.63.0",
         "vite": "^6.4.3",
         "vitest": "^3.2.6",
-        "wicked-crew-api-types": "0.35.0"
+        "wicked-crew-api-types": "0.36.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -7146,9 +7146,9 @@
       }
     },
     "node_modules/wicked-crew-api-types": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/wicked-crew-api-types/-/wicked-crew-api-types-0.35.0.tgz",
-      "integrity": "sha512-rTVcWBI7G3/i0ASs7fW/zz9AxJBFwjNz1B97pD9ngh82DZ9tCDJjG9gLFJFkgoFGY5uG+AoyCaqVWF2+5bGYdg==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/wicked-crew-api-types/-/wicked-crew-api-types-0.36.0.tgz",
+      "integrity": "sha512-Up3DT3A95w3VeFiG3vPzz7jjrwiZS4VtiAJq5QZ4nUagpROh5zjA782o7vhxUyMDqBO0hZGPSZzDngfdI7LgPw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "typescript-eslint": "^8.63.0",
     "vite": "^6.4.3",
     "vitest": "^3.2.6",
-    "wicked-crew-api-types": "0.35.0"
+    "wicked-crew-api-types": "0.36.0"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/src/api/skills-wire.ts
+++ b/src/api/skills-wire.ts
@@ -1,5 +1,5 @@
 /**
- * MIRROR of wicked-crew-api-types 0.35.0 skills block (crew#531) — replace with imports from the
+ * MIRROR of wicked-crew-api-types 0.36.0 skills block (crew#531, crew#535) — replace with imports from the
  * published package at release.
  *
  * Studio pins `wicked-crew-api-types` exactly; the skills contract lives in the package's skills
@@ -7,16 +7,19 @@
  * two regions copied VERBATIM from the package's `index.d.ts` between the `>>> VERBATIM` /
  * `<<< VERBATIM` markers. Nothing inside a marked region is studio's wording, and nothing may be
  * edited there: `tests/skillsWire.test.ts` pins each region byte-for-byte against the vendored
- * fixture `tests/fixtures/api-types-0.35.0-skills.d.ts`, so any drift — a hand edit here, or a
+ * fixture `tests/fixtures/api-types-0.36.0-skills.d.ts`, so any drift — a hand edit here, or a
  * re-vendored fixture from a re-minted contract — fails the suite until both sides agree again.
  *
- * 0.35.0 (crew#533) carries the 0.34.0 skills block UNCHANGED — byte-identical, shifted by the wave-5 roster
- * and chat additions above it — so this mirror is re-vendored by label only (line ranges). 0.34.0 (F-079,
- * crew#531, published by PR #532) is ADDITIVE over the 0.33.0 block: `SkillPortabilityReason`
- * + `SkillPortability` and the optional `SkillEntry.portability` — the publisher's per-reason
- * verdict (five authoring reasons an author can fix, plus `requires-harness:claude`) with
- * `<file>:<line>` evidence. `portable` stays the admission key core reads; an older daemon simply
- * omits the field and every reader falls back to `portable` alone.
+ * 0.36.0 (F-083, crew#535, published by crew#536) is ADDITIVE over the 0.35.0 block:
+ * `SkillsManifestResponse.current` grows the optional `rules` (`PortabilityRulesIdentity` recorded vs
+ * running, `stale`) and `drift` (`SnapshotRowDrift[]` — the rows the RUNNING rules derive
+ * differently), and `DiagnosticsSkillsFinding.kind` gains `skills.stale-rules` — a `warning`: the
+ * current generation was published under other portability rules and is ACCEPTED, never refused.
+ * 0.35.0 (crew#533) carried the 0.34.0 skills block unchanged; 0.34.0 (F-079, crew#531, published by
+ * PR #532) added `SkillPortabilityReason` + `SkillPortability` and the optional
+ * `SkillEntry.portability` — the publisher's per-reason verdict (five authoring reasons an author can
+ * fix, plus `requires-harness:claude`) with `<file>:<line>` evidence. `portable` stays the admission
+ * key core reads; an older daemon simply omits the field and every reader falls back to `portable` alone.
  *
  * THE RELEASE SWAP: replace the body of this file with `export type { … } from
  * 'wicked-crew-api-types';` for every name below, delete the fixture + pin test, and nothing else
@@ -28,7 +31,7 @@
  * is EXCLUSIVELY a stale `expectedRevision`.
  */
 
-// >>> VERBATIM wicked-crew-api-types@0.35.0 index.d.ts:1768-2186 (crew#531 via PR #532) — the skills block
+// >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:1969-2419 (crew#535 via crew#536) — the skills block
 // ── Skills — the daemon-owned garden plugin root, published as immutable snapshots (api-types 0.28.0) ──
 //
 // api-types 0.29.0 (design amendment v3.6, crew #490): the installer-managed copy
@@ -226,8 +229,40 @@ export interface SkillsManifestResponse {
   root: string;
   /** The VERIFIED published snapshot `current` resolves to, or `null` before the first publish.
    *  `path` is the absolute REAL path of `snapshots/<gen>` — byte-identical to the one input the
-   *  engine is handed (`WICKED_SKILLS_SNAPSHOT`; design v3.1 §2). */
-  current: { gen: number; path: string } | null;
+   *  engine is handed (`WICKED_SKILLS_SNAPSHOT`; design v3.1 §2). `rules` / `drift` (api-types
+   *  0.36.0, F-083 / crew#535) ride beside it on a daemon ≥ 0.7.30 — absent on an older one. */
+  current: {
+    gen: number;
+    path: string;
+    /** The portability rules the generation was published under vs the rules this daemon runs:
+     *  `recorded` is `null` for a generation predating the identity (0.7.29 and earlier);
+     *  `stale: true` = they differ and the daemon raised `skills.stale-rules`. */
+    rules?: {
+      recorded: PortabilityRulesIdentity | null;
+      running: PortabilityRulesIdentity;
+      stale: boolean;
+    };
+    /** The rows whose portability derives differently under the running rules than the snapshot
+     *  recorded — the `skills.stale-rules` warning names up to five; the list carries the rest.
+     *  `recorded.reasons` is `null` for a row written before per-reason portability (0.34.0). */
+    drift?: SnapshotRowDrift[];
+  } | null;
+}
+
+/** The identity of a portability-rule table (api-types 0.36.0, F-083): its version and the
+ *  sha256 of the committed parity fixture (`tests/fixtures/portability_rules.json`). */
+export interface PortabilityRulesIdentity {
+  version: number;
+  sha256: string;
+}
+
+/** One snapshot row whose portability the RUNNING rules derive differently than the snapshot
+ *  recorded (api-types 0.36.0, F-083) — see `SkillsManifestResponse.current.drift`. */
+export interface SnapshotRowDrift {
+  name: string;
+  recorded: { portable: boolean; reasons: SkillPortabilityReason[] | null };
+  /** What the RUNNING rules derive for the row — the same per-reason shape `SkillEntry.portability` carries. */
+  derived: SkillPortability;
 }
 
 export interface SkillFileEntry {
@@ -450,7 +485,7 @@ export interface ReplaceSkillBody {
 }
 // <<< VERBATIM
 
-// >>> VERBATIM wicked-crew-api-types@0.35.0 index.d.ts:4223-4272 (crew#531 via PR #532) — the diagnostics skills block
+// >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:4682-4741 (crew#535 via crew#536) — the diagnostics skills block
 /** The skills seam's state as `GET /diagnostics` reports it (skills keystone, api-types 0.28.0). */
 export type DiagnosticsSkillsState = 'published' | 'fallback' | 'blocked' | 'config-error' | 'disabled';
 
@@ -470,8 +505,18 @@ export interface DiagnosticsSkillsFinding {
    *  (`error`, api-types 0.29.0) = `manifest.json` could not be read when diagnostics were taken
    *  (corrupt, unreadable, or the root no longer the one the store bound) — reported as
    *  `config-error` with the cause instead of the stale boot outcome; the exported engine input is
-   *  unchanged until the daemon restarts. */
-  kind: 'skills.fallback' | 'skills.blocked' | 'skills.config' | 'skills.source' | 'skills.manifest';
+   *  unchanged until the daemon restarts; `skills.stale-rules` (`warning`, api-types 0.36.0, F-083 /
+   *  crew#535) = the CURRENT generation was published under OTHER portability rules than the daemon
+   *  now runs — accepted (the snapshot is never rewritten; the runtime stays `published`), the rows
+   *  that now derive differently are named (`SkillsManifestResponse.current.drift`), and a publish
+   *  records the running rules and clears it. */
+  kind:
+    | 'skills.fallback'
+    | 'skills.blocked'
+    | 'skills.config'
+    | 'skills.source'
+    | 'skills.manifest'
+    | 'skills.stale-rules';
   severity: 'warning' | 'error';
   message: string;
 }

--- a/src/api/wave6-wire.ts
+++ b/src/api/wave6-wire.ts
@@ -1,198 +1,843 @@
 /**
  * MIRROR of the wicked-crew-api-types 0.36.0 wave-6 additions (the governed testing journey —
- * wicked-crew `feat/qe-test-authoring-workflow`, wicked-core `feat/governed-testing-floor-and-fence`)
- * — replace with imports from the published package at release.
+ * crew#536, the wave-6 crew PR; `skills.stale-rules` from crew#535) — replace with imports from the
+ * published package at release.
  *
- * PROVISIONAL: 0.36.0 is not published while this file is written. Every name below is spelled
- * EXACTLY as the wave-6 briefs give it (camelCase as the engine's `event_to_json` emits), and
- * every reader in studio is null-safe, so an older daemon — 0.34.0/0.35.0, which sends none of
- * these keys — changes nothing. At the release swap the body becomes VERBATIM regions copied from
- * the package's `index.d.ts` between `>>> VERBATIM` / `<<< VERBATIM` markers, pinned byte-for-byte
- * by `tests/wave6Wire.test.ts` against a vendored fixture AND the installed package (the
- * `skills-wire.ts` / `tests/skillsWire.test.ts` pattern from #257). Until then that test asserts
- * the pin is BELOW 0.36.0 and this header still says PROVISIONAL — a pin bump without the
- * re-vendor fails the suite.
+ * Studio pins `wicked-crew-api-types` exactly (0.36.0). Every declaration below that is a contract
+ * shape is a region copied VERBATIM from the package's `index.d.ts` between `>>> VERBATIM` /
+ * `<<< VERBATIM` markers, labelled with the version and the 1-based line range it was cut from.
+ * Nothing inside a marked region is studio's wording, and nothing may be edited there:
+ * `tests/wave6Wire.test.ts` pins each region byte-for-byte against the INSTALLED package at the
+ * labelled range, so a hand edit here or a pin bump without a re-vendor fails the suite. The same
+ * shapes also reach studio through `./types.js` (`export type * from 'wicked-crew-api-types'`);
+ * this module is the pinned EVIDENCE of the wave-6 wire plus the null-safe readers every surface
+ * shares, one spelling per field.
  *
- * What the wave adds, and where studio reads it:
- *  - {@link QE_AUTHOR_TESTS_WORKFLOW_ID} — the drop-in workflow "New test" launches (recon → author →
- *    verify → review → deliver); studio reads its presence off `GET /workflows`, never assumes it.
- *  - {@link TestingAuthorBody} / {@link TestingAuthorResponse} — the launch route for THAT workflow
- *    (`POST /testing/author`; the recon body grows an additive `workflow` too). `workflow` on the
- *    answer echoes what the daemon launched.
- *  - {@link TestSetRegistration} — the produced test set a completed `qe-author-tests` run registers
- *    on the campaigns surface (`Campaign.test_set` / `RunGroup.test_set`, daemon-joined like
- *    `node_delivery`), with the counts the verify phase RE-DERIVED (executed / passed / failed) —
- *    never the author's claim.
- *  - {@link RunDiffSource} — `GET /runs/:id/diff` answers 200 with `source: "branch"` (the run branch
- *    vs its base) once the worktree is gone, instead of 409.
- *  - {@link GateEvaluatedUngated} — `gateEvaluated.ungated` / `ungatedReason`: the engine SAYS no
- *    judge seat could be convened ("no eligible judge seat"), so the card reads UNGATED, not pass.
- *  - {@link UnitDistributedWave6} — `unitDistributed.degradedReason` (+ the camelCase twins of the
- *    snake_case names 0.34.0 declared: `agreementPct`, `seated`, `routingMethod`): why the council
- *    was smaller than configured ("4 of 5 seats benched: …").
- *  - {@link WorkerToolCallDeniedEvent} — a creator/evaluator seat asked for a REMOTE WRITE
- *    (`git push`, `gh pr create`, …) and the fence refused it; `remedy` says delivery is the run's
- *    deliver phase's job.
+ * What the wave adds, region by region:
+ *  - `POST /testing/author` — {@link TestingAuthorBody} / {@link TestingAuthorResponse} (+ the
+ *    {@link WorkflowPlan} the intake gate renders, {@link TestingAuthorRun}) and the registered
+ *    {@link TestSet} the daemon serves as `CampaignsListResponse.test_sets`. {@link TestingReconBody}
+ *    is vendored beside them as evidence that the recon body carries NO `workflow` key (see the wire
+ *    gaps below).
+ *  - `GET /runs/:id/diff` — {@link RunDiff}`.source` (`worktree` | `branch`), `branch`, `base`.
+ *  - `gateEvaluated` — {@link GateEvaluatedEvent}`.ungated` / `ungatedReason` / `floorNote` /
+ *    `judgeSkippedReason`.
+ *  - `repoChecksEvaluated` — {@link RepoChecksEvaluatedEvent}`.sandboxLevel` / `sandboxError` /
+ *    `detectError`.
+ *  - `unitDistributed` — {@link UnitDistributedEvent} spelled camelCase as the engine emits it
+ *    (`routingMethod`, `agreementPct`, `seated`, `degradedReason`, `seatConstraint`); the snake_case
+ *    names are `@deprecated` aliases the engine never emitted, and the readers below no longer read
+ *    them. {@link BenchedSeat} rides with it.
+ *  - `workerToolCallDenied` — {@link WorkerToolCallDeniedEvent} incl. `carrier`, `role`, `tool`.
+ *  - `acpFallback` — {@link AcpFallbackKind} grows the auth kinds `auth_failed` / `unauthenticated`.
+ *  - `runBaseResolved` — {@link RunBaseResolvedEvent}`.runBranch`.
+ *  - `GET /roster` — {@link RosterSeat}`.auth` / `auth_source` / `free_tier_source` /
+ *    `council_eligible` / `council_bench` ({@link RosterSeatCouncilBench}, {@link SeatAuth}).
+ *  - `POST /chats` / `GET /chats/:id` — {@link ChatSeatRefusal}`.source` ({@link ChatRefusalSource}),
+ *    `refused[]` on {@link ChatOpenResponse} and {@link ChatDetailResponse}.
+ *  - `GET /interactive/docs` — {@link InteractiveDocsListing} rows ({@link InteractiveDocIndexRow}).
+ *  - `skills.stale-rules` + `SkillsManifestResponse.current.rules` / `current.drift` live in the
+ *    SKILLS block and are vendored by `./skills-wire.ts` (its own byte-pinned regions), not here.
+ *
+ * WIRE GAPS — two shapes studio codes against are NOT declared by 0.36.0 and stay studio-worded at
+ * the bottom of this file, each guarded by `tests/wave6Wire.test.ts` so the day the package
+ * declares them the suite says "re-vendor": (1) a row-level `Campaign.test_set` / `RunGroup.test_set`
+ * join ({@link TestSetRegistration}) — 0.36.0 serves the produced sets as a separate top-level
+ * `CampaignsListResponse.test_sets: TestSet[]` (snake_case, `run_id`-keyed), so the Test landing's
+ * per-card counts render only when a daemon joins the row; (2) `TestingReconBody.workflow`
+ * ({@link TestingReconWorkflowBody}) — the launch ladder's middle rung; a 0.36.0 daemon has
+ * `POST /testing/author` itself, so the rung is reached only on a daemon that lacks the route.
  */
 
-import type { CoreEvent, RunDiff } from './types.js';
+import type {
+  Campaign,
+  ChatScope,
+  CoreEvent,
+  PhaseRole,
+  RepoCheckRun,
+  RunGroup,
+  SeatHealth,
+  SessionStatus,
+  StageKindPhase,
+  UnitDenial,
+} from './types.js';
 
-// ── The QE authoring workflow ─────────────────────────────────────────────────────────────────
+// ── The QE authoring workflow — `POST /testing/author`, the plan, the registered test set ──────
 
-/** The drop-in workflow id "New test" launches (wave 6). Read off `GET /workflows` — a daemon that
- *  does not list it has no governed test workflow, and the panel says so before launching. */
-export const QE_AUTHOR_TESTS_WORKFLOW_ID = 'qe-author-tests';
+// >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:2801-2941 (crew#536) — the governed test-authoring launch: QeAuthorTestsWorkflowId, TestingAuthorBody, WorkflowPlanPhase, WorkflowPlan, TestingAuthorRun, TestingAuthorResponse, TestSetFile, TestSet
+// ── The governed test-authoring launch (wave 6; api-types 0.36.0) ──────────────────────────────
 
 /**
- * `POST /testing/author` body — launch the `qe-author-tests` workflow with the operator's intent as
- * the problem statement. Every sibling pauses at its intake gate (`before:1`) by default; the intake
- * card shows the planned phases + seats.
- *
- * SCOPE SEMANTICS — a REQUIREMENT on the wave-6 crew PR, NOT the recon route's union (independent
- * review of #263, R2-1): `repoRefs` WITH `projectId` is the EXACT set of repositories to launch over
- * — `projectId` FILES the runs into the project and never adds its other members back in. That is
- * what lets a narrowed project ("attach the project, drop repos", F-076) launch in ONE call with the
- * engine's own deliver phase. `repoRefs` alone = those repos, unfiled; `projectId` alone = every
- * member, filed (as today). Studio guards the answer: a route that returns more `runIds` than repos
- * requested did not honour the narrowing, and the panel says so instead of claiming the scope.
+ * The id of the governed test-authoring workflow the daemon serves (`GET /workflows` lists it, not
+ * `is_system` — an operator-selectable work mode): recon (`wicked-garden-qe` plan) → author
+ * (creator, evidence-floor pinned, `wicked-garden-qe` author) → verify (a TOOL phase that RUNS every
+ * produced test under the repository's own harness — vitest/jest/pytest/Playwright — and FAILS the
+ * unit when one fails or was never executed) → review (evaluator ≠ creator, `wicked-garden-qe`
+ * review) → the ENGINE's deliver phase (appended per run; never a worker's `gh pr create`).
+ * F-7R2-003/004/005/012/014/015 + acceptance R4-r2.
+ */
+export type QeAuthorTestsWorkflowId = 'qe-author-tests';
+
+/**
+ * Body of `POST /testing/author` — the Testing page's "New test". Same scope wire as
+ * {@link TestingReconBody} (`repoRefs` and/or `projectId`, resolved server-side), but the scope
+ * MUST resolve to ≥ 1 repo (a test-authoring run writes into a repository; an unscoped author is a
+ * 400). One governed `qe-author-tests` run per resolved repo, each filed under the repo's
+ * `qe-tests-<repo name>` label group (`RunGroup` on `GET /campaigns`).
  */
 export interface TestingAuthorBody {
+  /** The operator's intent — what to test — verbatim; the run's problem statement. */
   problem: string;
+  /** The project to FILE the runs into. Alone: the scope is the project's `crew.repo` members. */
   projectId?: string;
+  /**
+   * The repos to author into (registry id or name). With `projectId`, THIS is the scope and the
+   * project is the filing only (a NARROWED project scope — studio #263 F-4): the runs are filed
+   * into the project without inheriting its other repo members, so a skin with repo chips names
+   * the repos and the project once instead of fanning one `POST /runs` per repo (one deliver/PR
+   * each). Unlike {@link TestingReconBody}, where both fields union. The 201 says which was used
+   * (`scope`).
+   */
   repoRefs?: string[];
-  /** EXPLICITLY launch unattended (no intake gate). Default `false`. */
+  /** EXPLICITLY launch unattended (no intake gate). Default `false`: each run pauses at its intake
+   *  gate (`before:1`) with the plan on the table before any unit runs. */
   ungated?: boolean;
+  /** `pr` (default) — the ENGINE's deliver phase opens the PR; `none` — the tests stay on the run
+   *  branch (`delivery: 'stranded'` on the wire, liftable via `POST /runs/:id/deliver`). */
+  deliver?: 'pr' | 'none';
 }
 
-/** `POST /testing/author` 201 body — `TestingReconResponse` plus the workflow the daemon launched. */
+/** One planned phase as the intake gate shows it — derived from the workflow DEFINITION. */
+export interface WorkflowPlanPhase {
+  id: string;
+  kind: StageKindPhase;
+  role: PhaseRole;
+  executor: 'agent' | 'tool';
+  /** The garden skill the phase routes through (`wicked-garden-qe`), `null` for a tool phase. */
+  skillRef: string | null;
+  /** `auto` | `human` (unconditional confirm) | `human_if_not_pass` (a not-pass verdict escalates). */
+  gate: 'auto' | 'human' | 'human_if_not_pass';
+  executesCode: boolean;
+  /** `true` for the phase the ENGINE appends and owns (the deliver phase) — not in the def. */
+  engine?: boolean;
+}
+
+/** The plan the intake gate shows (F-7R2-008): the phases in order + the seats a council may
+ *  pick from (the launcher's eligible roster — benched seats excluded). */
+export interface WorkflowPlan {
+  workflow: string;
+  phases: WorkflowPlanPhase[];
+  seats: string[];
+}
+
+/** One launched authoring run and the label group it was filed under. */
+export interface TestingAuthorRun {
+  runId: string;
+  repoRef: string;
+  /** `qe-tests-<repo name>` — the `RunGroup.label` on `GET /campaigns`. */
+  label: string;
+}
+
+/**
+ * The `POST /testing/author` 201 body. `runIds` is the source of truth (one per resolved repo in
+ * the caller's order); `runId` is its first entry. `plan` is what the intake card renders before
+ * approval; `gate` says whether the runs paused there. `campaignRegistered` is always `false`: an
+ * author launch is filed as label groups, never an engine campaign (campaign nodes are
+ * engine-launched and would not receive the daemon's deliver composition).
+ */
 export interface TestingAuthorResponse {
   runId: string;
   runIds: string[];
-  campaign: string;
-  campaignRegistered: boolean;
-  /** The workflow id every launched run carries (`qe-author-tests`). */
-  workflow: string;
-  projectAttachError?: string;
+  workflow: QeAuthorTestsWorkflowId;
+  runs: TestingAuthorRun[];
+  gate: 'before:1' | 'none';
+  deliver: 'pr' | 'none';
+  plan: WorkflowPlan;
+  /** How the repos were chosen: `repoRefs` — the named repos (a `projectId`, when given, was the
+   *  filing only); `project` — the project's `crew.repo` members. Absent on a daemon predating it. */
+  scope?: 'repoRefs' | 'project';
+  campaignRegistered: false;
 }
 
-/** The additive `workflow` key on `TestingReconBody` (0.36.0): route the recon launch through a
- *  registered workflow instead of free-text planning. A pre-0.36 daemon's strict schema 400s it
- *  as an unrecognized key — the launch chain reads that refusal and falls back. */
-export interface TestingReconWorkflowBody {
-  problem: string;
-  projectId?: string;
-  repoRefs?: string[];
-  ungated?: boolean;
-  workflow?: string;
+/** One produced test file as the verify phase judged it. */
+export interface TestSetFile {
+  path: string;
+  /** `playwright` | `playwright-python` | `vitest` | `jest` | `pytest` | `python` | `unknown`. */
+  harness: string;
+  status: 'passed' | 'failed' | 'not-executed';
 }
 
-// ── The produced test set (campaign registration) ─────────────────────────────────────────────
-
-/** The counts the VERIFY phase re-derived over the produced tests — `executed` is how many the run
- *  actually ran; a set whose `executed < tests` was not fully verified and the card says so. */
-export interface TestSetCounts {
-  files: number;
-  tests: number;
+/**
+ * A registered TEST SET (wave 6, F-7R2-014; api-types 0.36.0) — the produced tests of a terminal
+ * `qe-author-tests` run, read back from its verify phase's `QE-VERIFY` report and recorded as a
+ * durable `testing.testset.registered` audit entry the daemon hydrates at boot. Served as
+ * `CampaignsListResponse.test_sets` — what the Test landing counts. Deny-dominates: a run whose
+ * verify phase FAILED registers too (`verified: false`, counts intact) so a red set is shown, never
+ * hidden; a run that never reached its verdict registers with zero counts and `plan: null`.
+ */
+export interface TestSet {
+  /** `testset-<run id>` — one set per producing run. */
+  id: string;
+  run_id: string;
+  workflow_id: QeAuthorTestsWorkflowId;
+  /** The `RunGroup.label` the launch filed the run under, when it did. */
+  label?: string;
+  repo_ref: string | null;
+  repo_name?: string;
+  /** Unix millis. */
+  registered_at: number;
+  /** The producing run's terminal status. */
+  run_status: SessionStatus | (string & {});
+  /** The verify unit's status (`done` | `rejected` | …); `null` when the run never planned one. */
+  verify_status: string | null;
+  /** `true` ONLY when the verify phase passed: ≥ 1 produced test, every one executed and green,
+   *  the repository checks green, the PLAN present. */
+  verified: boolean;
+  files: TestSetFile[];
+  produced: number;
   executed: number;
   passed: number;
   failed: number;
-}
-
-/**
- * The test set a completed `qe-author-tests` run registers (0.36.0) — DAEMON-JOINED onto the
- * campaigns surface (`Campaign.test_set` / `RunGroup.test_set`), so the Test landing shows what a
- * New test produced with its counts, from ONE `GET /campaigns`.
- */
-export interface TestSetRegistration {
-  /** The run that produced the set. */
-  runId: string;
-  /** The workflow that produced it (`qe-author-tests`). */
-  workflow: string;
-  /** Repo-relative paths of the produced test files. */
-  files: string[];
-  counts: TestSetCounts;
-  /** Repo-relative path of the PLAN the author phase wrote; `null` when none. */
+  not_executed: number;
+  /** The produced `tests/PLAN-*.md`, `null` when none was produced. */
   plan: string | null;
-  /** The delivered PR URL when the deliver phase opened one; `null` otherwise. */
-  prUrl: string | null;
+  /** The harnesses the produced tests ran under (unique, first-use order). */
+  harnesses: string[];
+  /** The delivered PR, when the engine's deliver phase opened one. */
+  deliverUrl?: string;
 }
+// <<< VERBATIM
 
-/** A campaign row (or ad-hoc group) as the wave-6 wire decorates it. */
-export interface WithTestSet {
-  test_set?: TestSetRegistration | null;
+/** The recon body, vendored as EVIDENCE: no `workflow` key (see {@link TestingReconWorkflowBody}). */
+// >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:2745-2778 (crew#536) — TestingReconBody (no `workflow` key)
+/**
+ * The `POST /testing/recon` request body (api-types 0.15.0) — the Testing page's campaign-recon
+ * trigger. `problem` is the recon brief, passed to every launched run VERBATIM (the client owns
+ * the framing). The two optional fields are the multiscope wire, shared with
+ * {@link LaunchCampaignBody}:
+ *
+ *  - `repoRefs` — explicit codebase attachments: registered repo refs (ids; a unique repo NAME
+ *    also resolves), deduped; a ref that does not resolve fails the whole request with a 400
+ *    naming it.
+ *  - `projectId` — crew resolves the project's `crew.repo` members server-side (404 unknown
+ *    project; 400 when the project has zero repo members and no `repoRefs` cover for it) AND
+ *    files every launched run into the project (the `POST /runs` §2.2 semantics: atomic
+ *    membership + project-graph binding).
+ *
+ * BOTH ⇒ the union (`repoRefs` order first). NEITHER ⇒ one unscoped recon run — the launch the
+ * Testing page sent before this wire existed, unchanged.
+ *
+ * One engine run carries ONE repo, so a multi-repo recon FANS: one governed run per resolved
+ * repo, all under one shared campaign label (`TestingReconResponse.campaign`) — and a real fan
+ * (>= 2 repos) registers an ENGINE campaign under that same id, so `GET /campaigns` serves it
+ * (api-types 0.17.0, crew#390).
+ *
+ * Every launched sibling pauses at its INTAKE GATE (`human_confirm: before:1` — the launch
+ * banner's promise) by default; `ungated: true` is the EXPLICIT opt-out for an unattended fan
+ * (api-types 0.17.0, crew#391). It is never the silent default, and it is audited.
+ */
+export interface TestingReconBody {
+  problem: string;
+  projectId?: string;
+  repoRefs?: string[];
+  /** EXPLICITLY launch the siblings unattended (no intake gate). Default `false`: each sibling
+   *  pauses at its intake gate before any unit runs. */
+  ungated?: boolean;
 }
+// <<< VERBATIM
+
+/** The drop-in workflow id "New test" launches (wave 6). Read off `GET /workflows` — a daemon that
+ *  does not list it has no governed test workflow, and the panel says so before launching. */
+export const QE_AUTHOR_TESTS_WORKFLOW_ID = 'qe-author-tests' satisfies QeAuthorTestsWorkflowId;
+
+// ── The campaigns surface — where the registered sets are served ──────────────────────────────
+
+// >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:4396-4407 (crew#536) — CampaignsListResponse incl. test_sets
+/**
+ * `GET /campaigns` 200 body (api-types 0.19.0 — `groups` is ADDITIVE: a pre-0.19 daemon sends
+ * only `campaigns`). One fetch answers the whole grouping surface: engine campaigns (each
+ * carrying its own per-node rollup fields) plus the ad-hoc label groups.
+ */
+export interface CampaignsListResponse {
+  campaigns: Campaign[];
+  groups: RunGroup[];
+  /** The registered test sets (wave 6, F-7R2-014; api-types 0.36.0 — ADDITIVE: a pre-0.36 daemon
+   *  omits it). Newest first. See {@link TestSet}. */
+  test_sets?: TestSet[];
+}
+// <<< VERBATIM
 
 // ── The diff route once the worktree is gone ──────────────────────────────────────────────────
 
-/** Where `GET /runs/:id/diff` read the diff from (0.36.0): `worktree` = the live worktree vs HEAD
- *  (today's answer, uncommitted work only); `branch` = the run branch vs its base commit, served
- *  once the worktree is reaped — COMMITTED work included. Absent from a pre-0.36 daemon. */
-export type RunDiffSource = 'worktree' | 'branch';
-
-export interface RunDiffWave6 extends RunDiff {
-  source?: RunDiffSource;
-}
-
-// ── Gate / routing / fence events ─────────────────────────────────────────────────────────────
-
-/** `gateEvaluated` (0.36.0): the engine SAYS the unit went ungated — no eligible judge seat could be
- *  convened (evaluator ≠ creator could not be held) — and why. Absent from a pre-0.36 daemon, where
- *  the card's "no floor, no judge, no policy" fold is the only signal. */
-export interface GateEvaluatedUngated {
-  ungated?: boolean;
-  ungatedReason?: string | null;
-}
-
-/** `unitDistributed` (0.36.0): the camelCase names the engine emits (declared in 0.34.0 as
- *  snake_case, which consumers read as undefined) plus `degradedReason` — set whenever the eligible
- *  seat set was smaller than the configured seats ("4 of 5 seats benched: codex, pi (signed out)"). */
-export interface UnitDistributedWave6 {
-  routingMethod?: 'council' | 'degraded' | 'evaluator_distinct' | 'tool';
-  agreementPct?: number | null;
-  returned?: number | null;
-  seated?: number | null;
-  dissent?: number | null;
-  degradedReason?: string | null;
-}
-
+// >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:553-580 (crew#536) — RunDiff incl. source / branch / base
 /**
- * `workerToolCallDenied` (0.36.0, F-7R2-012): a creator/evaluator seat asked for a REMOTE-WRITING
- * command (`git push`, `gh pr create|merge|edit|comment`, `gh api` mutations, `gh release`) and the
- * fence refused it — delivery is the ENGINE's job (the run's deliver phase). Mirrors
- * `EvaluatorToolCallDeniedEvent`'s envelope; `role` and `command` are the two facts the brief names.
+ * Response of `GET /runs/:id/diff` / `GET /runs/:id/diff?path=<abs>` (DES-FEEDBACK-002 CREW-1) —
+ * the run worktree's unified diff against HEAD (staged + unstaged), with untracked files appended
+ * as all-addition `--no-index` hunks. `diff: ""` = clean tree (a real answer, not an error).
+ * 404 unknown run; 409 when the run has no workdir or it no longer exists; with `path`, the same
+ * 400/403 containment as `RunFileContent`.
  */
-export interface WorkerToolCallDeniedEvent {
+export interface RunDiff {
+  /** Unified diff text (`git diff --no-color --no-ext-diff HEAD`), cut at 1 MB when `truncated`. */
+  diff: string;
+  /** The diff exceeded the 1 MB output cap and was cut. */
+  truncated: boolean;
+  /**
+   * Where the diff was read from (wave 6, F-7R2-013; api-types 0.36.0): `worktree` — the live run
+   * worktree (staged + unstaged + untracked; the pre-0.36 answer); `branch` — the run's retained
+   * `wicked/<id>` branch in the REGISTERED repository, diffed against its base, served when the
+   * engine has reaped the worktree (a completed run) so the files view never goes dark at
+   * completion. A pre-0.36 daemon omits the field and answers 409 for a reaped worktree; 409 now
+   * means "no worktree AND no run branch" (nothing was ever committed for the run).
+   */
+  source?: 'worktree' | 'branch';
+  /** `source: 'branch'` — the run branch the diff was read from. */
+  branch?: string;
+  /** `source: 'branch'` — the base commit the branch was diffed against: the engine's recorded
+   *  `AgentSession.base_commit` when it has one, else the branch's merge-base with the default
+   *  branch; `?base=<ref>` overrides it with a plain in-repo ref. */
+  base?: string;
+}
+// <<< VERBATIM
+
+/** The two declared sources of a diff — studio's alias over {@link RunDiff}`.source`. */
+export type RunDiffSource = NonNullable<RunDiff['source']>;
+
+// ── Gate / floor / routing / fence / carrier / base events ────────────────────────────────────
+
+// >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:1008-1059 (crew#536) — GateEvaluatedEvent incl. ungated / ungatedReason / floorNote / judgeSkippedReason
+/** §3 B1 — the gate's decision depth, emitted alongside `gateDecided`. `denial` is the structured
+ *  twin of `denialReason`: `null` when the gate approved, else the winning layer (deny-dominates) —
+ *  `worktree_guard` and `repo_checks` are the two wicked-core F-036/F-039 layers. `judgeCli` /
+ *  `judgeDistinct` (wicked-core#431 / F-3R2-007, api-types 0.33.0) name WHO rendered `agentVerdict`,
+ *  so evaluator ≠ creator is auditable from the event stream alone (compare with the unit's
+ *  `unitDistributed.cli`). Both keys are ALWAYS present: `null` when no judge ran (`agentVerdict`
+ *  is `null` too) and on the bus-mediated evaluator path, where the seat is not reported back. */
+export interface GateEvaluatedEvent {
+  type: 'gateEvaluated';
+  session: string;
+  ord: number;
+  criterion: string | null;
+  hasDeterministicFloor: boolean;
+  deterministicPass: boolean;
+  agentVerdict: string | null;
+  agentReasoning: string | null;
+  evaluatorPass: boolean | null;
+  /** Policy ids the evaluator≠creator pass applied (empty = vacuous default-allow, FINDING-025). */
+  evaluatorPolicies: string[];
+  denialReason: string | null;
+  denial: UnitDenial | null;
+  combined: boolean;
+  /** The council seat key the layer-2 judge ran under (`codex`, `pi`, …) — WHO rendered
+   *  `agentVerdict`. `null` when no judge ran, and on the bus-mediated path. */
+  judgeCli: string | null;
+  /** Whether that judge seat was IDENTITY-DISTINCT from the work's author: `true` for the rotation
+   *  pick, `false` when the judge fell back to the single default runner (prompt-only independence).
+   *  `null` when no judge ran or the seat is unknown. */
+  judgeDistinct: boolean | null;
+  /**
+   * Wave 6 (F-7R2-005, api-types 0.36.0): `true` when NOTHING gated this unit — no deterministic
+   * floor (no pinned validator, and the repo-checks floor did not apply), no agent judge, and an
+   * EMPTY evaluator-policy selection — the exact default-allow shape run b86c14c1 passed seven times.
+   * A consumer MUST render it as UNGATED, never as "pass", and a narrator must never say "checks
+   * ran" without a `repoChecksEvaluated` for the same unit. Absent on an engine predating wave 6
+   * (read `=== true`); `false` on a gated unit.
+   */
+  ungated?: boolean;
+  /** WHY, when `ungated` — each absent layer and its cause (`"no judge: no eligible judge seat
+   *  distinct from creator \`claude\` (roster: claude; benched: codex (signed out))"`). `null` when
+   *  gated; absent on an older engine. */
+  ungatedReason?: string | null;
+  /** Wave 6 (wicked-core#449 @ 9e11685, api-types 0.36.0): WHY the deterministic layer is absent —
+   *  set whenever `hasDeterministicFloor` is `false` on an agent unit, judge or not (`"no pinned
+   *  validator; the repo-checks floor did not apply: the tree was not changed"`). `null` when a
+   *  floor ran; absent on an older engine. */
+  floorNote?: string | null;
+  /** Wave 6: WHY no judge was convened for a unit that WANTED one (its tree changed and no pinned
+   *  validator gated it) — `"no eligible judge seat distinct from creator \`claude\` (roster: …;
+   *  benched: …)"`. `null` when a judge ran or none was wanted; absent on an older engine. */
+  judgeSkippedReason?: string | null;
+}
+// <<< VERBATIM
+
+// >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:1328-1385 (crew#536) — RepoChecksEvaluatedEvent incl. sandboxLevel / sandboxError / detectError
+/** wicked-core F-039 — the engine ran the repository's OWN checks in the worktree for the def's
+ *  code-verifying unit (`verified_evidence` with an `executes_code` creator upstream: `bug/verify`,
+ *  `feature/test`, `migration/verify`) and folded them into the gate as a deterministic floor. Fires
+ *  once per fold, just before `gateEvaluated` (whose `hasDeterministicFloor`/`criterion` include this
+ *  floor). `checks` is what actually ran, in order (`package.json` `typecheck`/`lint`/`test` via the
+ *  lockfile's package manager, an `install` first when `node_modules/` is absent; `Cargo.toml` →
+ *  `cargo test`); `skipped` names detected checks not run because an earlier one failed. `passed:
+ *  false` ⇒ the unit is denied (`denial.source` is `repo_checks`).
+ *
+ *  The checks are repo-controlled code and run ONLY inside an OS write boundary (macOS
+ *  `sandbox-exec` / Linux `bwrap`: writes confined to the worktree, the curated secret directories
+ *  unreadable, network open for installs) with an isolated `HOME`, `npm_config_cache`, `CARGO_HOME`,
+ *  `CARGO_TARGET_DIR` and `XDG_*` under `<worktree>/tmp/wicked-checks/`, and with a MINIMAL
+ *  environment — the daemon's env is cleared and only `PATH`, locale (`LANG`/`LC_*`), `TERM`,
+ *  `USER`/`LOGNAME`, `RUSTUP_HOME`, the Windows shell essentials and those isolation overrides
+ *  (`CI=1` included) reach a check: no token, API key or `WICKED_*` variable does; installs are always
+ *  `--ignore-scripts` (`--no-package-lock` when the repo ships no lockfile). When NO boundary can be
+ *  armed (no sandbox tool on the host — Windows) the checks do NOT run and the floor FAILS
+ *  (`passed: false`, `checks: []`, the reason on the unit record) — repo-controlled scripts never
+ *  run unsandboxed. Detection is fail-closed the same way: a `package.json` that cannot be read or
+ *  parsed, or a symlinked manifest/lockfile/`node_modules` (every probe `lstat`s, opens `O_NOFOLLOW`
+ *  and `fstat`s the opened descriptor before reading — links are never followed), FAILS the floor.
+ *  Only a repo with NO DETECTABLE check is the disclosed vacuous pass (`checks: []`, `passed:
+ *  true`): no manifest at all, or a readable `package.json` with no string `typecheck`/`lint`/`test`
+ *  script and no `Cargo.toml`. A manifest that cannot be read or trusted still FAILS.
+ *  "Done" for a verify phase is now the exit code the engine observed, not the seat's account of
+ *  having run the suite.
+ *
+ *  wicked-core#431 (api-types 0.33.0): the frame ALSO arrives for the DELIVER ord — a Tool unit —
+ *  whenever the worktree's tree is NOT the tree the run verified when the deliver phase is about to
+ *  push: after a lift onto the remote tip ({@link DeliverLiftEvaluatedEvent} `outcome: 'lifted'`), on
+ *  a retry after a failed re-verify, after an operator's by-hand rebase, or for a run that recorded
+ *  no verified tree. The engine re-runs the repository's checks on the tree that would ship before
+ *  allowing the push (a lockfile that moved with the base forces a frozen `--ignore-scripts` install
+ *  first), and the deliver unit's `gateEvaluated` then carries `hasDeterministicFloor: true` with
+ *  this floor's `criterion`. `passed: false` there fails the deliver unit closed — nothing is pushed.
+ *  `type` alias on purpose — see {@link EvaluatorMutatedWorktreeEvent}. */
+export type RepoChecksEvaluatedEvent = {
+  type: 'repoChecksEvaluated';
+  session: string;
+  ord: number;
+  attempt: number;
+  passed: boolean;
+  criterion: string;
+  /** The checks that RAN. EMPTY means "0 checks detected" — a consumer must say so, never "checks
+   *  ran"; since wave 6 the frame says WHY (`detectError`, `sandboxError`). */
+  checks: RepoCheckRun[];
+  skipped: string[];
+  /** Wave 6 (wicked-core#449 @ 9e11685, api-types 0.36.0): the sandbox level the checks ran under
+   *  (`bwrap`, `sandbox-exec`, `none`, …). Absent on an older engine. */
+  sandboxLevel?: string;
+  /** Wave 6: why the sandbox could not be armed, when it could not (`null` when it was). */
+  sandboxError?: string | null;
+  /** Wave 6: why check DETECTION failed (an unreadable `package.json`, a manifest with no
+   *  `typecheck`/`lint`/`test` script, …) — the reason an empty `checks` is empty; `null` when
+   *  detection succeeded. */
+  detectError?: string | null;
+};
+// <<< VERBATIM
+
+// >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:1645-1703 (crew#536) — UnitDistributedEvent (camelCase) + BenchedSeat
+/**
+ * Foundation wave: a unit was distributed with full routing detail.
+ *
+ * WIRE SPELLING (api-types 0.36.0, crew#533 follow-through): the engine's `CoreEvent::to_json` and
+ * the napi frames spell these fields camelCase — `routingMethod`, `agreementPct`, `returned`,
+ * `seated`, `dissent`, `degradedReason`, `seatConstraint` — exactly as `wicked-core-ts`'s own
+ * `UnitDistributedEventJson` declares them; `packages/crew/tests/wire-contract.test.ts` pins this
+ * interface against that type AND against a recorded frame. Pre-0.36 this interface declared the
+ * snake_case spellings, which the engine never emitted — a consumer reading `degraded_reason` got
+ * `undefined` and rendered a benched council as whole. The snake_case names stay for ONE minor as
+ * `@deprecated` optional aliases (a normalising relay may still produce them); consumers read the
+ * camelCase names. Every camelCase `Option` field is emitted unconditionally: `null`, never absent.
+ */
+export interface UnitDistributedEvent {
+  type: 'unitDistributed';
+  session: string;
+  ord: number;
+  /** The roster key of the assigned seat. */
+  cli: string;
+  /** How the seat was chosen: the council verdict, a degrade to the first candidate, an
+   *  evaluator ≠ creator reassignment, or a deterministic tool execution. */
+  routingMethod: 'council' | 'degraded' | 'evaluator_distinct' | 'tool';
+  agreementPct: number | null;
+  /** Ballots that came back. Read against `seated`. */
+  returned: number | null;
+  /** Seats CONVENED for the council that produced this assignment (`null` = unknown / not a council). */
+  seated: number | null;
+  dissent: number | null;
+  /**
+   * WHY the routing was degraded. Since wave 6 (F-7R2-006) the engine sets it on EVERY routing arm
+   * whenever the eligible seat set is smaller than the configured roster — `"4 of 5 seats benched:
+   * codex (signed out — launcher), pi (unauthenticated — ballot), …"` — not only for its `degraded`
+   * arm, so a council that held on a fraction of its seats reads as degraded. `null` when whole.
+   */
+  degradedReason: string | null;
+  /** WHY the candidate seats were narrowed BEFORE the council voted (core#401): a non-portable
+   *  skill constrained the unit to a claude seat. `null` when every roster seat was a candidate. */
+  seatConstraint: string | null;
+  /** @deprecated api-types 0.36.0 — the engine emits `routingMethod`; removed in 0.37. */
+  routing_method?: 'council' | 'degraded' | 'evaluator_distinct' | 'tool';
+  /** @deprecated api-types 0.36.0 — the engine emits `agreementPct`; removed in 0.37. */
+  agreement_pct?: number | null;
+  /** @deprecated api-types 0.36.0 — the engine emits `degradedReason`; removed in 0.37. */
+  degraded_reason?: string | null;
+}
+
+/** One seat the wave-6 engine BENCHED for a run (`AgentSession.benched_seats`, F-7R2-006): never
+ *  convened, never a failover or judge target, named in `unitDistributed.degradedReason`. */
+export interface BenchedSeat {
+  /** The roster key. */
+  cli: string;
+  /** Why — the launcher's words (`signed out`) or the engine's classification (`not_logged_in`,
+   *  `unauthenticated`). */
+  reason: string;
+  /** Who benched it: `launcher` (the roster's health probe — crew's `council_eligible`), `ballot`
+   *  (a council seat failure), `worker` (a unit's worker failed with an auth refusal), `judge`
+   *  (the seat failed while judging another unit — wicked-core#449 @ 9e11685). */
+  source: 'launcher' | 'ballot' | 'worker' | 'judge' | (string & {});
+}
+// <<< VERBATIM
+
+// >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:1535-1565 (crew#536) — WorkerToolCallDeniedEvent
+/**
+ * Wave 6 (F-7R2-012, api-types 0.36.0) — a WORKER seat asked to run a REMOTE-WRITING command
+ * (`git push`, `gh pr create|merge|edit|comment`, a `gh api` mutation, `gh release`, …) and the
+ * engine REFUSED it: delivery is performed by the run's deliver phase (which lifts, re-verifies,
+ * pushes and opens the PR so the ledger records it), never by a creator or evaluator seat. Emitted
+ * on both carriers: the ACP permission bridge (`carrier: 'acp'`) answers the seat's permission
+ * request with its reject option; the wrapped carrier's PreToolUse gate hook (`carrier:
+ * 'wrapped_cli'`) blocks the call and the fold replays the record at the gate. A refusal costs the
+ * seat one tool call, never the unit — the seat continues with `remedy`. Spelled exactly as
+ * wicked-core's `CoreEvent::to_json` emits it. `type` alias on purpose (relays through the
+ * `CoreEvent`-typed seams unchanged).
+ */
+export type WorkerToolCallDeniedEvent = {
   type: 'workerToolCallDenied';
   session: string;
   ord: number;
   attempt: number;
   /** The registry seat key. */
   cli: string;
-  /** The carrier the refusal happened on — `acp` (the per-call deny) or `wrapped_cli` (the
-   *  wrapped carrier's command filter). Open-ended for a future carrier (core #449 emits both). */
+  /** `'acp'` | `'wrapped_cli'`; open-ended for a future carrier. */
   carrier: 'acp' | 'wrapped_cli' | (string & {});
-  /** The seat's role on the unit — `creator`, `evaluator`, or `neutral` (a recon/planning rung;
-   *  core #449 emits all three). */
-  role: string;
-  /** The tool the seat asked for, as it named it (`Bash`, `shell`, `run_command`, …). */
+  /** The unit's role (`creator` | `evaluator` | `neutral`). */
+  role: 'creator' | 'evaluator' | 'neutral' | (string & {});
+  /** The tool the seat invoked (`Bash`, `bash`, `shell`, …). */
   tool: string;
-  /** The refused command, as the seat spelled it. */
+  /** The command text the seat sent. */
   command: string;
   reason: string;
-  /** The remedy the engine attaches ("delivery is performed by the run's deliver phase"). */
-  remedy: string | null;
+  /** What the seat was told to do instead ("delivery is performed by the run's deliver phase"). */
+  remedy: string;
+};
+// <<< VERBATIM
+
+// >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:1108-1144 (crew#536) — AcpFallbackKind incl. the auth kinds + AcpFallbackEvent
+/**
+ * `acpFallback.fallbackKind` — WHY a unit left the ACP carrier for the wrapped (single-shot) one:
+ * - `binary_unavailable` / `session_died` / `auth_required` — the ACP session could not be had; the
+ *   run continues single-shot (a FAILURE of the seat's transport or account, counted by seat health);
+ * - `governance_requires_wrapped` — a governed unit on a seat whose ACP adapter cannot enforce input
+ *   governance is routed to the wrapped carrier by design (crew#276);
+ * - `read_only_requires_wrapped` (wicked-core#431 / F-3R2-009, api-types 0.33.0) — an
+ *   `executes_code: false` unit (an evaluator, a recon rung, a review) on an ACP seat NOT admitted to
+ *   input governance (pi-acp, codex-acp) is routed to the wrapped carrier BEFORE any ACP turn, where
+ *   the read-only lever is an argv fact (`--sandbox read-only` / `--exclude-tools edit,write`). No
+ *   per-call {@link EvaluatorToolCallDeniedEvent} exists on that route — consumers must not wait for one.
+ * The two `*_requires_wrapped` kinds are deliberate routing, not failures — never a seat-health signal.
+ * Open-ended (`string & {}`) so a newer engine's kind parses in an older consumer.
+ */
+export type AcpFallbackKind =
+  | 'binary_unavailable'
+  | 'session_died'
+  | 'auth_required'
+  /** Wave 6 (F-7R2-019, api-types 0.36.0): the ACP handshake was REFUSED for authentication — the
+   *  seat's account, not its binary (`pi-acp` existed; pi answered 401). The engine benches the seat
+   *  for the run and does NOT attempt the single-shot wrapped fallback (it fails the same way). */
+  | 'auth_failed'
+  /** Wave 6 — the seat reported no credential at all (`unauthenticated`); same bench, same no-retry. */
+  | 'unauthenticated'
+  | 'governance_requires_wrapped'
+  | 'read_only_requires_wrapped'
+  | (string & {});
+
+/** P1 — ACP unavailable or failed for a CLI, or the unit was deliberately routed off ACP; the run
+ *  continues on the wrapped carrier. `fallbackKind` says which (see {@link AcpFallbackKind}). */
+export interface AcpFallbackEvent {
+  type: 'acpFallback';
+  session: string;
+  cliKey: string;
+  reason: string;
+  fallbackKind: AcpFallbackKind;
 }
+// <<< VERBATIM
+
+// >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:1500-1528 (crew#536) — RunBaseResolvedEvent incl. runBranch
+/** wicked-core#431 / F-3R2-013 — how the run's BASE commit was chosen when its worktree was minted:
+ *  the engine fetches `origin` and, when the registered clone's `HEAD` is strictly behind the remote
+ *  default branch's tip, bases the run on that tip — so the worker starts from the current code and
+ *  the deliver lift has nothing to move. `lifted: true` = the base moved off the clone's `HEAD` by
+ *  `behind` commits; `false` = `HEAD` was already the tip, or was ahead of / diverged from it (local
+ *  unpushed work — kept, `note` says so), or no remote default ref resolved (`baseRef: null`).
+ *  Emitted once per freshly minted worktree, BEFORE `worktreeReady`; a resumed run reuses its live
+ *  worktree and emits nothing. Session-level (no `ord`). `type` alias on purpose. */
+export type RunBaseResolvedEvent = {
+  type: 'runBaseResolved';
+  session: string;
+  /** The remote default ref (`origin/main`), or `null` when none could be resolved. */
+  baseRef: string | null;
+  /** The commit the run worktree was minted from. */
+  baseCommit: string;
+  /** The registered clone's `HEAD` at mint time. */
+  localHead: string;
+  /** How many commits `localHead` was behind `baseRef`; `0` when not behind or unknown. */
+  behind: number;
+  /** Whether `git fetch origin` succeeded (a failed fetch is disclosed in `note`, cached refs used). */
+  fetched: boolean;
+  lifted: boolean;
+  note: string | null;
+  /** Wave 6 (F-7R2-013, api-types 0.36.0): the run branch the worktree was minted on
+   *  (`wicked/<run id>`, sanitized), recorded on the session as `run_branch` beside `base_commit`
+   *  so the run's diff is servable from the branch once the worktree is reaped. Absent on an
+   *  engine predating wave 6. */
+  runBranch?: string;
+};
+// <<< VERBATIM
+
+// ── The roster — auth, free tier, council eligibility, the bench ──────────────────────────────
+
+// >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:424-521 (crew#536) — RosterSeat incl. auth / auth_source / free_tier_source / council_eligible / council_bench + RosterSeatCouncilBench + SeatAuth
+/**
+ * A council seat (`AgenticCli`) as returned by `GET /roster`. Only the fields
+ * the launch form uses are named; the index signature keeps the (large) rest of
+ * the seat intact so it round-trips verbatim into `clisJson` on launch.
+ */
+export interface RosterSeat {
+  key: string;
+  display_name: string;
+  binary: string;
+  enabled_for_council: boolean;
+  category?: string;
+  /**
+   * Runtime health (crew#274). Additive: absent on a daemon predating the field, and safe to
+   * round-trip into `clisJson` (the engine's `AgenticCli` deserializer ignores unknown fields).
+   * Absent-or-default reads as `active` with no message.
+   */
+  health?: SeatHealth;
+  /**
+   * The shell invocation that runs this seat's own interactive login flow (seat sign-in;
+   * wicked-core PR#278 `AgenticCli.login_invocation`). Passed through from the engine roster
+   * VERBATIM — the daemon never synthesizes one. The studio hosts it in a PTY terminal
+   * (`POST /terminals`) so every CLI's native sign-in gets one uniform surface. Absent on an
+   * engine predating the field (serde omits `None`) and on seats with no known login flow.
+   */
+  login_invocation?: string;
+  /**
+   * Whether the seat LOOKS signed in — a cheap file/env-presence HEURISTIC computed by the
+   * daemon (`seat-signin.ts`), never a spawned probe and never proof the credential still
+   * works. Three-valued on purpose: `true`/`false` when the seat's auth state is observable
+   * from files or env, `null`/absent when it is unknowable cheaply (keychain-backed seats,
+   * unknown seat keys, or a daemon predating the field).
+   */
+  signed_in?: boolean | null;
+  /**
+   * What `signed_in` MEANS for this seat (api-types 0.35.0, F-2R2-009): `signed_in` — a credential
+   * artifact is observable; `signed_out` — none is and the seat needs one (a council benches it on
+   * its first ballot; a chat refuses it up front); `not_required` — none is, but the seat answers
+   * on a free tier with no account (`free_tier` names it); `unknown` — the probe cannot tell
+   * cheaply (keychain-backed seats, unknown seat keys). Absent on a daemon predating the field.
+   */
+  auth?: SeatAuth;
+  /**
+   * Where `auth` came from (api-types 0.36.0, F-A45-006): `seat-stderr` — the seat ITSELF reported
+   * no credential (a council ballot's "No API key found", a worker's 401, an authentication ACP
+   * fallback) within the last 30 minutes with no ok output since, which OVERRIDES the credential-
+   * file probe (`signed_in`) — the fresh rig's pi read `signed_in: true` off an empty `auth.json`
+   * while every ballot failed. Absent = the probe decided (and since 0.36.0 the probe itself needs
+   * a credential-SHAPED file, never mere presence).
+   */
+  auth_source?: 'seat-stderr';
+  /** Present with `auth_source: 'seat-stderr'`: the seat's own words, bounded. */
+  auth_evidence?: string;
+  /** Present when `auth` is `not_required`: the free tier the seat answers on. */
+  free_tier?: string;
+  /**
+   * Where the `not_required` reading came from: `registry` when the CLI's own record declared the
+   * credential requirement, `crew-heuristic` when the daemon's per-CLI table did (today's only
+   * source — the engine's `AgenticCli` declares none; a wicked-core follow-up). A reader can show
+   * the heuristic as such.
+   */
+  free_tier_source?: 'registry' | 'crew-heuristic';
+  /**
+   * Whether a council would seat AND keep this seat as far as the daemon can tell: enabled for
+   * council, runtime `health` active, `auth` not `signed_out`. The daemon's PREDICTION from its
+   * own records — the engine still convenes whatever roster it is handed and benches a seat only
+   * after it fails. Chat admission (`POST /chats` defaults) reads the same auth predicate.
+   */
+  council_eligible?: boolean;
+  /** Present when `council_eligible` is false: the one reason, in the operator's words. */
+  council_ineligible_reason?: string;
+  /**
+   * Present when THIS daemon's recent councils benched the seat: the engine's own
+   * `councilSeatFailed` evidence (`non_zero_exit` / `timed_out`, the derivative `benched` kind
+   * excluded), folded over a bounded window (`window_ms`) and cleared by the seat's next ok unit
+   * output. `council_eligible` is false while it is present.
+   */
+  council_bench?: RosterSeatCouncilBench;
+  [k: string]: unknown;
+}
+
+/** `RosterSeat.council_bench` (api-types 0.35.0). */
+export interface RosterSeatCouncilBench {
+  /** Primary ballot failures inside the window. */
+  failures: number;
+  /** The last failure's `councilSeatFailed.kind`. */
+  last_kind: string;
+  /** ISO-8601 of the last failure. */
+  last_at: string;
+  /** The run the last failure happened in, when the frame named one. */
+  last_run?: string;
+  /** A bounded excerpt of the last failure's detail / stderr, when there was one. */
+  last_detail?: string;
+  /** The rolling window the failures were counted over, ms. */
+  window_ms: number;
+}
+
+/** A seat's auth reading (`RosterSeat.auth`; api-types 0.35.0). */
+export type SeatAuth = 'signed_in' | 'signed_out' | 'not_required' | 'unknown';
+// <<< VERBATIM
+
+// ── Chat admission — the refused seats and why ────────────────────────────────────────────────
+
+// >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:3917-3978 (crew#536) — ChatSeatOutcome, ChatRefusalSource, ChatSeatRefusal, ChatOpenResponse incl. refused[], ChatSeatRefusedFrame
+/** One seat's warm-up outcome on `POST /chats`. */
+export interface ChatSeatOutcome {
+  cliKey: string;
+  ok: boolean;
+  error?: string;
+}
+
+/**
+ * One seat a `POST /chats` did NOT seat, and why (api-types 0.35.0, F-2R2-007): a DEFAULT seat the
+ * daemon's admission dropped before the engine saw it (signed out; not admissible to a scoped chat
+ * — its ACP adapter asks no permissions and arms no sandbox, or it has no ACP adapter), or a
+ * REQUESTED seat (`clis`) the engine refused (`ChatSeatOutcome.ok: false`, its `error` repeated
+ * here as `reason`). One list for the scope card and the thread to read.
+ */
+/**
+ * Why a seat was not seated (api-types 0.36.0, F-A45-011): `auth` — signed out (the probe, or the
+ * seat's own "no credential" report); `scope` — the scoped-chat admission rule; `bench` — benched by
+ * this daemon's recent councils; `budget` — the engine did not warm it within its dispatch budget
+ * (the seat timed out or was dropped at dispatch); `engine` — the engine refused it with its own
+ * reason. Open-ended so a newer daemon's source parses in an older skin.
+ */
+export type ChatRefusalSource = 'auth' | 'scope' | 'bench' | 'budget' | 'engine' | (string & {});
+
+export interface ChatSeatRefusal {
+  cliKey: string;
+  reason: string;
+  /** api-types 0.36.0 (F-A45-011): the cause class. Absent on a daemon predating the field. Since
+   *  0.36.0 EVERY requested-or-defaulted seat that is not in `seats` as warm has an entry — a seat
+   *  the engine DROPPED at dispatch (absent from `seats` altogether) included, never a silent gap. */
+  source?: ChatRefusalSource;
+}
+
+/** `POST /chats` → 201. */
+export interface ChatOpenResponse {
+  chatId: string;
+  seats: ChatSeatOutcome[];
+  /** The resolved scope (crew#502). */
+  scope: ChatScope;
+  /** Present when the chat opened but its `crew.chat` filing into `projectId` failed. */
+  projectAttachError?: string;
+  /** Every seat that was asked for or defaulted and is NOT in `seats` as warm, with its reason
+   *  (api-types 0.35.0). Empty when every seat warmed; absent on a daemon predating the field. */
+  refused?: ChatSeatRefusal[];
+}
+
+/**
+ * A seat refused at `POST /chats` (api-types 0.35.0, F-2R2-007). DAEMON-SYNTHETIC: broadcast
+ * straight to `/ws` once per refused seat, right after the open, so the chat thread can say why a
+ * seat is missing (the studio's `chat-scope-admission` copy) — the engine emits nothing for a seat
+ * it never saw. `chat` names the chat the way the engine's `chatClosed` does; `project_id` rides
+ * along when the chat was filed. An anonymous object type on purpose, like the stall frames, so it
+ * flows through `CoreEvent`-typed seams.
+ */
+export type ChatSeatRefusedFrame = {
+  type: 'chatSeatRefused';
+  chat: string;
+  cliKey: string;
+  reason: string;
+  /** api-types 0.36.0 (F-A45-011): the cause class — see {@link ChatRefusalSource}. */
+  source?: ChatRefusalSource;
+  project_id?: string;
+};
+// <<< VERBATIM
+
+// >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:4000-4010 (crew#536) — ChatDetailResponse incl. refused[]
+/** `GET /chats/:id` → 200. */
+export interface ChatDetailResponse {
+  chatId: string;
+  seats: string[];
+  /** The scope recorded at open; `null` for a chat this daemon did not open (or after a restart). */
+  scope: ChatScope | null;
+  /** The seats refused at open (api-types 0.36.0, F-A45-011) — the same list the 201 carried, so
+   *  the admission copy survives a reload; `null` for a chat this daemon did not open; absent on a
+   *  daemon predating the field. */
+  refused?: ChatSeatRefusal[] | null;
+}
+// <<< VERBATIM
 
 // ── The daemon-wide docs listing (no bridge spawn) ────────────────────────────────────────────
 
+// >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:3741-3795 (crew#536) — GET /interactive/docs: InteractiveDocsListing, InteractiveSeamKind, InteractiveDocIndexRow, InteractiveDocsUnreachable
 /**
- * `GET /interactive/docs` (0.36.0 — the wave-6 crew PR): every project's documents from the
- * state-home doc LEDGERS, served by the daemon itself — it never resolves a project root and never
- * starts a `wicked-interactive` bridge. The cheap census the Vibe surface and the Home door count
- * from (independent review of #263, F-1); absent on a pre-0.36 daemon (route-absent 404), and then
- * studio counts only what a surface has already listed. PROVISIONAL spelling: rows are the bridge's
- * `DocSummary` (snake_case, as `GET /projects/:id/interactive/api/docs` serves them) plus the
- * project they belong to.
+ * `GET /api/v1/interactive/docs` (api-types 0.36.0, studio #263) — every interactive document across
+ * projects, listed by the DAEMON from disk WITHOUT spawning a bridge: each project's docs root
+ * (the per-project `interactiveRoot` binding, else `WICKED_INTERACTIVE_ROOT`, else the default
+ * root / its `projects/<id>` partition), each slug-named child carrying a `versions.json`, read by
+ * the bridge's own `listDocs` rules — plus what only the daemon knows: the seams that answered
+ * the document and the governed runs they launched (the handoff ledgers). The per-project
+ * `GET /projects/:id/interactive/api/docs` spawns one bridge per project (≈60 s cold start) — a
+ * skin must never fan that out on mount; this is the listing it mounts with. `?includeRetired=1`
+ * lists tombstoned rows too.
+ */
+export interface InteractiveDocsListing {
+  /** Newest first (by `updatedAt`), then by name. */
+  docs: InteractiveDocIndexRow[];
+  /** Project docs roots the daemon could not read (or a partition its containment walk refused),
+   *  with the reason — never silently dropped. `[]` when every root was readable. */
+  unreachable: InteractiveDocsUnreachable[];
+}
+
+/** The seams that can answer a document (the handoff ledgers). */
+export type InteractiveSeamKind = 'draft' | 'edit' | 'chat' | 'demo' | (string & {});
+
+/** One document on the daemon-wide listing (api-types 0.36.0). */
+export interface InteractiveDocIndexRow {
+  /** The project whose docs root holds the document. A root SHARED by several projects (an
+   *  explicit `interactiveRoot` binding, or `WICKED_INTERACTIVE_ROOT` applying to all) lists once,
+   *  under the first project in listing order (the synthesized `default` first). */
+  projectId: string;
+  /** The doc name (slug). */
+  name: string;
+  /** Manifest `kind`; a manifest without one lists as `doc`. */
+  kind: 'doc' | 'html' | 'source' | 'demo' | (string & {});
+  /** Head version; `null` when the manifest carries none. */
+  head: number | null;
+  /** Lineage size. */
+  versions: number;
+  /** ISO-8601 of the head (last) version, or `null` when the lineage is empty. */
+  updatedAt: string | null;
+  /** Present only on a retired (tombstoned) row, listed only with `?includeRetired=1`. */
+  retired?: true;
+  /** ISO-8601 retirement timestamp; present with `retired`. */
+  retiredAt?: string;
+  /** The seams that answered this document, from the handoff ledgers (`[]` = none yet). */
+  kinds: InteractiveSeamKind[];
+  /** The governed runs those seams launched for it (ledger order) — the doc ↔ run binding. */
+  runs: string[];
+}
+
+/** A project docs root the listing could not read (api-types 0.36.0). */
+export interface InteractiveDocsUnreachable {
+  projectId: string;
+  /** The resolved root, or `null` when the containment walk refused the partition before resolving one. */
+  root: string | null;
+  error: string;
+}
+// <<< VERBATIM
+
+/**
+ * Studio's NORMALIZED row of the daemon-wide listing — what `docsIndexOf` hands the Vibe corpus
+ * and the Home door: {@link InteractiveDocIndexRow} narrowed to the fields the surfaces count on,
+ * in studio's own snake_case (the surfaces were written against it while the wire was unpublished;
+ * the wire spells `projectId` / `updatedAt` and the reader accepts both).
  */
 export interface InteractiveDocsIndexRow {
   project_id: string;
@@ -201,10 +846,6 @@ export interface InteractiveDocsIndexRow {
   head: number;
   versions: number;
   updated_at: string | null;
-}
-
-export interface InteractiveDocsIndexResponse {
-  docs: InteractiveDocsIndexRow[];
 }
 
 /** Narrow the daemon-wide listing off the wire bag — rows without a project or a name are dropped;
@@ -249,31 +890,81 @@ export function gateUngatedReason(ev: CoreEvent): string | null {
   return str((ev as Record<string, unknown>)['ungatedReason']);
 }
 
-/**
- * `unitDistributed.degradedReason` — the camelCase spelling the engine emits, with the snake_case
- * `degraded_reason` 0.34.0 declared read as the fallback. TODO(api-types 0.36.0): drop the
- * snake_case read once the pin declares the camelCase name.
- */
+/** `unitDistributed.degradedReason` — the camelCase spelling the engine emits and 0.36.0 declares.
+ *  The `@deprecated` snake_case alias is NOT read: the engine never emitted it. */
 export function distributionDegradedReason(ev: CoreEvent): string | null {
-  const bag = ev as Record<string, unknown>;
-  // The camelCase key PRESENT — even as an explicit `null` (the engine saying "none") — is the
-  // answer; the snake_case read is only for a frame that never carried the camelCase key.
-  if ('degradedReason' in bag) return str(bag['degradedReason']);
-  return str(bag['degraded_reason']);
+  return str((ev as Record<string, unknown>)['degradedReason']);
 }
 
-/** `unitDistributed.agreementPct` (camelCase as emitted), `agreement_pct` as the 0.34.0 fallback.
- *  TODO(api-types 0.36.0): drop the snake_case read. */
+/** `unitDistributed.agreementPct` (camelCase as emitted and declared); `null` when absent or not finite. */
 export function distributionAgreementPct(ev: CoreEvent): number | null {
-  const bag = ev as Record<string, unknown>;
-  const v = 'agreementPct' in bag ? bag['agreementPct'] : bag['agreement_pct'];
+  const v = (ev as Record<string, unknown>)['agreementPct'];
   return typeof v === 'number' && Number.isFinite(v) ? v : null;
 }
 
 /** `RunDiff.source` — `null` when the daemon predates the field (a worktree diff, by construction). */
 export function diffSource(d: RunDiff): RunDiffSource | null {
-  const s = (d as RunDiffWave6).source;
+  const s = d.source;
   return s === 'branch' || s === 'worktree' ? s : null;
+}
+
+// ── WIRE GAPS — PROVISIONAL, studio-worded: NOT declared by wicked-crew-api-types 0.36.0 ──────
+//
+// Each shape here is guarded by `tests/wave6Wire.test.ts`: the suite asserts the installed package
+// does NOT declare it, so the pin that does makes this section a failing test, not a silent drift.
+
+/**
+ * PROVISIONAL (wire gap 1) — the counts of a row-joined test set. 0.36.0's {@link TestSet} carries
+ * `produced` / `executed` / `passed` / `failed` / `not_executed` at the top level of the
+ * `CampaignsListResponse.test_sets` entry instead; `tests` here is the produced count.
+ */
+export interface TestSetCounts {
+  files: number;
+  tests: number;
+  executed: number;
+  passed: number;
+  failed: number;
+}
+
+/**
+ * PROVISIONAL (wire gap 1) — the test set a completed `qe-author-tests` run registers, as studio
+ * reads it off a campaign ROW (`Campaign.test_set` / `RunGroup.test_set`, daemon-joined like
+ * `node_delivery`). 0.36.0 declares no row-level join: it serves the sets as
+ * `CampaignsListResponse.test_sets: TestSet[]` (`run_id`, `files: TestSetFile[]`, `plan`,
+ * `deliverUrl`). Until a pin declares the join, a 0.36.0 daemon's row renders no counts (absence,
+ * never a fabricated zero) — `testSetOf` answers `null`.
+ */
+export interface TestSetRegistration {
+  /** The run that produced the set. */
+  runId: string;
+  /** The workflow that produced it (`qe-author-tests`). */
+  workflow: string;
+  /** Repo-relative paths of the produced test files. */
+  files: string[];
+  counts: TestSetCounts;
+  /** Repo-relative path of the PLAN the author phase wrote; `null` when none. */
+  plan: string | null;
+  /** The delivered PR URL when the deliver phase opened one; `null` otherwise. */
+  prUrl: string | null;
+}
+
+/** PROVISIONAL (wire gap 1) — a campaign row (or ad-hoc group) as studio reads the join. */
+export interface WithTestSet {
+  test_set?: TestSetRegistration | null;
+}
+
+/**
+ * PROVISIONAL (wire gap 2) — the additive `workflow` key studio sends on `TestingReconBody` as the
+ * launch ladder's middle rung. 0.36.0's {@link TestingReconBody} declares no such key: a daemon with
+ * a strict schema 400s it as unrecognized and the ladder falls through to one `POST /runs` per repo.
+ * On a 0.36.0 daemon the first rung (`POST /testing/author`) answers, so this rung is never reached.
+ */
+export interface TestingReconWorkflowBody {
+  problem: string;
+  projectId?: string;
+  repoRefs?: string[];
+  ungated?: boolean;
+  workflow?: string;
 }
 
 /** `Campaign.test_set` / `RunGroup.test_set` narrowed off the wire bag — `null` unless the shape holds. */

--- a/tests/RunDegradedNote.test.tsx
+++ b/tests/RunDegradedNote.test.tsx
@@ -5,7 +5,7 @@ import { degradedCouncil, RunDegradedNote } from '../src/components/RunDegradedN
 import {
   UNIT_DISTRIBUTED_DEGRADED,
   UNIT_DISTRIBUTED_FULL,
-  UNIT_DISTRIBUTED_SNAKE,
+  UNIT_DISTRIBUTED_DEPRECATED_ALIASES,
   W6_DEGRADED_REASON,
   W6_EVENTS,
 } from './fixtures/wave6.js';
@@ -13,7 +13,7 @@ import {
 /**
  * "council degraded: …" on the run head (wave 6 — F-7R2-006 studio half, api-types 0.36.0
  * `unitDistributed.degradedReason`): the latest reason speaks, the affected-unit count rides
- * beside it, a full council renders nothing, and the 0.34.0 snake_case spelling is still read.
+ * beside it, a full council renders nothing, and the deprecated snake_case alias is not read.
  */
 
 const ev = (e: unknown): CoreEvent => e as CoreEvent;
@@ -43,8 +43,8 @@ describe('degradedCouncil — the fold', () => {
     expect(degradedCouncil([ev(UNIT_DISTRIBUTED_FULL)])).toBeNull();
     expect(degradedCouncil([])).toBeNull();
   });
-  it('reads the 0.34.0 snake_case spelling as the fallback', () => {
-    expect(degradedCouncil([ev(UNIT_DISTRIBUTED_SNAKE)])!.reason).toBe('2 of 5 seats benched: codex, pi (signed out)');
+  it('does NOT read the deprecated snake_case alias (dropped at the 0.36.0 pin) — a frame carrying only `degraded_reason` renders nothing', () => {
+    expect(degradedCouncil([ev(UNIT_DISTRIBUTED_DEPRECATED_ALIASES)])).toBeNull();
   });
 });
 

--- a/tests/fixtures/api-types-0.36.0-skills.d.ts
+++ b/tests/fixtures/api-types-0.36.0-skills.d.ts
@@ -1,4 +1,4 @@
-// >>> VERBATIM wicked-crew-api-types@0.35.0 index.d.ts:1768-2186 (crew#531 via PR #532) — the skills block
+// >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:1969-2419 (crew#535 via crew#536) — the skills block
 // ── Skills — the daemon-owned garden plugin root, published as immutable snapshots (api-types 0.28.0) ──
 //
 // api-types 0.29.0 (design amendment v3.6, crew #490): the installer-managed copy
@@ -196,8 +196,40 @@ export interface SkillsManifestResponse {
   root: string;
   /** The VERIFIED published snapshot `current` resolves to, or `null` before the first publish.
    *  `path` is the absolute REAL path of `snapshots/<gen>` — byte-identical to the one input the
-   *  engine is handed (`WICKED_SKILLS_SNAPSHOT`; design v3.1 §2). */
-  current: { gen: number; path: string } | null;
+   *  engine is handed (`WICKED_SKILLS_SNAPSHOT`; design v3.1 §2). `rules` / `drift` (api-types
+   *  0.36.0, F-083 / crew#535) ride beside it on a daemon ≥ 0.7.30 — absent on an older one. */
+  current: {
+    gen: number;
+    path: string;
+    /** The portability rules the generation was published under vs the rules this daemon runs:
+     *  `recorded` is `null` for a generation predating the identity (0.7.29 and earlier);
+     *  `stale: true` = they differ and the daemon raised `skills.stale-rules`. */
+    rules?: {
+      recorded: PortabilityRulesIdentity | null;
+      running: PortabilityRulesIdentity;
+      stale: boolean;
+    };
+    /** The rows whose portability derives differently under the running rules than the snapshot
+     *  recorded — the `skills.stale-rules` warning names up to five; the list carries the rest.
+     *  `recorded.reasons` is `null` for a row written before per-reason portability (0.34.0). */
+    drift?: SnapshotRowDrift[];
+  } | null;
+}
+
+/** The identity of a portability-rule table (api-types 0.36.0, F-083): its version and the
+ *  sha256 of the committed parity fixture (`tests/fixtures/portability_rules.json`). */
+export interface PortabilityRulesIdentity {
+  version: number;
+  sha256: string;
+}
+
+/** One snapshot row whose portability the RUNNING rules derive differently than the snapshot
+ *  recorded (api-types 0.36.0, F-083) — see `SkillsManifestResponse.current.drift`. */
+export interface SnapshotRowDrift {
+  name: string;
+  recorded: { portable: boolean; reasons: SkillPortabilityReason[] | null };
+  /** What the RUNNING rules derive for the row — the same per-reason shape `SkillEntry.portability` carries. */
+  derived: SkillPortability;
 }
 
 export interface SkillFileEntry {
@@ -420,7 +452,7 @@ export interface ReplaceSkillBody {
 }
 // <<< VERBATIM
 
-// >>> VERBATIM wicked-crew-api-types@0.35.0 index.d.ts:4223-4272 (crew#531 via PR #532) — the diagnostics skills block
+// >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:4682-4741 (crew#535 via crew#536) — the diagnostics skills block
 /** The skills seam's state as `GET /diagnostics` reports it (skills keystone, api-types 0.28.0). */
 export type DiagnosticsSkillsState = 'published' | 'fallback' | 'blocked' | 'config-error' | 'disabled';
 
@@ -440,8 +472,18 @@ export interface DiagnosticsSkillsFinding {
    *  (`error`, api-types 0.29.0) = `manifest.json` could not be read when diagnostics were taken
    *  (corrupt, unreadable, or the root no longer the one the store bound) — reported as
    *  `config-error` with the cause instead of the stale boot outcome; the exported engine input is
-   *  unchanged until the daemon restarts. */
-  kind: 'skills.fallback' | 'skills.blocked' | 'skills.config' | 'skills.source' | 'skills.manifest';
+   *  unchanged until the daemon restarts; `skills.stale-rules` (`warning`, api-types 0.36.0, F-083 /
+   *  crew#535) = the CURRENT generation was published under OTHER portability rules than the daemon
+   *  now runs — accepted (the snapshot is never rewritten; the runtime stays `published`), the rows
+   *  that now derive differently are named (`SkillsManifestResponse.current.drift`), and a publish
+   *  records the running rules and clears it. */
+  kind:
+    | 'skills.fallback'
+    | 'skills.blocked'
+    | 'skills.config'
+    | 'skills.source'
+    | 'skills.manifest'
+    | 'skills.stale-rules';
   severity: 'warning' | 'error';
   message: string;
 }

--- a/tests/fixtures/wave6.ts
+++ b/tests/fixtures/wave6.ts
@@ -1,22 +1,16 @@
 import type { Campaign, RunGroup } from '../../src/api/campaigns.js';
 import type { CoreEvent, GateEvaluatedEvent, UnitDistributedEvent, WorkflowDef } from '../../src/api/types.js';
-import type {
-  GateEvaluatedUngated,
-  TestSetRegistration,
-  UnitDistributedWave6,
-  WorkerToolCallDeniedEvent,
-} from '../../src/api/wave6-wire.js';
+import type { TestSetRegistration, WorkerToolCallDeniedEvent } from '../../src/api/wave6-wire.js';
 import { makeUnit } from '../factories.js';
 
 /**
  * The wave-6 wire (api-types 0.36.0 — the governed testing journey) as SYNTHETIC frames in the
  * engine's `event_to_json` spelling: camelCase, every key present, `null` never absent. Not a
- * recording: 0.36.0 was unpublished when this was written — every literal is spelled exactly as
- * the wave-6 briefs name the fields (`ungated` / `ungatedReason`, `degradedReason`,
- * `workerToolCallDenied {role, command}` + a remedy, `diff.source: "branch"`, the campaign's
- * `test_set`), typed `satisfies` the provisional mirror so a drift fails `tsc`. Re-vendor against
- * the published package at the pin bump. Privacy-scrubbed by construction: synthetic ids, no host
- * paths, no operator text.
+ * recording — every event literal is typed `satisfies` the PUBLISHED 0.36.0 declaration (through
+ * `./types.js` / the byte-pinned `wave6-wire.ts` regions) so a drift fails `tsc`. The campaign rows'
+ * `test_set` is studio's provisional row-level join (wire gap 1 in `wave6-wire.ts`: 0.36.0 serves
+ * `CampaignsListResponse.test_sets` instead). Privacy-scrubbed by construction: synthetic ids, no
+ * host paths, no operator text.
  */
 
 export const W6_RUN = 'r-gt-done';
@@ -57,7 +51,8 @@ export const UNIT_DISTRIBUTED_DEGRADED = {
   seated: 5,
   dissent: 0,
   degradedReason: W6_DEGRADED_REASON,
-} satisfies Omit<UnitDistributedEvent, 'routing_method' | 'agreement_pct' | 'returned' | 'dissent' | 'degraded_reason'> & UnitDistributedWave6;
+  seatConstraint: null,
+} satisfies UnitDistributedEvent;
 
 /** The same frame with a full council — no reason. */
 export const UNIT_DISTRIBUTED_FULL = {
@@ -67,11 +62,12 @@ export const UNIT_DISTRIBUTED_FULL = {
   returned: 5,
   dissent: 1,
   degradedReason: null,
-} satisfies Omit<UnitDistributedEvent, 'routing_method' | 'agreement_pct' | 'returned' | 'dissent' | 'degraded_reason'> & UnitDistributedWave6;
+} satisfies UnitDistributedEvent;
 
-/** The 0.34.0 snake_case spelling a consumer might still be handed (the declared-but-never-emitted
- *  names) — the readers fall back to it until the 0.36.0 pin. */
-export const UNIT_DISTRIBUTED_SNAKE: UnitDistributedEvent = {
+/** A frame carrying ONLY the `@deprecated` snake_case aliases 0.36.0 keeps for one minor (the
+ *  pre-0.36 declared-but-never-emitted names) — the readers no longer read them: no pct, no degraded
+ *  line. Not a `UnitDistributedEvent` (its camelCase fields are required); a permissive frame. */
+export const UNIT_DISTRIBUTED_DEPRECATED_ALIASES = {
   type: 'unitDistributed',
   session: W6_RUN,
   ord: 2,
@@ -81,7 +77,7 @@ export const UNIT_DISTRIBUTED_SNAKE: UnitDistributedEvent = {
   returned: 3,
   dissent: 1,
   degraded_reason: '2 of 5 seats benched: codex, pi (signed out)',
-};
+} satisfies Pick<UnitDistributedEvent, 'type' | 'session' | 'ord' | 'cli' | 'routing_method' | 'agreement_pct' | 'returned' | 'dissent' | 'degraded_reason'>;
 
 export const W6_UNGATED_REASON = 'no eligible judge seat';
 
@@ -105,7 +101,7 @@ export const GATE_UNGATED_WITH_FLOOR = {
   judgeDistinct: null,
   ungated: true,
   ungatedReason: W6_UNGATED_REASON,
-} satisfies GateEvaluatedEvent & GateEvaluatedUngated;
+} satisfies GateEvaluatedEvent;
 
 /** UNGATED with no floor either — the free-text case the phase7-r2 rig recorded, now said. */
 export const GATE_UNGATED_NO_FLOOR = {
@@ -114,7 +110,7 @@ export const GATE_UNGATED_NO_FLOOR = {
   criterion: null,
   hasDeterministicFloor: false,
   deterministicPass: true,
-} satisfies GateEvaluatedEvent & GateEvaluatedUngated;
+} satisfies GateEvaluatedEvent;
 
 /** A judged pass on the same wire — `ungated: false`, a judge seat named. */
 export const GATE_JUDGED_PASS = {
@@ -127,7 +123,7 @@ export const GATE_JUDGED_PASS = {
   judgeDistinct: true,
   ungated: false,
   ungatedReason: null,
-} satisfies GateEvaluatedEvent & GateEvaluatedUngated;
+} satisfies GateEvaluatedEvent;
 
 export const W6_REFUSED_COMMAND = 'gh pr create --title "test(run-lifecycle): gap tests" --body-file /tmp/body.md';
 export const W6_REMEDY = "delivery is performed by the run's deliver phase";
@@ -147,13 +143,14 @@ export const WORKER_TOOL_DENIED = {
   remedy: W6_REMEDY,
 } satisfies WorkerToolCallDeniedEvent;
 
-/** The same fence with the remedy left `null` — the studio states the platform's sentence. */
+/** The same fence with the remedy left `null` — 0.36.0 declares `remedy: string`, so this is the
+ *  frame of an engine that sends none; the studio states the platform's sentence. */
 export const WORKER_TOOL_DENIED_NO_REMEDY = {
   ...WORKER_TOOL_DENIED,
   command: 'git push origin HEAD',
   reason: 'remote write refused for a creator seat: git push',
   remedy: null,
-} satisfies WorkerToolCallDeniedEvent;
+} satisfies Omit<WorkerToolCallDeniedEvent, 'remedy'> & { remedy: null };
 
 /** The frames of the completed run, in the daemon's order (`seq`-less: `hydrate` keeps order). */
 export const W6_EVENTS: CoreEvent[] = [

--- a/tests/narrator.test.ts
+++ b/tests/narrator.test.ts
@@ -29,7 +29,7 @@ describe('narrate — the event → status-line templates (§4)', () => {
     [{ type: 'councilDeliberated', session: 'r', ord: 1, round: 2, agreementPct: 50, neededPct: 75 }, 'Ballot 2: 50% — below the 75% bar, runoff', 'info'],
     [{ type: 'councilVoted', session: 'r', ord: 1, agreementPct: 100, votes: 4 }, 'Council voted — 100% agreement (4 votes)', 'info'],
     [{ type: 'councilSeatFailed', session: 'r', ord: 1, cli: 'codex', kind: 'timed_out' }, 'Seat codex did not vote (timed_out)', 'fail'],
-    [{ type: 'unitDistributed', session: 'r', ord: 2, cli: 'claude', agreement_pct: 83 }, 'phase-2 routed to claude — council 83%', 'info'],
+    [{ type: 'unitDistributed', session: 'r', ord: 2, cli: 'claude', agreementPct: 83 }, 'phase-2 routed to claude — council 83%', 'info'],
     [{ type: 'unitDispatched', session: 'r', ord: 2, attempt: 0 }, 'Worker started phase-2', 'work'],
     [{ type: 'unitDispatched', session: 'r', ord: 2, attempt: 1 }, 'phase-2 re-dispatched (attempt 2)', 'work'],
     [{ type: 'unitExecuting', session: 'r', ord: 2 }, 'phase-2 is running', 'work'],

--- a/tests/narrator.wave6.test.ts
+++ b/tests/narrator.wave6.test.ts
@@ -1,7 +1,7 @@
 // The wave-6 wire (api-types 0.36.0) in the FEED (DES-RUN-NARRATOR §4): a degraded council said
 // on the routing line, a gate the engine calls UNGATED said as UNGATED (never "Checks ran — pass"
 // alone), the remote-write fence with its remedy, and the camelCase `agreementPct` the engine
-// actually emits — with the snake_case 0.34.0 spelling still read as the fallback until the pin.
+// actually emits and 0.36.0 declares — the deprecated snake_case aliases are no longer read.
 
 import { describe, expect, it } from 'vitest';
 import type { CoreEvent } from '../src/api/types.js';
@@ -12,7 +12,7 @@ import {
   GATE_UNGATED_WITH_FLOOR,
   UNIT_DISTRIBUTED_DEGRADED,
   UNIT_DISTRIBUTED_FULL,
-  UNIT_DISTRIBUTED_SNAKE,
+  UNIT_DISTRIBUTED_DEPRECATED_ALIASES,
   W6_DEGRADED_REASON,
   W6_REFUSED_COMMAND,
   W6_REMEDY,
@@ -40,13 +40,14 @@ describe('unitDistributed — the camelCase spelling, and the degraded council',
     expect(line.ord).toBe(2);
   });
 
-  it('the 0.34.0 snake_case spelling is still read as the fallback (TODO drop at the 0.36.0 pin)', () => {
-    const line = narrate(ev(UNIT_DISTRIBUTED_SNAKE), ctx)!;
-    expect(line.text).toBe('phase-2 routed to claude — council 67% — council degraded: 2 of 5 seats benched: codex, pi (signed out)');
+  it('the deprecated snake_case aliases are NOT read (dropped at the 0.36.0 pin) — a frame carrying only them routes with no pct and no degraded line', () => {
+    const line = narrate(ev(UNIT_DISTRIBUTED_DEPRECATED_ALIASES), ctx)!;
+    expect(line.text).toBe('phase-2 routed to claude');
+    expect(line.tone).toBe('info');
   });
 
-  it('camelCase wins when both spellings are present', () => {
-    const line = narrate(ev({ ...UNIT_DISTRIBUTED_SNAKE, agreementPct: 100, degradedReason: null }), ctx)!;
+  it('the camelCase spelling beside the aliases is the only one read', () => {
+    const line = narrate(ev({ ...UNIT_DISTRIBUTED_DEPRECATED_ALIASES, agreementPct: 100, degradedReason: null }), ctx)!;
     expect(line.text).toBe('phase-2 routed to claude — council 100%');
     expect(line.tone).toBe('info');
   });

--- a/tests/skillsWire.test.ts
+++ b/tests/skillsWire.test.ts
@@ -1,9 +1,9 @@
 /**
- * The skills wire MIRROR is pinned byte-for-byte to the vendored 0.35.0 contract (the 0.34.0 skills block, byte-identical, relabelled).
+ * The skills wire MIRROR is pinned byte-for-byte to the vendored 0.36.0 contract (the 0.35.0 skills block + the F-083 stale-rules additions).
  *
  * `src/api/skills-wire.ts` carries the skills block and the `diagnostics.skills` block of
- * `wicked-crew-api-types@0.35.0` (crew#533; the skills block is 0.34.0/crew#531, unchanged) copied VERBATIM between `>>> VERBATIM` / `<<< VERBATIM`
- * markers, and `tests/fixtures/api-types-0.35.0-skills.d.ts` is a byte copy of the same regions
+ * `wicked-crew-api-types@0.36.0` (crew#535 via crew#536; the 0.34.0/crew#531 block plus F-083) copied VERBATIM between `>>> VERBATIM` / `<<< VERBATIM`
+ * markers, and `tests/fixtures/api-types-0.36.0-skills.d.ts` is a byte copy of the same regions
  * taken from the package's `index.d.ts`. This test compares every marked region of the two files:
  * a hand edit to the mirror, or a re-vendored fixture from a re-minted contract, fails here until
  * both agree again — the mirror can never quietly drift from the wire crew serves.
@@ -19,7 +19,7 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 const MIRROR = fileURLToPath(new URL('../src/api/skills-wire.ts', import.meta.url));
-const FIXTURE = fileURLToPath(new URL('./fixtures/api-types-0.35.0-skills.d.ts', import.meta.url));
+const FIXTURE = fileURLToPath(new URL('./fixtures/api-types-0.36.0-skills.d.ts', import.meta.url));
 const INSTALLED = fileURLToPath(new URL('../node_modules/wicked-crew-api-types/index.d.ts', import.meta.url));
 const INSTALLED_PKG = fileURLToPath(new URL('../node_modules/wicked-crew-api-types/package.json', import.meta.url));
 const PINNED_PKG = fileURLToPath(new URL('../package.json', import.meta.url));
@@ -53,10 +53,10 @@ function regions(path: string): Array<{ label: string; body: string }> {
   return out;
 }
 
-describe('src/api/skills-wire.ts — a byte-for-byte mirror of the 0.35.0 skills contract', () => {
+describe('src/api/skills-wire.ts — a byte-for-byte mirror of the 0.36.0 skills contract', () => {
   it('carries the MIRROR header naming the contract, the PR, and the release swap', () => {
     const head = readFileSync(MIRROR, 'utf8').slice(0, 400);
-    expect(head).toContain('MIRROR of wicked-crew-api-types 0.35.0 skills block (crew#531) — replace with imports from the');
+    expect(head).toContain('MIRROR of wicked-crew-api-types 0.36.0 skills block (crew#531, crew#535) — replace with imports from the');
     expect(head).toContain('published package at release.');
   });
 
@@ -71,10 +71,10 @@ describe('src/api/skills-wire.ts — a byte-for-byte mirror of the 0.35.0 skills
     }
   });
 
-  it('the two regions are the skills block and the diagnostics.skills block of 0.35.0', () => {
+  it('the two regions are the skills block and the diagnostics.skills block of 0.36.0', () => {
     const labels = regions(FIXTURE).map((r) => r.label);
-    expect(labels[0]).toMatch(/^wicked-crew-api-types@0\.35\.0 index\.d\.ts.* — the skills block$/);
-    expect(labels[1]).toMatch(/^wicked-crew-api-types@0\.35\.0 index\.d\.ts.* — the diagnostics skills block$/);
+    expect(labels[0]).toMatch(/^wicked-crew-api-types@0\.36\.0 index\.d\.ts.* — the skills block$/);
+    expect(labels[1]).toMatch(/^wicked-crew-api-types@0\.36\.0 index\.d\.ts.* — the diagnostics skills block$/);
     const [skills, diagnostics] = regions(FIXTURE).map((r) => r.body);
     // The declarations studio consumes are all in the block — a re-mint that drops one fails here.
     for (const name of [
@@ -86,11 +86,16 @@ describe('src/api/skills-wire.ts — a byte-for-byte mirror of the 0.35.0 skills
       'export interface SkillAnalyzeResult', 'export interface SkillMutationResult', 'export interface SkillPublishResult',
       'export interface SkillRefreshResult', 'export interface SkillRevisionConflict', 'export interface SkillRevisionBody',
       'export interface PutSkillFileBody', 'export interface AddSkillBody', 'export interface ReplaceSkillBody',
+      'export interface PortabilityRulesIdentity', 'export interface SnapshotRowDrift',
     ]) {
       expect(skills, name).toContain(name);
     }
     expect(diagnostics).toContain("export type DiagnosticsSkillsState = 'published' | 'fallback' | 'blocked' | 'config-error' | 'disabled';");
     expect(diagnostics).toContain('export interface DiagnosticsSkills {');
+    // 0.36.0 (F-083 / crew#535): the stale-rules finding kind, and the manifest's recorded-vs-running rules + drift.
+    expect(diagnostics).toContain("    | 'skills.stale-rules';");
+    expect(skills).toContain('    rules?: {');
+    expect(skills).toContain('    drift?: SnapshotRowDrift[];');
     // The three wire rules the mirror header restates come from the block itself.
     expect(skills).toContain('revision: number;');
     expect(skills).toContain('expectedRevision: number;');

--- a/tests/wave6Wire.test.ts
+++ b/tests/wave6Wire.test.ts
@@ -1,17 +1,15 @@
 /**
  * The wave-6 wire MIRROR (`src/api/wave6-wire.ts`) against the INSTALLED `wicked-crew-api-types`.
  *
- * The #257 parity pattern (`tests/skillsWire.test.ts`), in two postures keyed on the pin:
+ * The #257 parity pattern (`tests/skillsWire.test.ts`), now in its PINNED posture (pin ≥ 0.36.0,
+ * the version that published the wire): every `>>> VERBATIM … <<< VERBATIM` region of the mirror is
+ * byte-equal to the installed package at the labelled line range, every label names the pinned
+ * version, and every wave-6 declaration studio codes against lives INSIDE a region (a trivial region
+ * beside a hand-written wave-6 block does not satisfy the pin — independent review of #263, F-6).
  *
- *  - PROVISIONAL (pin < 0.36.0 — the wire is not published yet): the mirror's header says
- *    PROVISIONAL, none of the wave-6 names exist in the installed `index.d.ts` (so studio cannot
- *    be silently reading a shape the pinned contract already declares differently), the readers
- *    are null-safe on a frame without the keys, and every name the wave-6 briefs give is spelled
- *    in the mirror exactly.
- *  - PINNED (pin ≥ 0.36.0): the mirror MUST have been re-vendored — VERBATIM regions between
- *    `>>> VERBATIM wicked-crew-api-types@<v> index.d.ts:<from>-<to> …` / `<<< VERBATIM` markers,
- *    each byte-equal to the installed package at the labelled line range — and the PROVISIONAL
- *    header must be gone. A pin bump without the re-vendor fails HERE.
+ * The two WIRE GAPS the mirror keeps studio-worded (a row-level `Campaign.test_set` /
+ * `RunGroup.test_set` join; `TestingReconBody.workflow`) are guarded the other way round: the
+ * installed package must NOT declare them — the version that does fails here and says "re-vendor".
  *
  * @vitest-environment node
  */
@@ -32,16 +30,18 @@ import {
 } from '../src/api/wave6-wire.js';
 
 const MIRROR = fileURLToPath(new URL('../src/api/wave6-wire.ts', import.meta.url));
+const SKILLS_MIRROR = fileURLToPath(new URL('../src/api/skills-wire.ts', import.meta.url));
 const INSTALLED = fileURLToPath(new URL('../node_modules/wicked-crew-api-types/index.d.ts', import.meta.url));
 const INSTALLED_PKG = fileURLToPath(new URL('../node_modules/wicked-crew-api-types/package.json', import.meta.url));
 const PINNED_PKG = fileURLToPath(new URL('../package.json', import.meta.url));
 
-/** The version the wave-6 wire publishes under. */
+/** The version the wave-6 wire publishes under — the mirror's floor. */
 const WAVE6_VERSION = [0, 36, 0] as const;
 
 const LABEL = /^wicked-crew-api-types@(\S+) index\.d\.ts:(\d+)-(\d+) /;
 const BEGIN = /^\/\/ >>> VERBATIM (.+)$/;
 const END = '// <<< VERBATIM';
+const GAPS_BANNER = '// ── WIRE GAPS — PROVISIONAL';
 
 function semver(v: string): [number, number, number] {
   const m = /^(\d+)\.(\d+)\.(\d+)/.exec(v);
@@ -83,59 +83,98 @@ const installed = JSON.parse(readFileSync(INSTALLED_PKG, 'utf8')) as { version: 
 const pinned = (JSON.parse(readFileSync(PINNED_PKG, 'utf8')) as { devDependencies: Record<string, string> }).devDependencies['wicked-crew-api-types']!;
 const mirror = readFileSync(MIRROR, 'utf8');
 const installedDts = readFileSync(INSTALLED, 'utf8');
-const pinnedAtWave6 = atLeast(installed.version, WAVE6_VERSION);
+const rs = regions(MIRROR);
+const regionText = rs.map((r) => r.body).join('\n');
+const gapsAt = mirror.indexOf(GAPS_BANNER);
 
-/** Every wave-6 name the briefs give — spelled once here, asserted present in the mirror. The first
- *  entry is studio's own constant (the workflow id the panel reads off `GET /workflows`); every other
- *  entry is a contract declaration that must live inside a VERBATIM region once the pin lands. */
-const STUDIO_CONSTANTS = ["QE_AUTHOR_TESTS_WORKFLOW_ID = 'qe-author-tests'"];
+/** Studio's own spellings — the constants the surfaces speak; asserted present in the mirror. */
+const STUDIO_CONSTANTS = [
+  "QE_AUTHOR_TESTS_WORKFLOW_ID = 'qe-author-tests'",
+  `WORKER_REMOTE_WRITE_REMEDY = "delivery is performed by the run's deliver phase"`,
+];
+
+/** Every wave-6 declaration the briefs name, spelled as 0.36.0 PUBLISHES it — each must live inside
+ *  a VERBATIM region of the mirror. */
 const WAVE6_DECLS = [
-  'export interface TestingAuthorBody',
-  'export interface TestingAuthorResponse',
-  'export interface TestSetRegistration',
-  "export type RunDiffSource = 'worktree' | 'branch'",
+  // POST /testing/author + the registered test set
+  "export type QeAuthorTestsWorkflowId = 'qe-author-tests';",
+  'export interface TestingAuthorBody {',
+  'export interface TestingAuthorResponse {',
+  'export interface WorkflowPlan {',
+  'export interface TestingAuthorRun {',
+  'export interface TestSet {',
+  'test_sets?: TestSet[];',
+  'export interface TestingReconBody {',
+  // GET /runs/:id/diff
+  "source?: 'worktree' | 'branch';",
+  // gateEvaluated
   'ungated?: boolean;',
   'ungatedReason?: string | null;',
-  'degradedReason?: string | null;',
-  'agreementPct?: number | null;',
+  'floorNote?: string | null;',
+  'judgeSkippedReason?: string | null;',
+  // repoChecksEvaluated
+  'sandboxLevel?: string;',
+  'sandboxError?: string | null;',
+  'detectError?: string | null;',
+  // unitDistributed — camelCase
+  'export interface UnitDistributedEvent {',
+  "routingMethod: 'council' | 'degraded' | 'evaluator_distinct' | 'tool';",
+  'agreementPct: number | null;',
+  'seated: number | null;',
+  'degradedReason: string | null;',
+  'seatConstraint: string | null;',
+  // workerToolCallDenied
   "type: 'workerToolCallDenied';",
   "carrier: 'acp' | 'wrapped_cli' | (string & {});",
-  'role: string;',
+  "role: 'creator' | 'evaluator' | 'neutral' | (string & {});",
   'tool: string;',
   'command: string;',
-  'remedy: string | null;',
+  'remedy: string;',
+  // acpFallback auth kinds
+  "| 'auth_failed'",
+  "| 'unauthenticated'",
+  // runBaseResolved
+  'runBranch?: string;',
+  // roster
+  'auth?: SeatAuth;',
+  "auth_source?: 'seat-stderr';",
+  "free_tier_source?: 'registry' | 'crew-heuristic';",
+  'council_eligible?: boolean;',
+  'council_bench?: RosterSeatCouncilBench;',
+  // chat refused[]
+  "export type ChatRefusalSource = 'auth' | 'scope' | 'bench' | 'budget' | 'engine' | (string & {});",
+  'refused?: ChatSeatRefusal[];',
+  'refused?: ChatSeatRefusal[] | null;',
+  // GET /interactive/docs
+  'export interface InteractiveDocsListing {',
+  'export interface InteractiveDocIndexRow {',
+  'unreachable: InteractiveDocsUnreachable[];',
 ];
-const WAVE6_NAMES = [...STUDIO_CONSTANTS, ...WAVE6_DECLS];
+
+/** The wave-6 SKILLS additions live in the skills block, vendored by `skills-wire.ts`. */
+const WAVE6_SKILLS_DECLS = [
+  "| 'skills.stale-rules';",
+  'export interface PortabilityRulesIdentity {',
+  'export interface SnapshotRowDrift {',
+  'drift?: SnapshotRowDrift[];',
+];
 
 describe('src/api/wave6-wire.ts — the wave-6 mirror against the installed contract', () => {
-  it('the devDependency is an exact pin equal to the installed version', () => {
+  it('the devDependency is an exact pin equal to the installed version, at or above the wave-6 floor', () => {
     expect(pinned).toBe(installed.version);
+    expect(atLeast(installed.version, WAVE6_VERSION), `${installed.version} ≥ 0.36.0`).toBe(true);
   });
 
-  it('spells every name the wave-6 briefs give, exactly', () => {
-    for (const name of WAVE6_NAMES) expect(mirror, name).toContain(name);
+  it('carries the MIRROR header naming the contract and the release swap; PROVISIONAL only in the wire-gaps section', () => {
+    const head = mirror.slice(0, 400);
+    expect(head).toContain(`MIRROR of the wicked-crew-api-types ${installed.version} wave-6 additions`);
+    expect(head).toContain('replace with imports from the');
+    expect(gapsAt, 'the wire-gaps section exists').toBeGreaterThan(0);
+    expect(mirror.slice(0, gapsAt)).not.toContain('PROVISIONAL');
   });
 
-  it(`posture: ${pinnedAtWave6 ? 'PINNED ≥ 0.36.0 — re-vendored VERBATIM regions, no PROVISIONAL header' : 'PROVISIONAL < 0.36.0 — the wave-6 names are NOT yet in the installed contract'}`, () => {
-    if (!pinnedAtWave6) {
-      expect(mirror.slice(0, 1200)).toContain('PROVISIONAL');
-      // None of these are declared by the pinned contract yet — if one appears, the pin moved (or a
-      // 0.35.x publish carried the wire under these names) and the mirror must be re-vendored
-      // against it (the other posture) rather than kept provisional. Both studio's own spellings
-      // (`TestSetRegistration`, `TestingAuthorBody`, `TestSetCounts`, `test_set`, `testing/author`)
-      // and the engine's (`workerToolCallDenied`, `ungatedReason`, `degradedReason`) are guarded —
-      // independent review of #263, F-6.
-      for (const name of [
-        'workerToolCallDenied', 'ungatedReason', 'degradedReason',
-        'TestSetRegistration', 'TestingAuthorBody', 'TestSetCounts', 'test_set', 'testing/author',
-      ]) {
-        expect(installedDts, `${name} declared by ${installed.version} — re-vendor the mirror`).not.toContain(name);
-      }
-      return;
-    }
-    expect(mirror.slice(0, 1200)).not.toContain('PROVISIONAL');
-    const rs = regions(MIRROR);
-    expect(rs.length, 'at least one VERBATIM region').toBeGreaterThan(0);
+  it('every VERBATIM region is byte-equal to the INSTALLED package at the labelled line range, and the label names the pinned version', () => {
+    expect(rs.length, 'the regions').toBeGreaterThanOrEqual(14);
     const lines = installedDts.split('\n');
     for (const { label, body } of rs) {
       const m = LABEL.exec(label);
@@ -144,15 +183,41 @@ describe('src/api/wave6-wire.ts — the wave-6 mirror against the installed cont
       expect(version, label).toBe(installed.version);
       expect(body, label).toBe(lines.slice(Number(from) - 1, Number(to)).join('\n'));
     }
-    // Every wave-6 declaration must live INSIDE a verbatim region — a trivial region beside a
-    // still-hand-written wave-6 block does not satisfy the pin (F-6).
-    const regionText = rs.map((r) => r.body).join('\n');
-    for (const name of WAVE6_DECLS) {
-      expect(regionText, `${name} inside a VERBATIM region`).toContain(name);
-    }
-    for (const name of ['workerToolCallDenied', 'ungatedReason', 'degradedReason']) {
+  });
+
+  it('every wave-6 declaration lives INSIDE a VERBATIM region (F-6), spelled as the package publishes it', () => {
+    for (const name of WAVE6_DECLS) expect(regionText, `${name} inside a VERBATIM region`).toContain(name);
+    for (const name of WAVE6_DECLS) expect(installedDts, `${name} declared by ${installed.version}`).toContain(name);
+  });
+
+  it('spells the constants studio speaks, exactly', () => {
+    for (const name of STUDIO_CONSTANTS) expect(mirror, name).toContain(name);
+  });
+
+  it('the wave-6 SKILLS additions (stale-rules, current.rules / drift) are declared by the package and vendored by skills-wire.ts', () => {
+    const skills = regions(SKILLS_MIRROR).map((r) => r.body).join('\n');
+    for (const name of WAVE6_SKILLS_DECLS) {
       expect(installedDts, name).toContain(name);
+      expect(skills, `${name} inside a skills-wire.ts VERBATIM region`).toContain(name);
     }
+  });
+
+  it('WIRE GAP 1 — a row-level `test_set` join / `TestSetRegistration` is NOT declared by the package; the mirror keeps it provisional', () => {
+    expect(installedDts).not.toMatch(/\btest_set\b/);
+    expect(installedDts).not.toContain('TestSetRegistration');
+    // The package serves the sets at the list level instead — vendored, so the gap is legible.
+    expect(regionText).toContain('test_sets?: TestSet[];');
+    const gaps = mirror.slice(gapsAt);
+    expect(gaps).toContain('export interface TestSetRegistration {');
+    expect(gaps).toContain('test_set?: TestSetRegistration | null;');
+  });
+
+  it('WIRE GAP 2 — `TestingReconBody` declares no `workflow` key; the mirror keeps the ladder rung provisional', () => {
+    const recon = rs.find((r) => r.label.includes('TestingReconBody'));
+    expect(recon, 'the TestingReconBody region').toBeDefined();
+    expect(recon!.body).toContain('export interface TestingReconBody {');
+    expect(recon!.body).not.toContain('workflow');
+    expect(mirror.slice(gapsAt)).toContain('export interface TestingReconWorkflowBody {');
   });
 });
 
@@ -165,19 +230,20 @@ describe('the null-safe readers — an older daemon\'s frame changes nothing', (
     expect(gateUngated({ type: 'gateEvaluated', session: 'r', ungated: true } as never)).toBe(true);
     expect(gateUngatedReason({ type: 'gateEvaluated', session: 'r', ungatedReason: '' } as never)).toBeNull();
   });
-  it('distribution: camelCase first, snake_case fallback, null/absent → null', () => {
+  it('distribution: the camelCase spelling ONLY — the deprecated snake_case aliases the engine never emitted are not read', () => {
     expect(distributionDegradedReason(bare)).toBeNull();
     expect(distributionAgreementPct(bare)).toBeNull();
-    expect(distributionDegradedReason({ type: 'unitDistributed', session: 'r', degraded_reason: 'x' } as never)).toBe('x');
-    expect(distributionDegradedReason({ type: 'unitDistributed', session: 'r', degradedReason: 'y', degraded_reason: 'x' } as never)).toBe('y');
+    expect(distributionDegradedReason({ type: 'unitDistributed', session: 'r', degradedReason: 'y' } as never)).toBe('y');
+    expect(distributionDegradedReason({ type: 'unitDistributed', session: 'r', degraded_reason: 'x' } as never)).toBeNull();
+    expect(distributionDegradedReason({ type: 'unitDistributed', session: 'r', degradedReason: null, degraded_reason: 'x' } as never)).toBeNull();
     expect(distributionAgreementPct({ type: 'unitDistributed', session: 'r', agreementPct: 66 } as never)).toBe(66);
-    expect(distributionAgreementPct({ type: 'unitDistributed', session: 'r', agreement_pct: 50 } as never)).toBe(50);
+    expect(distributionAgreementPct({ type: 'unitDistributed', session: 'r', agreement_pct: 50 } as never)).toBeNull();
     expect(distributionAgreementPct({ type: 'unitDistributed', session: 'r', agreementPct: Number.NaN } as never)).toBeNull();
   });
   it('diff: only the two declared sources; anything else (absent, a newer token) is null', () => {
     expect(diffSource({ diff: '', truncated: false })).toBeNull();
-    expect(diffSource({ diff: '', truncated: false, source: 'branch' } as never)).toBe('branch');
-    expect(diffSource({ diff: '', truncated: false, source: 'worktree' } as never)).toBe('worktree');
+    expect(diffSource({ diff: '', truncated: false, source: 'branch' })).toBe('branch');
+    expect(diffSource({ diff: '', truncated: false, source: 'worktree' })).toBe('worktree');
     expect(diffSource({ diff: '', truncated: false, source: 'bundle' } as never)).toBeNull();
   });
   it('the constants studio speaks', () => {

--- a/tests/wire433.shapes.test.ts
+++ b/tests/wire433.shapes.test.ts
@@ -55,7 +55,10 @@ import {
  * reads the INSTALLED `index.d.ts`, extracts each declaration's key set and each union's tokens, and
  * diffs the frames against them — "every key present, `null` never absent, nothing the wire does not
  * declare" is re-derived from the package the lockfile resolved, not from a hand-copied list that
- * would drift silently on the next pin.
+ * would drift silently on the next pin. Since the 0.36.0 pin the installed declarations carry OPTIONAL
+ * wave-6 keys (`ungated?` / `floorNote?` / `judgeSkippedReason?`, `sandboxLevel?` / `sandboxError?` /
+ * `detectError?`, `runBranch?`, …) declared "absent on an older engine" — a recorded 0.33.0 frame omits
+ * them, so the key pin reads "every REQUIRED key present, nothing undeclared".
  */
 
 const PKG_ROOT = new URL('../', import.meta.url);
@@ -74,6 +77,12 @@ function declaredKeys(name: string): string[] {
   return [...declBody(name).matchAll(/^\s+([A-Za-z_]\w*)\??:/gm)].map((m) => m[1]!).sort();
 }
 
+/** The REQUIRED property names (no `?`) — the keys a frame from the declaring engine always carries.
+ *  The optional ones are the wire's later additions, declared absent on an older engine. */
+function requiredKeys(name: string): string[] {
+  return [...declBody(name).matchAll(/^\s+([A-Za-z_]\w*):/gm)].map((m) => m[1]!).sort();
+}
+
 /** The `type: '<token>'` discriminant a frame declaration carries. */
 function declaredType(name: string): string {
   const m = /^\s+type: '([A-Za-z]+)';/m.exec(declBody(name));
@@ -83,8 +92,10 @@ function declaredType(name: string): string {
 
 /** The quoted tokens of a string-literal union (`export type X = | 'a' | 'b' | (string & {})`), sorted. */
 function unionTokens(name: string): string[] {
+  // Doc comments between union members (0.36.0 documents the wave-6 `AcpFallbackKind` tokens inline)
+  // may carry a `;` — strip them before the lazy match to the union's terminating `;`.
   const re = new RegExp(`^export type ${name} =([\\s\\S]*?);`, 'm');
-  const m = re.exec(DTS);
+  const m = re.exec(DTS.replace(/\/\*[\s\S]*?\*\//g, ''));
   if (m === null) throw new Error(`${name} is not declared in the installed wicked-crew-api-types index.d.ts`);
   return [...m[1]!.matchAll(/'([^']+)'/g)].map((x) => x[1]!).sort();
 }
@@ -123,13 +134,19 @@ describe('wire433 fixtures — the shapes wicked-crew-api-types 0.33.0 declares'
   });
 
   for (const [name, frames] of Object.entries(pinned)) {
-    it(`${name}: every frame carries exactly the declared keys, each present (null, never absent)`, () => {
-      const keys = declaredKeys(name);
-      expect(keys.length).toBeGreaterThan(3);
+    it(`${name}: every frame carries every REQUIRED key, each present (null, never absent), and nothing undeclared`, () => {
+      const declared = declaredKeys(name);
+      const required = requiredKeys(name);
+      expect(required.length).toBeGreaterThan(3);
       const token = declaredType(name);
       for (const frame of frames) {
         expect(frame.type).toBe(token);
-        expect(wireKeys(frame)).toEqual(keys);
+        const keys = wireKeys(frame);
+        // Nothing the wire does not declare …
+        expect(keys.filter((k) => !declared.includes(k)), `${name}: undeclared keys`).toEqual([]);
+        // … and every required key present; the optional (later-wave) keys may be absent on these
+        // 0.33.0-era frames, exactly as their declarations say.
+        expect(required.filter((k) => !keys.includes(k)), `${name}: missing required keys`).toEqual([]);
         expect(Object.values(frame).some((v) => v === undefined)).toBe(false);
         expect(typeof frame['seq']).toBe('number');
         expect(typeof frame['ts']).toBe('number');


### PR DESCRIPTION
## Summary

Pins `wicked-crew-api-types` to **0.36.0** (exact — the wave-6 wire, published by crew#536; `skills.stale-rules` from crew#535) and re-vendors BOTH of studio's wire mirrors from the installed `index.d.ts`, the #257 byte-parity pattern.

### The skills mirror (`src/api/skills-wire.ts`)
- Fixture renamed `tests/fixtures/api-types-0.36.0-skills.d.ts`; both regions byte-equal to the installed package at the labelled ranges (`index.d.ts:1969-2419` — the skills block; `4682-4741` — the diagnostics skills block).
- 0.36.0 is **additive** over 0.35.0 (not byte-identical this time): `SkillsManifestResponse.current.rules` / `drift`, `PortabilityRulesIdentity`, `SnapshotRowDrift`, and the `skills.stale-rules` finding kind (F-083). The header + `tests/skillsWire.test.ts` say so and assert the new names.

### The wave-6 mirror (`src/api/wave6-wire.ts`) — PROVISIONAL → VERBATIM
Every PROVISIONAL declaration is replaced by **14 VERBATIM regions** cut from the installed `index.d.ts` (doc-comment start → closing brace), labelled `wicked-crew-api-types@0.36.0 index.d.ts:<from>-<to>`, and pinned byte-for-byte against the installed package by `tests/wave6Wire.test.ts` in its ≥ 0.36.0 posture (every wave-6 declaration must live INSIDE a region — review F-6):

| wave-6 name (brief) | published declaration vendored |
|---|---|
| `POST /testing/author` + `TestingAuthorBody` / `TestingAuthorResponse` | `QeAuthorTestsWorkflowId`, `TestingAuthorBody` (+ `deliver`), `WorkflowPlanPhase`, `WorkflowPlan`, `TestingAuthorRun`, `TestingAuthorResponse` (`runs[]`, `gate`, `deliver`, `plan`, `scope`), `TestSetFile`, `TestSet` |
| Campaign / RunGroup `test_set` + `TestSetRegistration` | `CampaignsListResponse.test_sets?: TestSet[]` — see wire gap 1 |
| `RunDiff.source` | `RunDiff` incl. `source` / `branch` / `base` |
| `gateEvaluated` ungated / ungatedReason / floorNote / judgeSkippedReason | `GateEvaluatedEvent` |
| `repoChecksEvaluated` sandboxLevel / sandboxError / detectError | `RepoChecksEvaluatedEvent` |
| `unitDistributed` camelCase | `UnitDistributedEvent` (+ `seatConstraint`, `BenchedSeat`) |
| `workerToolCallDenied` incl. carrier / tool | `WorkerToolCallDeniedEvent` (`remedy: string`) |
| `acpFallback` auth kinds | `AcpFallbackKind` (`auth_failed`, `unauthenticated`) + `AcpFallbackEvent` |
| `runBaseResolved.runBranch` | `RunBaseResolvedEvent` |
| roster auth / council_eligible / free_tier_source / council_bench | `RosterSeat` + `RosterSeatCouncilBench` + `SeatAuth` |
| chat `refused[]` | `ChatSeatOutcome`, `ChatRefusalSource`, `ChatSeatRefusal`, `ChatOpenResponse`, `ChatSeatRefusedFrame`, `ChatDetailResponse` |
| `GET /interactive/docs` rows | `InteractiveDocsListing`, `InteractiveSeamKind`, `InteractiveDocIndexRow`, `InteractiveDocsUnreachable` |
| `skills.stale-rules` + `current.rules` / `drift` | in the SKILLS block — vendored by `skills-wire.ts` (asserted from `wave6Wire.test.ts` too) |

- The `unitDistributed` **snake_case fallbacks are dropped** (`agreement_pct`, `degraded_reason`): 0.36.0 declares them `@deprecated` and states the engine never emitted them. The readers read camelCase only; the fixture frame carrying only the aliases now proves the readers ignore it (`narrator.wave6`, `RunDegradedNote`, `wave6Wire` tests). `tests/narrator.test.ts` spells its `unitDistributed` frame `agreementPct`.
- Consumer-facing exports are unchanged (`gateUngated`, `distribution*`, `diffSource`, `docsIndexOf`, `testSetOf`, the constants) — no `src/components` file moves.

### Wire gaps (kept PROVISIONAL, studio-worded, test-guarded)
Two shapes studio codes against are **not declared by 0.36.0**; each stays in the mirror's `WIRE GAPS` section with a comment, and `tests/wave6Wire.test.ts` asserts the installed package does NOT declare them — the version that does turns this into a failing test ("re-vendor"), never silent drift:
1. **Row-level `Campaign.test_set` / `RunGroup.test_set` (`TestSetRegistration`)** — 0.36.0 serves the produced sets as a separate top-level `CampaignsListResponse.test_sets: TestSet[]` (snake_case, `run_id`-keyed, `produced`/`executed`/`passed`/`failed`/`not_executed`, `deliverUrl`). Studio's Test landing reads the row join, so against a 0.36.0 daemon a card renders no counts (absence, never a fabricated zero). Adapting the landing to `test_sets` is a `src/` change outside this pin PR.
2. **`TestingReconBody.workflow`** — the launch ladder's middle rung; 0.36.0's `TestingReconBody` (vendored as evidence) has no such key. A 0.36.0 daemon answers the first rung (`POST /testing/author`), so the rung is only reached on a daemon lacking that route.

Also noted: the published `TestingAuthorResponse` carries `runs[]`/`plan`/`gate`/`scope` and no `campaign` — studio's launch panel already reads the answer as a bag (`TestingLaunchResult`), so nothing breaks; the "under <campaign>" line simply does not render for an author launch.

### `tests/wire433.shapes.test.ts`
The 0.33.0 gate-evidence key-parity test parsed the installed declarations as "exactly these keys"; 0.36.0 adds OPTIONAL keys declared "absent on an older engine" (`ungated?`, `floorNote?`, `sandboxLevel?`, `runBranch?`, …) and documents the `AcpFallbackKind` members inline (a `;` inside a doc comment truncated the union parse). The pin now reads "every REQUIRED key present, nothing undeclared" and strips block comments before the union match — the recorded 0.33.0 frames stay honest.

## Gates (local, this branch)
- `npm run typecheck` ✓ · `npm run lint` ✓ · `npm test` ✓ (293 files / 3160 tests) · `npm run build` ✓
- `e2e/governed_testing_test.py` ✓ 12/12 · `e2e/vibe_corpus_test.py` ✓ 5/5 (`PLAYWRIGHT_CHANNEL=chrome`, same-origin dist)
- Files changed: the pin, the lockfile (api-types entries only), the two mirrors, the skills fixture (renamed), tests, CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
