### PR TITLE
chore(release): 0.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ npm publish dates. Every version listed here exists on
 [npm](https://www.npmjs.com/package/wicked-studio?activeTab=versions).
 
 ## [Unreleased]
+
+## [0.5.7] — 2026-09-11
+_The published bundle is built against `wicked-crew-api-types` **0.36.0** — the exact
+devDependency pin on this cut (#264), and the wire the bundle's mirrors and `satisfies` checks are
+typed against: both wire mirrors (`src/api/skills-wire.ts`, `src/api/wave6-wire.ts`) are byte-pinned
+to it. Two wire gaps (a row-level `Campaign.test_set` / `RunGroup.test_set` join;
+`TestingReconBody.workflow`) stay studio-worded and test-guarded — see *Changed* below._
 ### Added
 - **New test launches the governed `qe-author-tests` workflow; the Test landing shows the produced
   set; honest UNGATED / degraded gates; a files view once the worktree is gone** (wave 6 — the
@@ -1015,7 +1022,8 @@ The merged interactive layer: wicked-interactive's UI moved into this skin (DES-
   `git subtree split` (92 commits).
 - The SPA as a pure HTTP/WS client of the wicked-crew daemon: runs, gates, live CoreEvents.
 
-[Unreleased]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.6...HEAD
+[Unreleased]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.7...HEAD
+[0.5.7]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.6...v0.5.7
 [0.5.6]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.5...v0.5.6
 [0.5.5]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.4...v0.5.5
 [0.5.4]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.3...v0.5.4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-studio",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-studio",
-      "version": "0.5.6",
+      "version": "0.5.7",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "^5.56.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-studio",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "The coder-facing skin of the wicked experience plane — a pure HTTP/WS client of the wicked-crew daemon's /api/v1",
   "type": "module",
   "repository": {

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -8,7 +8,7 @@
     "Entry kinds: `static` values appear verbatim in the DOM; `dynamic` are template-literal testids with each ${expr} normalised to '*'; `computed` carry the raw JSX expression — dynamic/computed resolve only against a live DOM."
   ],
   "version": 1,
-  "studioVersion": "0.5.6",
+  "studioVersion": "0.5.7",
   "counts": {
     "files": 146,
     "occurrences": 1295,


### PR DESCRIPTION
## Summary

Release **wicked-studio 0.5.7** — the wave-6 train cut: the governed testing journey from #263 plus the `wicked-crew-api-types` **0.36.0** pin and both re-vendored wire mirrors from #264.

Same shape as #262 (0.5.6):
- `package.json` + `package-lock.json` root fields → `0.5.7`
- `testid-inventory.json` `studioVersion` → `0.5.7` (`npm run manifest:testids`)
- `CHANGELOG.md`: `[Unreleased]` → `## [0.5.7] — 2026-09-11`, every wave-6 bullet kept, a **built against `wicked-crew-api-types` 0.36.0** note at the top of the section, the `[0.5.7]` compare link-ref added and `[Unreleased]` retargeted to `v0.5.7...HEAD`.

No source changes. After merge: annotated `v0.5.7` on the merge commit → `release.yml` (tag/manifest guard, `npm publish --provenance`, registry probe, GitHub Release from the CHANGELOG section).

## Gates (local, this branch)
- `npm run typecheck` ✓ · `npm run lint` ✓ · `npm test` ✓ · `npm run build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
