### PR TITLE
fix(testing): Test landing reads the daemon's top-level test_sets (0.36.0) — counts, PLAN and PR per produced set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,12 @@ npm publish dates. Every version listed here exists on
   `TestingReconBody` declares no `workflow` key) are deleted — `tests/wave6Wire.test.ts` now guards
   that neither shape returns. Fixtures (`tests/fixtures/wave6.ts`, `e2e/uxfix_fixture.py`) serve the
   real 0.36.0 shape; the testid inventory gains `campaign-card-testset-{verified,pr,more}`.
-  - *Review findings landed in-wave (independent review of #266, F-1..F-4):* the Tests tile's
-    context now LEADS with the sets word (`1 test set · 11/11 passed`) so it survives the tile's
-    ellipsis, the redundant "N ad-hoc group" word is gone, and every `StatTile` context carries
-    its full text as `title` (`stat-context`); sets no card can show are said as `· N
+  - *Review findings landed in-wave (independent review of #266, F-1..F-4, R2-1):* the Tests
+    tile's context now LEADS with the sets word — painted as `1 set · 11/11 passed`, sized to clear
+    the `…` glyph at 1440 px, with the unabridged `1 test set · 11/11 passed …` line as the span's
+    hover `title` — the redundant "N ad-hoc group" word is gone, and every `StatTile` context
+    carries its full text as `title` (`stat-context`; a `contextTitle` prop when the painted line
+    is an abridgement); sets no card can show are said as `· N
     unattributed` and `test_sets` rows served without a `run_id` as `· N malformed` (never
     folded away — `listCampaigns` now returns `malformedTestSets`); a 0.36 daemon's real zero
     renders as `no test sets registered yet` on the tile and `N tests · 0 test sets` on the Home

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,18 @@ npm publish dates. Every version listed here exists on
   `TestingReconBody` declares no `workflow` key) are deleted — `tests/wave6Wire.test.ts` now guards
   that neither shape returns. Fixtures (`tests/fixtures/wave6.ts`, `e2e/uxfix_fixture.py`) serve the
   real 0.36.0 shape; the testid inventory gains `campaign-card-testset-{verified,pr,more}`.
+  - *Review findings landed in-wave (independent review of #266, F-1..F-4):* the Tests tile's
+    context now LEADS with the sets word (`1 test set · 11/11 passed`) so it survives the tile's
+    ellipsis, the redundant "N ad-hoc group" word is gone, and every `StatTile` context carries
+    its full text as `title` (`stat-context`); sets no card can show are said as `· N
+    unattributed` and `test_sets` rows served without a `run_id` as `· N malformed` (never
+    folded away — `listCampaigns` now returns `malformedTestSets`); a 0.36 daemon's real zero
+    renders as `no test sets registered yet` on the tile and `N tests · 0 test sets` on the Home
+    door, while a pre-0.36 daemon still says nothing about sets; the launch panel reads
+    `/testing/author`'s `runs[].label` and says `filed under qe-tests-<repo> on the Test landing
+    — the set fills in when the verify phase registers it` (`testing-launch-filed-label`) instead
+    of "appears … when the run registers its test set". The Chrome rig asserts the sets word is
+    VISIBLE (glyph box inside the context span), not merely present in `textContent`.
 
 ## [0.5.7] — 2026-09-11
 _The published bundle is built against `wicked-crew-api-types` **0.36.0** — the exact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ npm publish dates. Every version listed here exists on
 [npm](https://www.npmjs.com/package/wicked-studio?activeTab=versions).
 
 ## [Unreleased]
+### Fixed
+- **The Test landing reads the daemon's top-level `test_sets` (api-types 0.36.0) — counts, PLAN and
+  PR per produced set.** The 0.5.7 landing (`CampaignsPage`, the Home "Test" door, `campaignStats`)
+  read a PROVISIONAL row-level `Campaign.test_set` / `RunGroup.test_set` join that 0.36.0 never
+  declared, so against a 0.36.0 daemon no card showed a produced set. The daemon serves the sets as
+  `CampaignsListResponse.test_sets: TestSet[]` (snake_case, `run_id`-keyed, tagged with the
+  `qe-tests-<repo>` label an authoring run is filed under); `listCampaigns` now normalizes them
+  (`testSets: null` = a pre-0.36 daemon — absence, never a fabricated zero), the store holds them,
+  and the fold joins them onto each campaign / label-group card by `run_id` (and by label for a
+  group). Each set renders its verified chip, `produced · executed · passed · failed` (plus
+  "· N not executed" when the verify phase left tests unrun), the PLAN (opens the producing run)
+  and the engine's PR (`isPrUrl`-gated); the Tests tile's context and the Home door append the
+  registered sets once the wire carries them. The provisional join, its `testSetOf` row reader and
+  the dead `POST /testing/recon` + `workflow` ladder rung (`qe-author-tests` shipped together with
+  `POST /testing/author`, so no daemon lists the workflow without the route; 0.36.0's
+  `TestingReconBody` declares no `workflow` key) are deleted — `tests/wave6Wire.test.ts` now guards
+  that neither shape returns. Fixtures (`tests/fixtures/wave6.ts`, `e2e/uxfix_fixture.py`) serve the
+  real 0.36.0 shape; the testid inventory gains `campaign-card-testset-{verified,pr,more}`.
 
 ## [0.5.7] — 2026-09-11
 _The published bundle is built against `wicked-crew-api-types` **0.36.0** — the exact

--- a/e2e/governed_testing_test.py
+++ b/e2e/governed_testing_test.py
@@ -16,9 +16,11 @@ No crew daemon is involved. Acceptance findings F-075 / F-076 / F-7R2-003 / -005
   3. THE PRODUCED SET (F-7R2-014): the landing's card — the `qe-tests-studio-api` label group
      0.36.0 files the run under — shows "verified · 11 produced · 11 executed · 11 passed · 0
      failed" off the TOP-LEVEL `test_sets` row joined by run_id, the workflow chip, the PLAN
-     (opens the run) and the engine's PR link. The Tests tile LEADS with the sets word — asserted
-     VISIBLE (its glyph box inside the context span, not ellipsized) with the full text as the
-     span's title — and says "1 malformed" for the run_id-less row the fixture also serves.
+     (opens the run) and the engine's PR link. The Tests tile LEADS with the sets word ("1 set ·
+     11/11 passed") — asserted PAINTED: its glyph box must end at least one `…` glyph (measured in
+     the span's own font) before the span's right edge whenever the line is clipped, at 1280, 1440
+     and 1920 px — with the unabridged "1 test set · …" line as the span's title, and it says
+     "1 malformed" for the run_id-less row the fixture also serves (R2-1 on #266).
   4. THE RUN PAGE (F-7R2-005 / -006 / -012 / -013 / -017): the run head says "council degraded:
      4 of 5 seats benched …"; the feed says "Gate UNGATED on author — no eligible judge seat …"
      (never "Checks ran — pass" for that gate) and "Refused a remote write by claude (creator)
@@ -92,6 +94,47 @@ def text(page, selector: str) -> str:
     return loc.first.text_content() if loc.count() > 0 else ""
 
 
+# The Tests tile's lead word as the operator SEES it (R2-1): `text-overflow: ellipsis` paints `…` in
+# place of the trailing glyphs that would otherwise fit, so "lead right edge <= span right edge" is
+# NOT enough — when the span is clipped the lead must end at least one ellipsis glyph (measured on a
+# probe span in the context span's computed font) before the span's right edge. Returns the raw
+# numbers so a failure names the shortfall.
+TILE_LEAD = "1 set · 11/11 passed"
+TILE_JS = """(lead) => {
+  const tile = document.querySelector('[data-testid="stat-campaigns"]');
+  const ctx = tile?.querySelector('[data-testid="stat-context"]');
+  const text = ctx?.textContent ?? '';
+  const box = ctx?.getBoundingClientRect();
+  let leadRight = null;
+  const node = ctx?.firstChild;
+  if (node && node.nodeType === Node.TEXT_NODE && text.startsWith(lead)) {
+    const r = document.createRange(); r.setStart(node, 0); r.setEnd(node, lead.length);
+    leadRight = r.getBoundingClientRect().right;
+  }
+  let ellipsisWidth = null;
+  if (ctx) {
+    const cs = getComputedStyle(ctx);
+    const probe = document.createElement('span');
+    probe.textContent = '\u2026';
+    probe.style.cssText = `position:absolute;visibility:hidden;white-space:nowrap;font:${cs.font};letter-spacing:${cs.letterSpacing}`;
+    document.body.appendChild(probe);
+    ellipsisWidth = probe.getBoundingClientRect().width;
+    probe.remove();
+  }
+  const clipped = ctx ? ctx.scrollWidth > ctx.clientWidth : null;
+  const limit = box && ellipsisWidth !== null ? (clipped ? box.right - ellipsisWidth : box.right) : null;
+  return {
+    viewport: window.innerWidth,
+    testsKpi: text, kpiTitle: ctx?.getAttribute('title'),
+    leadRight, boxRight: box?.right ?? null, boxWidth: box?.width ?? null, ellipsisWidth, clipped, limit,
+    kpiLeadVisible: leadRight !== null && limit !== null && (box?.width ?? 0) > 0 && leadRight <= limit + 0.5,
+    kpiTestSets: tile?.getAttribute('data-test-sets'),
+    kpiMalformed: tile?.getAttribute('data-test-sets-malformed'),
+    kpiUnattributed: tile?.getAttribute('data-test-sets-unattributed'),
+  };
+}"""
+
+
 with sync_playwright() as p:
     # PLAYWRIGHT_CHANNEL (review R2-6): run on an installed browser channel (`chrome`, `msedge`)
     # when the Playwright browser cache is absent on the host — nothing is installed by a rig.
@@ -155,30 +198,10 @@ with sync_playwright() as p:
             delivery: t('[data-testid="campaign-card-delivery"]'),
             header: document.querySelector('[data-testid="campaigns-header-copy"]')?.textContent ?? '',
             authorVerb: document.querySelector('[data-testid="testing-author-open"]')?.textContent?.trim(),
-            ...(() => {
-              // #266 F-1: the sets word must be SEEN, not merely present in textContent — measure the
-              // glyph box of the leading sets word against the context span's visible box.
-              const tile = document.querySelector('[data-testid="stat-campaigns"]');
-              const ctx = tile?.querySelector('[data-testid="stat-context"]');
-              const text = ctx?.textContent ?? '';
-              const lead = '1 test set · 11/11 passed';
-              let leadRight = null;
-              const node = ctx?.firstChild;
-              if (node && node.nodeType === Node.TEXT_NODE && text.startsWith(lead)) {
-                const r = document.createRange(); r.setStart(node, 0); r.setEnd(node, lead.length);
-                leadRight = r.getBoundingClientRect().right;
-              }
-              const box = ctx?.getBoundingClientRect();
-              return {
-                testsKpi: text, kpiTitle: ctx?.getAttribute('title'),
-                kpiLeadVisible: leadRight !== null && box ? leadRight <= box.right + 0.5 && box.width > 0 : false,
-                kpiTestSets: tile?.getAttribute('data-test-sets'),
-                kpiMalformed: tile?.getAttribute('data-test-sets-malformed'),
-                kpiUnattributed: tile?.getAttribute('data-test-sets-unattributed'),
-              };
-            })(),
           };
         }""")
+    # #266 F-1 / R2-1: the sets word must be PAINTED, not merely present in textContent.
+    card.update(page.evaluate(TILE_JS, TILE_LEAD))
     check(
         "landing_shows_produced_set",
         card["kind"] == "group" and card["title"]
@@ -190,15 +213,31 @@ with sync_playwright() as p:
         and card["plan"] == "plan: tests/PLAN-run-lifecycle.md" and card["planRun"] == GT_RUN
         and card["pr"] == "https://github.com/example/studio-api/pull/999" and card["prText"] == "PR #999"
         and "1 of 1 delivered" in card["delivery"]
-        # The Tests tile: sets word FIRST and visible, full text on title, the malformed row said.
-        and card["testsKpi"].startswith("1 test set · 11/11 passed · 1 malformed · ")
-        and card["kpiTitle"] == card["testsKpi"] and card["kpiLeadVisible"] is True
+        # The Tests tile: the short lead FIRST and painted clear of the `…` glyph, the unabridged line on
+        # the title, the malformed row said.
+        and card["testsKpi"].startswith("1 set · 11/11 passed · 1 malformed · ")
+        and card["kpiTitle"] == "1 test set · 11/11 passed · 1 malformed · 0 active now"
+        and card["kpiLeadVisible"] is True
         and (card["kpiTestSets"], card["kpiMalformed"], card["kpiUnattributed"]) == ("1", "1", "0")
         and "qe-author-tests" in card["header"]
         and card["authorVerb"] == "Add testing rules",
         **card,
     )
     page.screenshot(path=str(SHOTS / "gt-landing.png"))
+
+    # R2-1: the lead stays painted at the three desktop widths the tile is laid out for — the same
+    # measurement, re-taken after each reflow (no reload; the DOM is the one already asserted above).
+    widths = {}
+    for w in (1280, 1440, 1920):
+        page.set_viewport_size({"width": w, "height": 700})
+        page.wait_for_timeout(150)
+        widths[str(w)] = page.evaluate(TILE_JS, TILE_LEAD)
+    page.set_viewport_size({"width": 1440, "height": 700})
+    check(
+        "tile_lead_painted_at_desktop_widths",
+        all(m["kpiLeadVisible"] is True and m["viewport"] == int(w) for w, m in widths.items()),
+        **{w: {k: m[k] for k in ("leadRight", "boxRight", "boxWidth", "ellipsisWidth", "clipped", "limit", "kpiLeadVisible")} for w, m in widths.items()},
+    )
 
     # ── Scene 2: New test — governed launch, link + waiting, the intake plan ────────
     page.locator('[data-testid="testing-campaign-open"]').click()

--- a/e2e/governed_testing_test.py
+++ b/e2e/governed_testing_test.py
@@ -16,7 +16,9 @@ No crew daemon is involved. Acceptance findings F-075 / F-076 / F-7R2-003 / -005
   3. THE PRODUCED SET (F-7R2-014): the landing's card — the `qe-tests-studio-api` label group
      0.36.0 files the run under — shows "verified · 11 produced · 11 executed · 11 passed · 0
      failed" off the TOP-LEVEL `test_sets` row joined by run_id, the workflow chip, the PLAN
-     (opens the run) and the engine's PR link.
+     (opens the run) and the engine's PR link. The Tests tile LEADS with the sets word — asserted
+     VISIBLE (its glyph box inside the context span, not ellipsized) with the full text as the
+     span's title — and says "1 malformed" for the run_id-less row the fixture also serves.
   4. THE RUN PAGE (F-7R2-005 / -006 / -012 / -013 / -017): the run head says "council degraded:
      4 of 5 seats benched …"; the feed says "Gate UNGATED on author — no eligible judge seat …"
      (never "Checks ran — pass" for that gate) and "Refused a remote write by claude (creator)
@@ -153,7 +155,28 @@ with sync_playwright() as p:
             delivery: t('[data-testid="campaign-card-delivery"]'),
             header: document.querySelector('[data-testid="campaigns-header-copy"]')?.textContent ?? '',
             authorVerb: document.querySelector('[data-testid="testing-author-open"]')?.textContent?.trim(),
-            testsKpi: document.querySelector('[data-testid="stat-campaigns"]')?.textContent ?? '',
+            ...(() => {
+              // #266 F-1: the sets word must be SEEN, not merely present in textContent — measure the
+              // glyph box of the leading sets word against the context span's visible box.
+              const tile = document.querySelector('[data-testid="stat-campaigns"]');
+              const ctx = tile?.querySelector('[data-testid="stat-context"]');
+              const text = ctx?.textContent ?? '';
+              const lead = '1 test set · 11/11 passed';
+              let leadRight = null;
+              const node = ctx?.firstChild;
+              if (node && node.nodeType === Node.TEXT_NODE && text.startsWith(lead)) {
+                const r = document.createRange(); r.setStart(node, 0); r.setEnd(node, lead.length);
+                leadRight = r.getBoundingClientRect().right;
+              }
+              const box = ctx?.getBoundingClientRect();
+              return {
+                testsKpi: text, kpiTitle: ctx?.getAttribute('title'),
+                kpiLeadVisible: leadRight !== null && box ? leadRight <= box.right + 0.5 && box.width > 0 : false,
+                kpiTestSets: tile?.getAttribute('data-test-sets'),
+                kpiMalformed: tile?.getAttribute('data-test-sets-malformed'),
+                kpiUnattributed: tile?.getAttribute('data-test-sets-unattributed'),
+              };
+            })(),
           };
         }""")
     check(
@@ -167,7 +190,10 @@ with sync_playwright() as p:
         and card["plan"] == "plan: tests/PLAN-run-lifecycle.md" and card["planRun"] == GT_RUN
         and card["pr"] == "https://github.com/example/studio-api/pull/999" and card["prText"] == "PR #999"
         and "1 of 1 delivered" in card["delivery"]
-        and "1 test set · 11 of 11 passed" in card["testsKpi"]
+        # The Tests tile: sets word FIRST and visible, full text on title, the malformed row said.
+        and card["testsKpi"].startswith("1 test set · 11/11 passed · 1 malformed · ")
+        and card["kpiTitle"] == card["testsKpi"] and card["kpiLeadVisible"] is True
+        and (card["kpiTestSets"], card["kpiMalformed"], card["kpiUnattributed"]) == ("1", "1", "0")
         and "qe-author-tests" in card["header"]
         and card["authorVerb"] == "Add testing rules",
         **card,
@@ -212,7 +238,8 @@ with sync_playwright() as p:
             waiting: t('[data-testid="testing-launch-waiting"]'),
             workflow: t('[data-testid="testing-launch-launched-workflow"]'),
             routeLine: t('[data-testid="testing-launch-route"]'),
-            label: t('[data-testid="testing-launch-fanout-label"]'),
+            filedLabel: t('[data-testid="testing-launch-filed-label"]'),
+            fanoutLabel: !!p?.querySelector('[data-testid="testing-launch-fanout-label"]'),
           };
         }""")
     author_posts = [pd for m, u, pd in posted if u == "/api/v1/testing/author"]
@@ -224,7 +251,10 @@ with sync_playwright() as p:
         and "r-gt-1" in launched["waiting"] and "intake gate will appear here" in launched["waiting"]
         and launched["workflow"] == "qe-author-tests"
         and "via POST /testing/author" in launched["routeLine"]
-        and launched["label"] == "author-r-gt-1"
+        # #266 F-4: the label group is already on the Test landing — "filed under", off runs[].label.
+        and launched["filedLabel"] == "qe-tests-studio-api" and not launched["fanoutLabel"]
+        and "filed under qe-tests-studio-api on the Test landing — the set fills in when the verify phase registers it" in launched["routeLine"]
+        and "appears on the Test landing when" not in launched["routeLine"]
         and body is not None and body.get("repoRefs") == ["studio-api"] and "projectId" not in body
         and body.get("problem", "").startswith("New test: plan the test for the attached scope")
         and not any(u in ("/api/v1/testing/recon", "/api/v1/runs") for _, u, _ in posted),

--- a/e2e/governed_testing_test.py
+++ b/e2e/governed_testing_test.py
@@ -13,8 +13,10 @@ No crew daemon is involved. Acceptance findings F-075 / F-076 / F-7R2-003 / -005
      workflow + wire and shows the waiting line; the intake gate arrives over /ws and the card
      carries the PLAN — five phases with executor / skill / seat. Project chips carry a DROP
      button (F-076). Screenshots at 1440x700 and 400px.
-  3. THE PRODUCED SET (F-7R2-014): the landing's card shows "2 test files · 11 tests · 11
-     executed · 11 passed · 0 failed" off the campaign's `test_set`, the workflow chip, the plan.
+  3. THE PRODUCED SET (F-7R2-014): the landing's card — the `qe-tests-studio-api` label group
+     0.36.0 files the run under — shows "verified · 11 produced · 11 executed · 11 passed · 0
+     failed" off the TOP-LEVEL `test_sets` row joined by run_id, the workflow chip, the PLAN
+     (opens the run) and the engine's PR link.
   4. THE RUN PAGE (F-7R2-005 / -006 / -012 / -013 / -017): the run head says "council degraded:
      4 of 5 seats benched …"; the feed says "Gate UNGATED on author — no eligible judge seat …"
      (never "Checks ran — pass" for that gate) and "Refused a remote write by claude (creator)
@@ -135,13 +137,19 @@ with sync_playwright() as p:
           const set = c?.querySelector('[data-testid="campaign-card-testset"]');
           return {
             kind: c?.getAttribute('data-kind'),
-            title: (c?.textContent ?? '').includes('Tests · studio-api · run lifecycle'),
+            title: (c?.textContent ?? '').includes('qe-tests-studio-api'),
             workflow: c?.querySelector('[data-testid="campaign-card-workflow"]')?.getAttribute('data-workflow'),
             set: t('[data-testid="campaign-card-testset"]'),
-            tests: set?.getAttribute('data-tests'), executed: set?.getAttribute('data-executed'),
+            setRun: set?.getAttribute('data-run-id'), verified: set?.getAttribute('data-verified'),
+            verifiedChip: t('[data-testid="campaign-card-testset-verified"]'),
+            produced: set?.getAttribute('data-produced'), executed: set?.getAttribute('data-executed'),
             passed: set?.getAttribute('data-passed'), failed: set?.getAttribute('data-failed'),
+            notExecuted: set?.getAttribute('data-not-executed'),
             unverified: !!c?.querySelector('[data-testid="campaign-card-testset-unverified"]'),
             plan: t('[data-testid="campaign-card-testset-plan"]'),
+            planRun: c?.querySelector('[data-testid="campaign-card-testset-plan"]')?.getAttribute('data-run-id'),
+            pr: c?.querySelector('[data-testid="campaign-card-testset-pr"]')?.getAttribute('href'),
+            prText: t('[data-testid="campaign-card-testset-pr"]'),
             delivery: t('[data-testid="campaign-card-delivery"]'),
             header: document.querySelector('[data-testid="campaigns-header-copy"]')?.textContent ?? '',
             authorVerb: document.querySelector('[data-testid="testing-author-open"]')?.textContent?.trim(),
@@ -150,13 +158,16 @@ with sync_playwright() as p:
         }""")
     check(
         "landing_shows_produced_set",
-        card["kind"] == "campaign" and card["title"]
+        card["kind"] == "group" and card["title"]
         and card["workflow"] == "qe-author-tests"
-        and card["set"].startswith("2 test files · 11 tests · 11 executed · 11 passed · 0 failed")
-        and (card["tests"], card["executed"], card["passed"], card["failed"]) == ("11", "11", "11", "0")
+        and card["setRun"] == GT_RUN and card["verified"] == "true" and card["verifiedChip"] == "verified"
+        and "11 produced · 11 executed · 11 passed · 0 failed" in card["set"]
+        and (card["produced"], card["executed"], card["passed"], card["failed"], card["notExecuted"]) == ("11", "11", "11", "0", "0")
         and not card["unverified"]
-        and card["plan"] == "plan: tests/PLAN-run-lifecycle.md"
+        and card["plan"] == "plan: tests/PLAN-run-lifecycle.md" and card["planRun"] == GT_RUN
+        and card["pr"] == "https://github.com/example/studio-api/pull/999" and card["prText"] == "PR #999"
         and "1 of 1 delivered" in card["delivery"]
+        and "1 test set · 11 of 11 passed" in card["testsKpi"]
         and "qe-author-tests" in card["header"]
         and card["authorVerb"] == "Add testing rules",
         **card,

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -1342,6 +1342,22 @@ GT_GROUP = {
     "label": GT_LABEL,
     "runs": [{"runId": GT_RUN, "status": "completed", "delivery": "delivered", "deliverUrl": GT_PR}],
 }
+# A registration the daemon served WITHOUT a `run_id` — nothing to join, nothing to open. The landing
+# must SAY it ("1 malformed" on the Tests tile), never read it as "nothing registered" (#266 F-2).
+GT_TEST_SET_MALFORMED = {
+    "id": "testset-orphan", "workflow_id": "qe-author-tests", "repo_ref": None,
+    "registered_at": NOW0 - 9 * MIN, "run_status": "failed", "verify_status": None, "verified": False,
+    "files": [], "produced": 0, "executed": 0, "passed": 0, "failed": 0, "not_executed": 0,
+    "plan": None, "harnesses": [],
+}
+# The `WorkflowPlan` the 0.36.0 `TestingAuthorResponse` carries — derived from the def the panel read.
+GT_AUTHOR_PLAN = {
+    "workflow": "qe-author-tests",
+    "phases": [{"id": p["id"], "kind": p["kind"], "role": p["role"],
+                "executor": "tool" if p.get("executor") else "agent", "skillRef": p["skill_ref"],
+                "gate": "auto", "executesCode": p["executes_code"]} for p in GT_WORKFLOW_DEF["phases"]],
+    "seats": ["claude", "codex", "pi"],
+}
 GT_BRANCH_DIFF = """\
 diff --git a/tests/run-lifecycle.test.tsx b/tests/run-lifecycle.test.tsx
 new file mode 100644
@@ -2591,7 +2607,8 @@ class W2Handler(SimpleHTTPRequestHandler):
             if not gt_on:
                 self._json(404, {"error": f"w2 fixture: no such endpoint {path}"})
             else:
-                self._json(200, {"campaigns": [], "groups": [GT_GROUP], "test_sets": [GT_TEST_SET]})
+                self._json(200, {"campaigns": [], "groups": [GT_GROUP],
+                                 "test_sets": [GT_TEST_SET, GT_TEST_SET_MALFORMED]})
             return True
         # Slice V: GET /runs/<id> — one run's detail (`{run: SessionView}`), the
         # real daemon contract useRunModel re-hydrates on. Same corpus assembly
@@ -3671,9 +3688,13 @@ class W2Handler(SimpleHTTPRequestHandler):
                 run["units"] = gt_units(rid, done=False)
                 gt_launched.append(run)
                 state["extra_gates"].append({"session": rid, "ord": 1, "prompt": GT_INTAKE_PROMPT})
-                campaign = f"author-{rid}"
-            return self._json(201, {"runId": rid, "runIds": [rid], "campaign": campaign,
-                                    "campaignRegistered": False, "workflow": "qe-author-tests"})
+            # The 0.36.0 `TestingAuthorResponse`: NO `campaign` field — the filing rides `runs[].label`
+            # (`qe-tests-<repo>`, the RunGroup.label on GET /campaigns); the plan the intake card shows.
+            return self._json(201, {"runId": rid, "runIds": [rid], "workflow": "qe-author-tests",
+                                    "runs": [{"runId": rid, "repoRef": REPO_ID, "label": GT_LABEL}],
+                                    "gate": "before:1", "deliver": "pr", "plan": GT_AUTHOR_PLAN,
+                                    "scope": "repoRefs" if refs else "project",
+                                    "campaignRegistered": False})
         # POST /api/v1/runs — the REAL launch (slice S, project_dto only): the
         # daemon's `{runId}` answer; `body.projectId` files the run atomically
         # (LaunchSchema, routes.ts:148 — "never a silent unfiled run"), and the

--- a/e2e/uxfix_fixture.py
+++ b/e2e/uxfix_fixture.py
@@ -512,8 +512,9 @@ state = {"orphan": True, "q3_gate_age_ms": 30 * SEC,
          #   wires change: GET /workflows lists `qe-author-tests` (five phases);
          #   POST /testing/author launches ONE run that pauses at its intake gate (the
          #   awaitingHuman frame rides /ws, GET /runs/:id serves its planned units +
-         #   pool); GET /campaigns serves the COMPLETED run's registration with its
-         #   `test_set` counts; the completed run's events carry `degradedReason`,
+         #   pool); GET /campaigns serves the COMPLETED run as the `qe-tests-<repo>` label
+         #   group 0.36.0 files an authoring run under, with its registered set as the
+         #   TOP-LEVEL `test_sets` (no row-level join); the completed run's events carry `degradedReason`,
          #   `workerToolCallDenied` and an UNGATED gateEvaluated; its diff answers
          #   200 `source: "branch"` (the worktree is gone). Default False: GET
          #   /workflows and GET /campaigns keep answering the unknown-route 404.
@@ -1208,8 +1209,9 @@ FORENSICS_DIFF_HANG_SECONDS = 30
 #
 # Every name below is spelled EXACTLY as the wave-6 briefs give it (camelCase as the engine
 # emits): `qe-author-tests`, `degradedReason`, `ungated` / `ungatedReason`,
-# `workerToolCallDenied {role, command, remedy}`, `diff.source: "branch"`, the campaign's
-# `test_set`. Synthetic — 0.36.0 was unpublished when written; re-vendor at the pin bump.
+# `workerToolCallDenied {role, command, remedy}`, `diff.source: "branch"`, and the registered set as
+# `CampaignsListResponse.test_sets[]` (api-types 0.36.0: snake_case, `run_id`-keyed, tagged with the
+# `qe-tests-<repo>` label — served beside the label group, never joined onto a row). Synthetic.
 GT_RUN = "r-gt-done"                     # the COMPLETED New test (registered its set)
 GT_PROBLEM = "New test: cover the run lifecycle UI — launch form, gate answering, archive"
 GT_INTAKE_PROMPT = ("Approve unit 1 before it runs: recon — read the repository and its "
@@ -1319,22 +1321,26 @@ GT_EVENTS = [
     {"type": "sessionCompleted", "session": GT_RUN, "seq": 15, "ts": NOW0 - 5 * MIN},
 ]
 
+GT_LABEL = "qe-tests-studio-api"          # the RunGroup.label POST /testing/author files the run under
+GT_PR = "https://github.com/example/studio-api/pull/999"
+# The registered TEST SET — `CampaignsListResponse.test_sets[0]`, spelled as api-types 0.36.0
+# declares `TestSet` (snake_case, `run_id`-keyed, `label`-tagged; the verify phase's re-derived counts).
 GT_TEST_SET = {
-    "runId": GT_RUN, "workflow": "qe-author-tests",
-    "files": ["tests/run-lifecycle.test.tsx", "e2e/run_lifecycle_test.py"],
-    "counts": {"files": 2, "tests": 11, "executed": 11, "passed": 11, "failed": 0},
-    "plan": "tests/PLAN-run-lifecycle.md",
-    "prUrl": "https://github.com/example/studio-api/pull/999",
+    "id": f"testset-{GT_RUN}", "run_id": GT_RUN, "workflow_id": "qe-author-tests", "label": GT_LABEL,
+    "repo_ref": "studio-api", "repo_name": "studio-api",  # REPO_ID is bound further down; the literal, as GT_CAMPAIGN spelled it
+    "registered_at": NOW0 - 5 * MIN,  # unix millis (NOW0 is already ms)
+    "run_status": "completed", "verify_status": "done", "verified": True,
+    "files": [{"path": "tests/run-lifecycle.test.tsx", "harness": "vitest", "status": "passed"},
+              {"path": "e2e/run_lifecycle_test.py", "harness": "playwright-python", "status": "passed"}],
+    "produced": 11, "executed": 11, "passed": 11, "failed": 0, "not_executed": 0,
+    "plan": "tests/PLAN-run-lifecycle.md", "harnesses": ["vitest", "playwright-python"],
+    "deliverUrl": GT_PR,
 }
-GT_CAMPAIGN = {
-    "id": "qe-tests-studio-api", "def_id": "qe-tests-studio-api", "status": "completed",
-    "def": {"id": "qe-tests-studio-api", "name": "Tests · studio-api · run lifecycle",
-            "nodes": [{"node_id": "author", "run_spec": {"problem": GT_PROBLEM, "repo_ref": "studio-api",
-                                                          "workflow_id": "qe-author-tests"}}]},
-    "node_status": {"author": "completed"}, "node_run_id": {"author": GT_RUN}, "node_attempt": {"author": 0},
-    "pending_decision_amend": {}, "pending_failure_gates": [], "fail_fast_tripped": False,
-    "node_delivery": {"author": {"delivery": "delivered", "deliverUrl": "https://github.com/example/studio-api/pull/999"}},
-    "attached_runs": [], "test_set": GT_TEST_SET,
+# The label group the launch filed the run under (`campaignRegistered: false` — an author launch is
+# never an engine campaign); the set joins onto it client-side by run_id / label.
+GT_GROUP = {
+    "label": GT_LABEL,
+    "runs": [{"runId": GT_RUN, "status": "completed", "delivery": "delivered", "deliverUrl": GT_PR}],
 }
 GT_BRANCH_DIFF = """\
 diff --git a/tests/run-lifecycle.test.tsx b/tests/run-lifecycle.test.tsx
@@ -2576,15 +2582,16 @@ class W2Handler(SimpleHTTPRequestHandler):
             else:
                 self._json(200, {"workflows": GT_WORKFLOWS_ELSE + ([] if absent else [GT_WORKFLOW_DEF])})
             return True
-        # Wave 6: GET /campaigns — the completed New test's registration with its `test_set` counts
-        # (F-7R2-014). Off ⇒ the standing unknown-route 404 (the landing's "unsupported" state).
+        # Wave 6: GET /campaigns — the completed New test's label group beside its registered set as
+        # the TOP-LEVEL `test_sets` (api-types 0.36.0, F-7R2-014). Off ⇒ the standing unknown-route
+        # 404 (the landing's "unsupported" state).
         if path == "/api/v1/campaigns":
             with state_lock:
                 gt_on = state["governed_testing"]
             if not gt_on:
                 self._json(404, {"error": f"w2 fixture: no such endpoint {path}"})
             else:
-                self._json(200, {"campaigns": [GT_CAMPAIGN], "groups": []})
+                self._json(200, {"campaigns": [], "groups": [GT_GROUP], "test_sets": [GT_TEST_SET]})
             return True
         # Slice V: GET /runs/<id> — one run's detail (`{run: SessionView}`), the
         # real daemon contract useRunModel re-hydrates on. Same corpus assembly

--- a/src/api/campaigns.ts
+++ b/src/api/campaigns.ts
@@ -24,7 +24,7 @@
 
 import { apiFetch } from './client.js';
 import type { SessionStatus } from './types.js';
-import { testSetsOf, type TestSet } from './wave6-wire.js';
+import { testSetsReadOf, type TestSet } from './wave6-wire.js';
 
 /** Per-node lifecycle status. Terminal = `completed` | `failed` | `blocked` | `cancelled`. */
 export type CampaignNodeStatus =
@@ -163,6 +163,10 @@ export interface CampaignsListing {
   campaigns: Campaign[];
   groups: RunGroup[];
   testSets: TestSet[] | null;
+  /** `test_sets` rows the daemon served WITHOUT a `run_id` — registered but unjoinable; said on the
+   *  Test landing as "N malformed", never dropped silently (review of #266, F-2). 0 when none, and
+   *  0 on a pre-0.36 daemon (there is no list to be malformed). */
+  malformedTestSets: number;
 }
 
 /**
@@ -190,7 +194,13 @@ export interface RunAcceptance {
  */
 export async function listCampaigns(): Promise<CampaignsListing> {
   const res = await apiFetch<Partial<CampaignsListResponse>>('/campaigns');
-  return { campaigns: res.campaigns ?? [], groups: res.groups ?? [], testSets: testSetsOf(res) };
+  const read = testSetsReadOf(res);
+  return {
+    campaigns: res.campaigns ?? [],
+    groups: res.groups ?? [],
+    testSets: read === null ? null : read.sets,
+    malformedTestSets: read === null ? 0 : read.malformed,
+  };
 }
 
 /** `GET /campaigns/:id` — `{ campaign }`, the same daemon-side join as the list; 404 unknown. */

--- a/src/api/campaigns.ts
+++ b/src/api/campaigns.ts
@@ -24,7 +24,7 @@
 
 import { apiFetch } from './client.js';
 import type { SessionStatus } from './types.js';
-import type { TestSetRegistration } from './wave6-wire.js';
+import { testSetsOf, type TestSet } from './wave6-wire.js';
 
 /** Per-node lifecycle status. Terminal = `completed` | `failed` | `blocked` | `cancelled`. */
 export type CampaignNodeStatus =
@@ -128,13 +128,6 @@ export interface Campaign {
    * scheduler ignores them; provenance only. Absent from a pre-0.19 daemon; `[]` when none.
    */
   attached_runs?: AttachedRunView[];
-  /**
-   * The produced TEST SET a completed `qe-author-tests` run registered here (wave 6, api-types
-   * 0.36.0 — acceptance finding F-7R2-014): daemon-joined like `node_delivery`, with the counts the
-   * verify phase re-derived. Absent from a daemon that predates the wave; `null` when the run has
-   * registered nothing yet. Read through `testSetOf` (`./wave6-wire.ts`), never bare.
-   */
-  test_set?: TestSetRegistration | null;
   [k: string]: unknown;
 }
 
@@ -146,14 +139,30 @@ export interface Campaign {
 export interface RunGroup {
   label: string;
   runs: AttachedRunView[];
-  /** The produced test set, when a member `qe-author-tests` run registered one (wave 6). */
-  test_set?: TestSetRegistration | null;
 }
 
-/** `GET /campaigns` 200 body — `groups` is ADDITIVE (a pre-0.19 daemon sends only campaigns). */
+/**
+ * `GET /campaigns` 200 body — `groups` is ADDITIVE (a pre-0.19 daemon sends only campaigns), and so
+ * is `test_sets` (wave 6, api-types 0.36.0 — F-7R2-014): the registered TEST SETS, newest first,
+ * each keyed by the `run_id` that produced it and tagged with the `qe-tests-<repo>` `label` the
+ * daemon filed the authoring run under. A pre-0.36 daemon omits the key. There is NO row-level join
+ * on a campaign or a group — the sets are joined client-side (`board/campaignStats.ts`).
+ */
 export interface CampaignsListResponse {
   campaigns: Campaign[];
   groups: RunGroup[];
+  test_sets?: TestSet[];
+}
+
+/**
+ * The listing as studio holds it — the wire normalized ONCE: `groups` is always an array, and
+ * `testSets` keeps the wire's honest absence (`null` = a daemon predating the sets; `[]` = a 0.36
+ * daemon with nothing registered yet), so no surface fabricates a zero.
+ */
+export interface CampaignsListing {
+  campaigns: Campaign[];
+  groups: RunGroup[];
+  testSets: TestSet[] | null;
 }
 
 /**
@@ -176,11 +185,12 @@ export interface RunAcceptance {
 /**
  * `GET /campaigns` — 200 with empty lists on an empty store; 404/501 = daemon predates
  * campaigns (§1.5). A pre-0.19 daemon omits `groups`, normalized here to `[]` so no consumer
- * carries the `undefined` arm.
+ * carries the `undefined` arm; a pre-0.36 daemon omits `test_sets`, kept as `null` (absence is a
+ * fact the Test landing and the Home door render as "no sets on this wire", never as 0).
  */
-export async function listCampaigns(): Promise<CampaignsListResponse> {
-  const res = await apiFetch<{ campaigns?: Campaign[]; groups?: RunGroup[] }>('/campaigns');
-  return { campaigns: res.campaigns ?? [], groups: res.groups ?? [] };
+export async function listCampaigns(): Promise<CampaignsListing> {
+  const res = await apiFetch<Partial<CampaignsListResponse>>('/campaigns');
+  return { campaigns: res.campaigns ?? [], groups: res.groups ?? [], testSets: testSetsOf(res) };
 }
 
 /** `GET /campaigns/:id` — `{ campaign }`, the same daemon-side join as the list; 404 unknown. */

--- a/src/api/testing.ts
+++ b/src/api/testing.ts
@@ -210,7 +210,6 @@ export const INTAKE_GATE = 'before:1';
 /**
  * Which wire the launch actually rode — stated on the panel, never implied:
  *  - `testing-author`          — `POST /testing/author` (the wave-6 route for the QE workflow);
- *  - `testing-recon-workflow`  — `POST /testing/recon` with the additive `workflow` key;
  *  - `runs-fan`                — one `POST /runs {workflow, repoRef, projectId, humanConfirm}` per
  *                                resolved repo (the SHIPPING wire — `projectId` files, `repoRef`
  *                                scopes — used when the operator NARROWED a project (F-076: the
@@ -218,7 +217,7 @@ export const INTAKE_GATE = 'before:1';
  *                                daemon lists the workflow but its testing routes predate it);
  *  - `testing-recon-plain`     — today's free-text recon: the daemon has no governed test workflow.
  */
-export type GovernedLaunchRoute = 'testing-author' | 'testing-recon-workflow' | 'runs-fan' | 'testing-recon-plain';
+export type GovernedLaunchRoute = 'testing-author' | 'runs-fan' | 'testing-recon-plain';
 
 /** The panel's scope, as the operator composed it — the pure input `launchGovernedTest` plans from. */
 export interface GovernedLaunchScope {
@@ -266,14 +265,6 @@ export function effectiveRepos(scope: Pick<GovernedLaunchScope, 'projectId' | 'p
  *  express (its `projectId` unions every member back in). */
 export function isNarrowedProject(scope: Pick<GovernedLaunchScope, 'projectId' | 'excluded'>): boolean {
   return scope.projectId !== null && scope.excluded.length > 0;
-}
-
-/** A strict-schema 400 that names `key` as unrecognized — the wire of a daemon whose route predates
- *  the additive field (crew's schemas are `.strict()`; the error names the offending key). */
-export function isUnrecognizedKey(e: unknown, key: string): boolean {
-  if (!(e instanceof ApiError) || e.status !== 400) return false;
-  const wire = e.wire.toLowerCase();
-  return /unrecognized key/.test(wire) && wire.includes(key.toLowerCase());
 }
 
 /** The panel's mint for a client-side fan label — `test-<base36 clock>-<random>` (1–200 chars). */
@@ -350,14 +341,19 @@ async function launchRunsFan(scope: GovernedLaunchScope, repos: string[]): Promi
  * The chain, in order, each step taken only when the previous one's wire is ABSENT (never on a
  * named refusal — a 404 naming a bad ref, a 400 about the scope, a 409, a 500 all surface as
  * answers):
- *  1. a NARROWED project (members dropped) ⇒ the per-repo `POST /runs` fan over the remaining
- *     members ∪ explicit, `projectId` kept for filing — the recon body's `projectId` would union the
- *     dropped members back in; an empty remainder is refused HERE, before any wire call;
+ *  1. a NARROWED project (members dropped) ⇒ `POST /testing/author` with the exact `repoRefs`
+ *     (`projectId` files) when the daemon has the route, else the per-repo `POST /runs` fan over the
+ *     remaining members ∪ explicit — the recon body's `projectId` would union the dropped members
+ *     back in; an empty remainder is refused HERE, before any wire call;
  *  2. the workflow is listed ⇒ `POST /testing/author` (route absent ⇒ 3);
- *  3. `POST /testing/recon` + `workflow` (a strict schema naming `workflow` unrecognized ⇒ 4);
- *  4. the per-repo `POST /runs` fan with `workflow` (the shipping wire carries a workflow id);
- *  5. no workflow listed ⇒ today's plain recon ({@link launchTestingRun}) — the panel has already
+ *  3. the per-repo `POST /runs` fan with `workflow` (the shipping wire carries a workflow id);
+ *  4. no workflow listed ⇒ today's plain recon ({@link launchTestingRun}) — the panel has already
  *     said "this daemon has no governed test workflow — plain run".
+ *
+ * There is NO `POST /testing/recon` + `workflow` rung: 0.36.0's `TestingReconBody` declares no
+ * `workflow` key (vendored as evidence in `./wave6-wire.ts`), and `qe-author-tests` shipped together
+ * with `POST /testing/author`, so no daemon lists the workflow without the route — the rung studio
+ * 0.5.7 carried was unreachable. `/testing/recon` is only ever sent the pinned body (step 4).
  */
 export async function launchGovernedTest(scope: GovernedLaunchScope): Promise<GovernedLaunchResult> {
   const repos = effectiveRepos(scope);
@@ -396,15 +392,6 @@ export async function launchGovernedTest(scope: GovernedLaunchScope): Promise<Go
     return normalizeRecon(r, 'testing-author', scope.workflow);
   } catch (e) {
     if (!isRouteAbsent(e)) throw e;
-  }
-  try {
-    const r = await apiFetch<TestingLaunchResult>('/testing/recon', {
-      method: 'POST',
-      body: JSON.stringify({ ...pinned, workflow: scope.workflow }),
-    });
-    return normalizeRecon(r, 'testing-recon-workflow', scope.workflow);
-  } catch (e) {
-    if (!isUnrecognizedKey(e, 'workflow') && !isRouteAbsent(e)) throw e;
   }
   return launchRunsFan(scope, repos);
 }

--- a/src/api/testing.ts
+++ b/src/api/testing.ts
@@ -242,6 +242,15 @@ export interface GovernedLaunchResult extends TestingLaunchResult {
   workflow: string | null;
   campaignRegistered: boolean;
   /**
+   * The label groups the DAEMON filed the runs under — `POST /testing/author`'s `runs[].label`
+   * (`qe-tests-<repo>`, one per repo; the `RunGroup.label` on `GET /campaigns`, so the group card
+   * exists on the Test landing the moment the run does). Unique, answer order. `[]` for every other
+   * route: a `POST /runs` fan's client-minted `groupLabel` rides `campaign` as before (the panel says
+   * "grouped under one label"), a plain recon files nothing (review of #266, F-4: the author route
+   * says "filed under …", never "appears … when the run registers").
+   */
+  labels: string[];
+  /**
    * An honest note about the SCOPE the daemon actually launched, when it differs from the one asked
    * for (independent review of #263, R2-1): a `/testing/author` answer with more `runIds` than the
    * narrowed `repoRefs` did not honour the narrowing (it unioned the project's members back in). The
@@ -272,6 +281,20 @@ export function mintGroupLabel(now: number = Date.now(), rand: string = Math.ran
   return `test-${now.toString(36)}-${rand}`;
 }
 
+/** `TestingAuthorResponse.runs[].label` off the wire bag — the `qe-tests-<repo>` groups the launch
+ *  filed the runs under; unique, answer order; `[]` when the answer carries none (a recon answer). */
+export function filedLabelsOf(raw: TestingLaunchResult): string[] {
+  const runs = raw['runs'];
+  if (!Array.isArray(runs)) return [];
+  const out: string[] = [];
+  for (const r of runs) {
+    if (typeof r !== 'object' || r === null) continue;
+    const label = (r as Record<string, unknown>)['label'];
+    if (typeof label === 'string' && label !== '' && !out.includes(label)) out.push(label);
+  }
+  return out;
+}
+
 function normalizeRecon(raw: TestingLaunchResult, route: GovernedLaunchRoute, workflow: string | null): GovernedLaunchResult {
   const ids = launchedRunIds(raw);
   return {
@@ -281,6 +304,7 @@ function normalizeRecon(raw: TestingLaunchResult, route: GovernedLaunchRoute, wo
     route,
     workflow: typeof raw['workflow'] === 'string' && raw['workflow'] !== '' ? (raw['workflow'] as string) : workflow,
     campaignRegistered: raw['campaignRegistered'] === true,
+    labels: filedLabelsOf(raw),
     scopeNote: null,
   };
 }
@@ -331,6 +355,7 @@ async function launchRunsFan(scope: GovernedLaunchScope, repos: string[]): Promi
     route: 'runs-fan',
     workflow: scope.workflow,
     campaignRegistered: false,
+    labels: [],
     scopeNote: null,
   };
 }

--- a/src/api/wave6-wire.ts
+++ b/src/api/wave6-wire.ts
@@ -39,14 +39,18 @@
  *  - `skills.stale-rules` + `SkillsManifestResponse.current.rules` / `current.drift` live in the
  *    SKILLS block and are vendored by `./skills-wire.ts` (its own byte-pinned regions), not here.
  *
- * WIRE GAPS — two shapes studio codes against are NOT declared by 0.36.0 and stay studio-worded at
- * the bottom of this file, each guarded by `tests/wave6Wire.test.ts` so the day the package
- * declares them the suite says "re-vendor": (1) a row-level `Campaign.test_set` / `RunGroup.test_set`
- * join ({@link TestSetRegistration}) — 0.36.0 serves the produced sets as a separate top-level
- * `CampaignsListResponse.test_sets: TestSet[]` (snake_case, `run_id`-keyed), so the Test landing's
- * per-card counts render only when a daemon joins the row; (2) `TestingReconBody.workflow`
- * ({@link TestingReconWorkflowBody}) — the launch ladder's middle rung; a 0.36.0 daemon has
- * `POST /testing/author` itself, so the rung is reached only on a daemon that lacks the route.
+ * WIRE GAPS — none. Two shapes the 0.5.7 cut coded against provisionally are gone (studio 0.5.8):
+ * (1) a row-level `Campaign.test_set` / `RunGroup.test_set` join was never declared — 0.36.0 serves
+ * the produced sets as the top-level `CampaignsListResponse.test_sets: TestSet[]` (snake_case,
+ * `run_id`-keyed, `label`-tagged), which {@link testSetsOf} reads null-safely and
+ * `board/campaignStats.ts` joins onto the campaign / group cards by `run_id` (and by the
+ * `qe-tests-<repo>` label the daemon files an authoring run under); (2) `TestingReconBody.workflow`
+ * — the launch ladder's middle rung — was dead code: `qe-author-tests` and `POST /testing/author`
+ * shipped together in wave 6, so no daemon lists the workflow without the route, and the ladder
+ * falls from the route straight to the per-repo `POST /runs` fan. {@link TestingReconBody} stays
+ * vendored as the evidence that the recon body carries NO `workflow` key — studio sends none.
+ * `tests/wave6Wire.test.ts` guards both: a `test_set` row join or a `workflow` recon key appearing
+ * in a later pin fails the suite and says "re-vendor".
  */
 
 import type {
@@ -208,7 +212,7 @@ export interface TestSet {
 }
 // <<< VERBATIM
 
-/** The recon body, vendored as EVIDENCE: no `workflow` key (see {@link TestingReconWorkflowBody}). */
+/** The recon body, vendored as EVIDENCE: no `workflow` key — studio's launch ladder sends none. */
 // >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:2745-2778 (crew#536) — TestingReconBody (no `workflow` key)
 /**
  * The `POST /testing/recon` request body (api-types 0.15.0) — the Testing page's campaign-recon
@@ -908,81 +912,75 @@ export function diffSource(d: RunDiff): RunDiffSource | null {
   return s === 'branch' || s === 'worktree' ? s : null;
 }
 
-// ── WIRE GAPS — PROVISIONAL, studio-worded: NOT declared by wicked-crew-api-types 0.36.0 ──────
-//
-// Each shape here is guarded by `tests/wave6Wire.test.ts`: the suite asserts the installed package
-// does NOT declare it, so the pin that does makes this section a failing test, not a silent drift.
+// ── The registered test sets — `CampaignsListResponse.test_sets`, read null-safely ────────────
 
-/**
- * PROVISIONAL (wire gap 1) — the counts of a row-joined test set. 0.36.0's {@link TestSet} carries
- * `produced` / `executed` / `passed` / `failed` / `not_executed` at the top level of the
- * `CampaignsListResponse.test_sets` entry instead; `tests` here is the produced count.
- */
-export interface TestSetCounts {
-  files: number;
-  tests: number;
-  executed: number;
-  passed: number;
-  failed: number;
+const num = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : 0);
+
+/** One `TestSetFile` narrowed off the wire; `null` unless the row names its `path`. An unknown
+ *  status token reads as `not-executed` — never as a pass (deny-dominates). */
+function testSetFileOf(raw: unknown): TestSetFile | null {
+  if (typeof raw !== 'object' || raw === null) return null;
+  const f = raw as Record<string, unknown>;
+  const path = str(f['path']);
+  if (path === null) return null;
+  const status = f['status'];
+  return {
+    path,
+    harness: str(f['harness']) ?? 'unknown',
+    status: status === 'passed' || status === 'failed' ? status : 'not-executed',
+  };
 }
 
 /**
- * PROVISIONAL (wire gap 1) — the test set a completed `qe-author-tests` run registers, as studio
- * reads it off a campaign ROW (`Campaign.test_set` / `RunGroup.test_set`, daemon-joined like
- * `node_delivery`). 0.36.0 declares no row-level join: it serves the sets as
- * `CampaignsListResponse.test_sets: TestSet[]` (`run_id`, `files: TestSetFile[]`, `plan`,
- * `deliverUrl`). Until a pin declares the join, a 0.36.0 daemon's row renders no counts (absence,
- * never a fabricated zero) — `testSetOf` answers `null`.
+ * One `TestSet` row narrowed off the wire bag — `null` unless it names its producing `run_id` (the
+ * join key; a row without one attaches to nothing). The contract declares every count required;
+ * a count that is not a finite number reads as 0 and the row is still shown, never dropped — a
+ * malformed registration is a red set, not a hidden one. `verified` is `true` only on an explicit
+ * `true`.
  */
-export interface TestSetRegistration {
-  /** The run that produced the set. */
-  runId: string;
-  /** The workflow that produced it (`qe-author-tests`). */
-  workflow: string;
-  /** Repo-relative paths of the produced test files. */
-  files: string[];
-  counts: TestSetCounts;
-  /** Repo-relative path of the PLAN the author phase wrote; `null` when none. */
-  plan: string | null;
-  /** The delivered PR URL when the deliver phase opened one; `null` otherwise. */
-  prUrl: string | null;
-}
-
-/** PROVISIONAL (wire gap 1) — a campaign row (or ad-hoc group) as studio reads the join. */
-export interface WithTestSet {
-  test_set?: TestSetRegistration | null;
-}
-
-/**
- * PROVISIONAL (wire gap 2) — the additive `workflow` key studio sends on `TestingReconBody` as the
- * launch ladder's middle rung. 0.36.0's {@link TestingReconBody} declares no such key: a daemon with
- * a strict schema 400s it as unrecognized and the ladder falls through to one `POST /runs` per repo.
- * On a 0.36.0 daemon the first rung (`POST /testing/author`) answers, so this rung is never reached.
- */
-export interface TestingReconWorkflowBody {
-  problem: string;
-  projectId?: string;
-  repoRefs?: string[];
-  ungated?: boolean;
-  workflow?: string;
-}
-
-/** `Campaign.test_set` / `RunGroup.test_set` narrowed off the wire bag — `null` unless the shape holds. */
-export function testSetOf(row: unknown): TestSetRegistration | null {
-  if (typeof row !== 'object' || row === null) return null;
-  const raw = (row as Record<string, unknown>)['test_set'];
+export function testSetOf(raw: unknown): TestSet | null {
   if (typeof raw !== 'object' || raw === null) return null;
   const t = raw as Record<string, unknown>;
-  const counts = t['counts'];
-  if (typeof t['runId'] !== 'string' || typeof counts !== 'object' || counts === null) return null;
-  const c = counts as Record<string, unknown>;
-  const n = (k: string): number => (typeof c[k] === 'number' && Number.isFinite(c[k]) ? (c[k] as number) : 0);
+  const runId = str(t['run_id']);
+  if (runId === null) return null;
+  const label = str(t['label']);
+  const repoName = str(t['repo_name']);
+  const deliverUrl = str(t['deliverUrl']);
   return {
-    runId: t['runId'],
-    workflow: str(t['workflow']) ?? QE_AUTHOR_TESTS_WORKFLOW_ID,
-    files: Array.isArray(t['files']) ? (t['files'] as unknown[]).filter((f): f is string => typeof f === 'string') : [],
-    counts: { files: n('files'), tests: n('tests'), executed: n('executed'), passed: n('passed'), failed: n('failed') },
+    id: str(t['id']) ?? `testset-${runId}`,
+    run_id: runId,
+    workflow_id: QE_AUTHOR_TESTS_WORKFLOW_ID,
+    ...(label !== null ? { label } : {}),
+    repo_ref: str(t['repo_ref']),
+    ...(repoName !== null ? { repo_name: repoName } : {}),
+    registered_at: num(t['registered_at']),
+    run_status: str(t['run_status']) ?? 'unknown',
+    verify_status: str(t['verify_status']),
+    verified: t['verified'] === true,
+    files: Array.isArray(t['files'])
+      ? (t['files'] as unknown[]).map(testSetFileOf).filter((f): f is TestSetFile => f !== null)
+      : [],
+    produced: num(t['produced']),
+    executed: num(t['executed']),
+    passed: num(t['passed']),
+    failed: num(t['failed']),
+    not_executed: num(t['not_executed']),
     plan: str(t['plan']),
-    prUrl: str(t['prUrl']),
+    harnesses: Array.isArray(t['harnesses'])
+      ? (t['harnesses'] as unknown[]).filter((h): h is string => typeof h === 'string' && h !== '')
+      : [],
+    ...(deliverUrl !== null ? { deliverUrl } : {}),
   };
+}
+
+/**
+ * `CampaignsListResponse.test_sets` off the `GET /campaigns` body: `null` when the daemon carries
+ * no such key (pre-0.36 — absence, never a fabricated empty list), else every joinable row in wire
+ * order (newest first). `[]` is a real answer: a 0.36 daemon with nothing registered yet.
+ */
+export function testSetsOf(body: unknown): TestSet[] | null {
+  if (typeof body !== 'object' || body === null) return null;
+  const raw = (body as Record<string, unknown>)['test_sets'];
+  if (!Array.isArray(raw)) return null;
+  return raw.map(testSetOf).filter((t): t is TestSet => t !== null);
 }

--- a/src/api/wave6-wire.ts
+++ b/src/api/wave6-wire.ts
@@ -973,14 +973,36 @@ export function testSetOf(raw: unknown): TestSet | null {
   };
 }
 
+/** The `test_sets` list as read: the joinable rows plus the count of rows that could NOT be joined. */
+export interface TestSetsRead {
+  /** Every row naming its `run_id`, wire order (newest first). */
+  sets: TestSet[];
+  /** Rows the daemon registered WITHOUT a `run_id` (nothing to join, nothing to open). Counted, never
+   *  hidden — a malformed registration is still a registration (review of #266, F-2). */
+  malformed: number;
+}
+
 /**
  * `CampaignsListResponse.test_sets` off the `GET /campaigns` body: `null` when the daemon carries
- * no such key (pre-0.36 — absence, never a fabricated empty list), else every joinable row in wire
- * order (newest first). `[]` is a real answer: a 0.36 daemon with nothing registered yet.
+ * no such key (pre-0.36 — absence, never a fabricated empty list), else the joinable rows in wire
+ * order (newest first) plus how many rows were malformed. `{ sets: [], malformed: 0 }` is a real
+ * answer: a 0.36 daemon with nothing registered yet.
  */
-export function testSetsOf(body: unknown): TestSet[] | null {
+export function testSetsReadOf(body: unknown): TestSetsRead | null {
   if (typeof body !== 'object' || body === null) return null;
   const raw = (body as Record<string, unknown>)['test_sets'];
   if (!Array.isArray(raw)) return null;
-  return raw.map(testSetOf).filter((t): t is TestSet => t !== null);
+  const sets: TestSet[] = [];
+  let malformed = 0;
+  for (const row of raw) {
+    const t = testSetOf(row);
+    if (t !== null) sets.push(t);
+    else malformed += 1;
+  }
+  return { sets, malformed };
+}
+
+/** The joinable rows alone — {@link testSetsReadOf} without the malformed count. */
+export function testSetsOf(body: unknown): TestSet[] | null {
+  return testSetsReadOf(body)?.sets ?? null;
 }

--- a/src/board/campaignStats.ts
+++ b/src/board/campaignStats.ts
@@ -331,14 +331,24 @@ export function unattributedTestSets(cards: readonly CampaignCardModel[], testSe
 
 /**
  * The Tests tile's sets word — FIRST in the tile's context so it is the part that survives the
- * tile's ellipsis (review of #266, F-1): "1 test set · 11/11 passed", plus "· N unattributed" and
- * "· N malformed" whenever either is non-zero (deny-dominates: never hidden). A 0.36 daemon with
- * nothing registered says "no test sets registered yet" — its real zero (F-3); a pre-0.36 daemon has
- * no word at all (the caller passes no totals).
+ * tile's ellipsis (review of #266, F-1), plus "· N unattributed" and "· N malformed" whenever either
+ * is non-zero (deny-dominates: never hidden). A 0.36 daemon with nothing registered says its real
+ * zero (F-3); a pre-0.36 daemon has no word at all (the caller passes no totals).
+ *
+ * Two forms of the same fact (R2-1): the `lead` — "1 set · 11/11 passed" — is what the tile PAINTS,
+ * sized so the whole lead clears the `…` glyph at 1440 px (it is the Tests tile: "set" needs no
+ * "test"); the `full` — "1 test set · 11/11 passed" — rides the span's `title`, so hover always
+ * reads the unabridged line.
  */
-export function testSetsWord(totals: TestSetTotals, unattributed: number, malformed: number): string {
-  if (totals.sets === 0 && malformed === 0) return 'no test sets registered yet';
-  const parts = [`${totals.sets} test set${totals.sets === 1 ? '' : 's'} · ${totals.passed}/${totals.produced} passed`];
+export function testSetsWord(
+  totals: TestSetTotals,
+  unattributed: number,
+  malformed: number,
+  form: 'lead' | 'full' = 'lead',
+): string {
+  const noun = form === 'full' ? 'test set' : 'set';
+  if (totals.sets === 0 && malformed === 0) return `no ${noun}s registered yet`;
+  const parts = [`${totals.sets} ${noun}${totals.sets === 1 ? '' : 's'} · ${totals.passed}/${totals.produced} passed`];
   if (unattributed > 0) parts.push(`${unattributed} unattributed`);
   if (malformed > 0) parts.push(`${malformed} malformed`);
   return parts.join(' · ');

--- a/src/board/campaignStats.ts
+++ b/src/board/campaignStats.ts
@@ -302,8 +302,9 @@ export function testSetPrHref(t: TestSet | Pick<TestSet, 'deliverUrl'>): string 
 /**
  * The Home "Test" door's count line — the SAME census as the landing's "Tests" tile (campaigns +
  * label groups), with the registered sets appended once a 0.36 daemon serves them: "2 tests ·
- * 3 test sets". A pre-0.36 daemon (`testSets: null`) says only "2 tests" — the sets are absent, not
- * zero. (`groups` is optional only for older partial answers; it reads as none.)
+ * 3 test sets". A 0.36 daemon with nothing registered says "2 tests · 0 test sets" — its REAL zero;
+ * a pre-0.36 daemon (`testSets: null`) says only "2 tests" — the sets are absent, not zero (review
+ * of #266, F-3). (`groups` is optional only for older partial answers; it reads as none.)
  */
 export function testDoorWord(listing: {
   campaigns: readonly unknown[];
@@ -313,7 +314,34 @@ export function testDoorWord(listing: {
   const plural = (n: number, w: string): string => `${n} ${w}${n === 1 ? '' : 's'}`;
   const tests = plural(listing.campaigns.length + (listing.groups?.length ?? 0), 'test');
   const sets = listing.testSets ?? null;
-  return sets === null || sets.length === 0 ? tests : `${tests} · ${plural(sets.length, 'test set')}`;
+  return sets === null ? tests : `${tests} · ${plural(sets.length, 'test set')}`;
+}
+
+/**
+ * The registered sets NO card carries (review of #266, F-2): a set joins a card only through a
+ * member `run_id` or a group `label`, so once the producing run is archived / reaped and its group
+ * drops off the wire, the set — a durable audit entry the daemon still hydrates — has nowhere to
+ * open. Counted on the Tests tile as "N unattributed", never folded silently into the sets total.
+ */
+export function unattributedTestSets(cards: readonly CampaignCardModel[], testSets: readonly TestSet[]): TestSet[] {
+  const carried = new Set<string>();
+  for (const c of cards) for (const t of c.testSets) carried.add(t.id);
+  return testSets.filter((t) => !carried.has(t.id));
+}
+
+/**
+ * The Tests tile's sets word — FIRST in the tile's context so it is the part that survives the
+ * tile's ellipsis (review of #266, F-1): "1 test set · 11/11 passed", plus "· N unattributed" and
+ * "· N malformed" whenever either is non-zero (deny-dominates: never hidden). A 0.36 daemon with
+ * nothing registered says "no test sets registered yet" — its real zero (F-3); a pre-0.36 daemon has
+ * no word at all (the caller passes no totals).
+ */
+export function testSetsWord(totals: TestSetTotals, unattributed: number, malformed: number): string {
+  if (totals.sets === 0 && malformed === 0) return 'no test sets registered yet';
+  const parts = [`${totals.sets} test set${totals.sets === 1 ? '' : 's'} · ${totals.passed}/${totals.produced} passed`];
+  if (unattributed > 0) parts.push(`${unattributed} unattributed`);
+  if (malformed > 0) parts.push(`${malformed} malformed`);
+  return parts.join(' · ');
 }
 
 // ── The card models (needs-you first) ──────────────────────────────────────────

--- a/src/board/campaignStats.ts
+++ b/src/board/campaignStats.ts
@@ -6,7 +6,7 @@ import type {
   RunGroup,
 } from '../api/campaigns.js';
 import type { SessionView } from '../api/types.js';
-import { testSetOf, type TestSetRegistration } from '../api/wave6-wire.js';
+import type { TestSet } from '../api/wave6-wire.js';
 import { isPrUrl } from '../components/delivery.js';
 import { healthOf, type Health } from './windowStats.js';
 
@@ -26,6 +26,11 @@ import { healthOf, type Health } from './windowStats.js';
  *    `delivery`+`deliverUrl` (both daemon-joined, 0.19.0). A pre-0.19 daemon omits them and
  *    the rollup says so by being absent (`onWire: false`) — never a fabricated "0 of N".
  *  - Every PR href passes {@link isPrUrl} — the one shape gate every PR claim in studio takes.
+ *  - The produced TEST SETS (wave 6, api-types 0.36.0) arrive as the top-level
+ *    `CampaignsListResponse.test_sets`, NOT as a row-level join: the fold joins them onto a card by
+ *    `run_id` against the member runs and, for a label group, by the `qe-tests-<repo>` `label` the
+ *    daemon filed the producing run under. A pre-0.36 daemon carries none — every card's list is
+ *    `[]` and the KPI context says nothing about sets (absence, never a fabricated zero).
  */
 
 // ── Status folding ─────────────────────────────────────────────────────────────
@@ -229,6 +234,88 @@ export function passRateHealth(landed: number, terminal: number): Health {
   return healthOf(landed, terminal);
 }
 
+// ── The produced test sets (wave 6, api-types 0.36.0 — F-7R2-014) ─────────────
+
+/**
+ * The sets that belong on ONE card: joined by `run_id` against the member runs and — for a label
+ * group — by the `label` the daemon filed the producing run under (`qe-tests-<repo>`, so a set can
+ * name its group even when the group's member list is read from an older snapshot). Deduped by set
+ * id; wire order kept (newest first).
+ */
+export function joinTestSets(
+  memberRunIds: readonly string[],
+  label: string | null,
+  testSets: readonly TestSet[],
+): TestSet[] {
+  const members = new Set(memberRunIds);
+  const seen = new Set<string>();
+  const out: TestSet[] = [];
+  for (const t of testSets) {
+    if (!members.has(t.run_id) && (label === null || t.label !== label)) continue;
+    if (seen.has(t.id)) continue;
+    seen.add(t.id);
+    out.push(t);
+  }
+  return out;
+}
+
+/** The registered sets' rollup — the landing's KPI context and the Home door. Pure sums of the
+ *  wire's counts; nothing here is a rate or a fabricated denominator. */
+export interface TestSetTotals {
+  sets: number;
+  /** Sets whose verify phase PASSED (`verified: true`). */
+  verified: number;
+  produced: number;
+  executed: number;
+  passed: number;
+  failed: number;
+  notExecuted: number;
+}
+
+export function testSetTotals(testSets: readonly TestSet[]): TestSetTotals {
+  const t: TestSetTotals = { sets: 0, verified: 0, produced: 0, executed: 0, passed: 0, failed: 0, notExecuted: 0 };
+  for (const s of testSets) {
+    t.sets += 1;
+    if (s.verified) t.verified += 1;
+    t.produced += s.produced;
+    t.executed += s.executed;
+    t.passed += s.passed;
+    t.failed += s.failed;
+    t.notExecuted += s.not_executed;
+  }
+  return t;
+}
+
+/** The ONE spelling of a set's four counts — "11 produced · 11 executed · 11 passed · 0 failed".
+ *  The card appends "· N not executed" beside it only when the verify phase left tests unrun
+ *  (F-7R2-015's lesson: never silently). */
+export function testSetCountsWord(t: Pick<TestSet, 'produced' | 'executed' | 'passed' | 'failed'>): string {
+  return `${t.produced} produced · ${t.executed} executed · ${t.passed} passed · ${t.failed} failed`;
+}
+
+/** The set's delivered PR — `deliverUrl` through {@link isPrUrl}, the one gate every PR claim
+ *  takes; `null` when absent or out of shape. */
+export function testSetPrHref(t: TestSet | Pick<TestSet, 'deliverUrl'>): string | null {
+  return typeof t.deliverUrl === 'string' && isPrUrl(t.deliverUrl) ? t.deliverUrl : null;
+}
+
+/**
+ * The Home "Test" door's count line — the SAME census as the landing's "Tests" tile (campaigns +
+ * label groups), with the registered sets appended once a 0.36 daemon serves them: "2 tests ·
+ * 3 test sets". A pre-0.36 daemon (`testSets: null`) says only "2 tests" — the sets are absent, not
+ * zero. (`groups` is optional only for older partial answers; it reads as none.)
+ */
+export function testDoorWord(listing: {
+  campaigns: readonly unknown[];
+  groups?: readonly unknown[] | undefined;
+  testSets?: readonly TestSet[] | null | undefined;
+}): string {
+  const plural = (n: number, w: string): string => `${n} ${w}${n === 1 ? '' : 's'}`;
+  const tests = plural(listing.campaigns.length + (listing.groups?.length ?? 0), 'test');
+  const sets = listing.testSets ?? null;
+  return sets === null || sets.length === 0 ? tests : `${tests} · ${plural(sets.length, 'test set')}`;
+}
+
 // ── The card models (needs-you first) ──────────────────────────────────────────
 
 /** One campaign OR one ad-hoc group, as the grid renders it — one sort, one chip fold. */
@@ -255,9 +342,11 @@ export interface CampaignCardModel {
   runningNow: boolean;
   /** ≥ 1 member run inside the current recency window (positional, over the live list). */
   inWindow: boolean;
-  /** The produced test set a member `qe-author-tests` run registered (wave 6, api-types 0.36.0 —
-   *  F-7R2-014); `null` when the wire carries none. */
-  testSet: TestSetRegistration | null;
+  /** The produced test sets joined onto this card (wave 6, api-types 0.36.0 — F-7R2-014): every
+   *  `CampaignsListResponse.test_sets` row whose `run_id` is a member run, plus — for a group — every
+   *  row the daemon tagged with this group's `label` (`qe-tests-<repo>`). Wire order (newest first);
+   *  `[]` when none, and always `[]` on a pre-0.36 daemon. See {@link joinTestSets}. */
+  testSets: TestSet[];
   /** The distinct workflow ids of the member runs the live list knows (`session.workflow_id`) —
    *  how a card says "qe-author-tests" before any registration lands. */
   workflowIds: string[];
@@ -301,10 +390,13 @@ export function campaignCards(
   groups: readonly RunGroup[],
   runsById: ReadonlyMap<string, SessionView>,
   windowIds: ReadonlySet<string>,
+  /** `CampaignsListResponse.test_sets` as the store holds it — pass `[]` for a pre-0.36 daemon. */
+  testSets: readonly TestSet[] = [],
 ): CampaignCardModel[] {
   const models: CampaignCardModel[] = [];
   for (const c of campaigns) {
     const n = campaignCounts(c);
+    const memberRunIds = campaignMemberRunIds(c);
     models.push(withLiveJoin({
       kind: 'campaign',
       id: c.id,
@@ -318,10 +410,10 @@ export function campaignCards(
       awaitingHuman: n.awaitingHuman,
       attached: n.attached,
       rollup: campaignDeliveryRollup(c),
-      memberRunIds: campaignMemberRunIds(c),
+      memberRunIds,
       failing: n.failed > 0,
       runningNow: n.running > 0,
-      testSet: testSetOf(c),
+      testSets: joinTestSets(memberRunIds, null, testSets),
     }, runsById, windowIds));
   }
   for (const g of groups) {
@@ -342,7 +434,7 @@ export function campaignCards(
       memberRunIds: g.runs.map((r) => r.runId),
       failing: n.failed > 0,
       runningNow: n.running > 0,
-      testSet: testSetOf(g),
+      testSets: joinTestSets(g.runs.map((r) => r.runId), g.label, testSets),
     }, runsById, windowIds));
   }
   return models.sort((a, b) =>

--- a/src/components/CampaignsPage.tsx
+++ b/src/components/CampaignsPage.tsx
@@ -502,6 +502,9 @@ export function CampaignsPage({ runs, navigate, projectId = null, launchIntent =
   // absent on a pre-0.36 daemon (`setTotals === null`), "no test sets registered yet" on a 0.36
   // daemon's real zero (F-3), "· N unattributed" / "· N malformed" whenever non-zero (F-2).
   const setsWord = setTotals === null ? null : testSetsWord(setTotals, unattributed.length, malformedTestSets);
+  // The unabridged line for the span's hover title (R2-1): "1 test set · …" where the painted lead
+  // says "1 set · …" so it clears the ellipsis glyph at 1440 px.
+  const setsWordFull = setTotals === null ? null : testSetsWord(setTotals, unattributed.length, malformedTestSets, 'full');
 
   // The freshest member-run narration per card — `recentActivity` capped at 1 (the ONE
   // narrator fold the home pulse reads; a second derivation could contradict it), clocked by
@@ -658,6 +661,7 @@ export function CampaignsPage({ runs, navigate, projectId = null, launchIntent =
             // "N ad-hoc group" word is gone — every 0.36 New test IS a label group, so it only crowded
             // the line (#266 F-1 / F-8). The tile's `title` says what the value counts.
             context={[...(setsWord !== null ? [setsWord] : []), `${totals.activeNow} active now`].join(' · ')}
+            contextTitle={[...(setsWordFull !== null ? [setsWordFull] : []), `${totals.activeNow} active now`].join(' · ')}
             data={{
               'data-test-sets': setTotals === null ? 'absent' : setTotals.sets,
               'data-test-sets-unattributed': unattributed.length,

--- a/src/components/CampaignsPage.tsx
+++ b/src/components/CampaignsPage.tsx
@@ -3,7 +3,7 @@ import { campaignPath, testingPath, type LaunchIntent } from '../api/testing.js'
 import type { SessionView } from '../api/types.js';
 import {
   campaignCards, campaignTotals, deliveryRollupWord, matchesCampaignChip, memberRunIdSet,
-  passRateHealth, passRateWord, progressWord,
+  passRateHealth, passRateWord, progressWord, testSetCountsWord, testSetPrHref, testSetTotals,
   type CampaignCardModel, type CampaignChip,
 } from '../board/campaignStats.js';
 import { recentActivity } from '../board/homeActivity.js';
@@ -66,6 +66,8 @@ const CARD_STAT: React.CSSProperties = {
 
 /** Most per-sibling PR links a card renders inline; the rest fold into a "+n" word. */
 const CARD_PR_CAP = 4;
+/** Produced test sets shown per card, newest first; older ones are counted, never hidden silently. */
+const CARD_SET_CAP = 3;
 
 /** The scoreboard's segmented status bar, condensed onto the card — real counts, no series. */
 function StatusBar({ m }: { m: CampaignCardModel }): React.ReactElement | null {
@@ -269,50 +271,112 @@ function CampaignCard({ m, narration, navigate }: {
         </div>
       )}
 
-      {/* ── The produced test set (wave 6, F-7R2-014) — the counts the VERIFY phase re-derived, off
-             the campaign registration; the workflow chip reads the live runs' `workflow_id` so the
-             card says "qe-author-tests" from launch, before any registration lands. ── */}
-      {(m.workflowIds.length > 0 || m.testSet !== null) && (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap' }}>
-          {m.workflowIds.map((w) => (
-            <span
-              key={w}
-              data-testid="campaign-card-workflow"
-              data-workflow={w}
-              title={w === 'qe-author-tests'
-                ? 'The governed test-authoring workflow: recon → author → verify → review → deliver'
-                : `Workflow ${w}`}
-              style={{
-                ...CARD_STAT, color: w === 'qe-author-tests' ? S.accent : S.muted,
-                border: `1px solid ${S.border}`, borderRadius: 'var(--radius-full)', padding: '1px 8px',
-              }}
-            >
-              {w}
-            </span>
-          ))}
-          {m.testSet !== null && (
-            <span
-              data-testid="campaign-card-testset"
-              data-tests={m.testSet.counts.tests}
-              data-executed={m.testSet.counts.executed}
-              data-passed={m.testSet.counts.passed}
-              data-failed={m.testSet.counts.failed}
-              title={m.testSet.files.length > 0 ? m.testSet.files.join('\n') : 'no file list on the registration'}
-              style={{ ...CARD_STAT, color: m.testSet.counts.failed > 0 ? 'var(--status-fail)' : S.ink, whiteSpace: 'normal' }}
-            >
-              {m.testSet.counts.files} test file{m.testSet.counts.files === 1 ? '' : 's'} · {m.testSet.counts.tests} test{m.testSet.counts.tests === 1 ? '' : 's'}
-              {' · '}
-              {m.testSet.counts.executed} executed · {m.testSet.counts.passed} passed · {m.testSet.counts.failed} failed
-              {m.testSet.counts.executed < m.testSet.counts.tests && (
-                <span data-testid="campaign-card-testset-unverified" style={{ color: 'var(--status-gate)' }}>
-                  {' '}· {m.testSet.counts.tests - m.testSet.counts.executed} never executed
+      {/* ── The produced test sets (wave 6, F-7R2-014; api-types 0.36.0) — the top-level
+             `CampaignsListResponse.test_sets`, joined onto this card by run_id / label in the fold, with
+             the counts the VERIFY phase re-derived, the PLAN and the delivered PR. The workflow chip reads
+             the live runs' `workflow_id`, so the card says "qe-author-tests" from launch, before any set
+             registers. A pre-0.36 daemon serves no sets: nothing below renders (absence, never 0). ── */}
+      {(m.workflowIds.length > 0 || m.testSets.length > 0) && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+          {m.workflowIds.length > 0 && (
+            <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap' }}>
+              {m.workflowIds.map((w) => (
+                <span
+                  key={w}
+                  data-testid="campaign-card-workflow"
+                  data-workflow={w}
+                  title={w === 'qe-author-tests'
+                    ? 'The governed test-authoring workflow: recon → author → verify → review → deliver'
+                    : `Workflow ${w}`}
+                  style={{
+                    ...CARD_STAT, color: w === 'qe-author-tests' ? S.accent : S.muted,
+                    border: `1px solid ${S.border}`, borderRadius: 'var(--radius-full)', padding: '1px 8px',
+                  }}
+                >
+                  {w}
                 </span>
-              )}
-            </span>
+              ))}
+            </div>
           )}
-          {m.testSet !== null && m.testSet.plan !== null && (
-            <span data-testid="campaign-card-testset-plan" style={{ ...CARD_STAT, color: S.faint }} title="The PLAN the author phase wrote">
-              plan: {m.testSet.plan}
+          {m.testSets.slice(0, CARD_SET_CAP).map((t) => {
+            const pr = testSetPrHref(t);
+            return (
+              <div
+                key={t.id}
+                data-testid="campaign-card-testset"
+                data-set-id={t.id}
+                data-run-id={t.run_id}
+                data-verified={t.verified}
+                data-produced={t.produced}
+                data-executed={t.executed}
+                data-passed={t.passed}
+                data-failed={t.failed}
+                data-not-executed={t.not_executed}
+                title={t.files.length > 0
+                  ? t.files.map((f) => `${f.path} — ${f.status}`).join('\n')
+                  : 'no file list on the registration'}
+                style={{ display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap' }}
+              >
+                <span
+                  data-testid="campaign-card-testset-verified"
+                  title={t.verified
+                    ? 'The verify phase PASSED: every produced test executed and green, the repository checks green, the PLAN present'
+                    : `NOT verified — verify phase: ${t.verify_status ?? 'never planned'}; run ${t.run_status}`}
+                  style={{
+                    ...CARD_STAT, color: t.verified ? 'var(--status-done)' : 'var(--status-gate)',
+                    border: `1px solid ${S.border}`, borderRadius: 'var(--radius-full)', padding: '1px 8px', flexShrink: 0,
+                  }}
+                >
+                  {t.verified ? 'verified' : 'not verified'}
+                </span>
+                <span style={{ ...CARD_STAT, color: t.failed > 0 ? 'var(--status-fail)' : S.ink, whiteSpace: 'normal' }}>
+                  {testSetCountsWord(t)}
+                  {t.not_executed > 0 && (
+                    <span data-testid="campaign-card-testset-unverified" style={{ color: 'var(--status-gate)' }}>
+                      {' '}· {t.not_executed} not executed
+                    </span>
+                  )}
+                </span>
+                {t.plan !== null && (
+                  <button
+                    type="button"
+                    data-testid="campaign-card-testset-plan"
+                    data-run-id={t.run_id}
+                    data-plan={t.plan}
+                    title="The PLAN the author phase wrote — open the run; its Files view reads the run branch"
+                    onClick={(e) => { e.stopPropagation(); navigate(`/runs/${encodeURIComponent(t.run_id)}`); }}
+                    style={{
+                      ...CARD_STAT, color: S.muted, textDecoration: 'underline', cursor: 'pointer',
+                      background: 'transparent', border: 'none', padding: 0,
+                    }}
+                  >
+                    plan: {t.plan}
+                  </button>
+                )}
+                {pr !== null && (
+                  <a
+                    data-testid="campaign-card-testset-pr"
+                    data-run-id={t.run_id}
+                    href={pr}
+                    target="_blank"
+                    rel="noreferrer"
+                    title={`${runShortId(t.run_id)} — ${pr}`}
+                    onClick={(e) => e.stopPropagation()}
+                    style={{ ...CARD_STAT, color: S.accent, textDecoration: 'underline' }}
+                  >
+                    PR #{pr.split('/').pop()}
+                  </a>
+                )}
+              </div>
+            );
+          })}
+          {m.testSets.length > CARD_SET_CAP && (
+            <span
+              data-testid="campaign-card-testset-more"
+              style={{ ...CARD_STAT, color: S.faint }}
+              title="Older sets registered under this test — the daemon serves every one; the card shows the newest three"
+            >
+              +{m.testSets.length - CARD_SET_CAP} older set{m.testSets.length - CARD_SET_CAP === 1 ? '' : 's'}
             </span>
           )}
         </div>
@@ -363,6 +427,7 @@ export function CampaignsPage({ runs, navigate, projectId = null, launchIntent =
   const support = useCampaignsStore((s) => s.support);
   const campaigns = useCampaignsStore((s) => s.campaigns);
   const groups = useCampaignsStore((s) => s.groups);
+  const testSets = useCampaignsStore((s) => s.testSets);
   const refresh = useCampaignsStore((s) => s.refresh);
   const byRun = useRunEventStore((s) => s.byRun);
   const logs = useRuntimeStore((s) => s.logs);
@@ -411,6 +476,8 @@ export function CampaignsPage({ runs, navigate, projectId = null, launchIntent =
 
   // ── KPI folds (pure, board/campaignStats) ───────────────────────────────────
   const totals = useMemo(() => campaignTotals(campaigns, groups), [campaigns, groups]);
+  // The registered sets' rollup — `null` on a pre-0.36 daemon, so the tile says nothing about sets.
+  const setTotals = useMemo(() => (testSets === null ? null : testSetTotals(testSets)), [testSets]);
   const runsDelta = useMemo(() => windowDelta(buckets, (rs) => rs.length), [buckets]);
   const failedDelta = useMemo(
     () => windowDelta(buckets, (rs) => rs.filter((v) => outcomeOf(v.session.status) === 'fail').length),
@@ -421,8 +488,8 @@ export function CampaignsPage({ runs, navigate, projectId = null, launchIntent =
 
   // ── The card models (needs-you first; campaigns and groups, one sorted set) ──
   const cards = useMemo(
-    () => campaignCards(campaigns, groups, runsById, windowIds),
-    [campaigns, groups, runsById, windowIds],
+    () => campaignCards(campaigns, groups, runsById, windowIds, testSets ?? []),
+    [campaigns, groups, runsById, windowIds, testSets],
   );
 
   // The freshest member-run narration per card — `recentActivity` capped at 1 (the ONE
@@ -576,7 +643,14 @@ export function CampaignsPage({ runs, navigate, projectId = null, launchIntent =
             testId="stat-campaigns"
             label="Tests"
             value={totals.campaigns + totals.groups}
-            context={`${totals.activeNow} active now${totals.groups > 0 ? ` · ${totals.groups} ad-hoc group${totals.groups === 1 ? '' : 's'}` : ''}`}
+            context={[
+              `${totals.activeNow} active now`,
+              ...(totals.groups > 0 ? [`${totals.groups} ad-hoc group${totals.groups === 1 ? '' : 's'}`] : []),
+              // The produced sets (api-types 0.36.0) — said only when the wire carries them.
+              ...(setTotals !== null && setTotals.sets > 0
+                ? [`${setTotals.sets} test set${setTotals.sets === 1 ? '' : 's'} · ${setTotals.passed} of ${setTotals.produced} passed`]
+                : []),
+            ].join(' · ')}
             title="Every test and ad-hoc group on this daemon — click to clear filters"
             onOpen={() => { setChip('all'); setQuery(''); }}
           />
@@ -683,7 +757,8 @@ export function CampaignsPage({ runs, navigate, projectId = null, launchIntent =
           </p>
           <p style={{ fontSize: '12px', color: S.faint, margin: 0 }}>
             A test appears here the moment New test launches it (one card per launch, its runs inside) and
-            fills in with the produced set — files, tests, executed / passed / failed — when the run finishes.
+            fills in with the produced set — produced, executed / passed / failed, the PLAN and the PR — when
+            the run finishes.
           </p>
           <button
             type="button"

--- a/src/components/CampaignsPage.tsx
+++ b/src/components/CampaignsPage.tsx
@@ -3,7 +3,8 @@ import { campaignPath, testingPath, type LaunchIntent } from '../api/testing.js'
 import type { SessionView } from '../api/types.js';
 import {
   campaignCards, campaignTotals, deliveryRollupWord, matchesCampaignChip, memberRunIdSet,
-  passRateHealth, passRateWord, progressWord, testSetCountsWord, testSetPrHref, testSetTotals,
+  passRateHealth, passRateWord, progressWord, testSetCountsWord, testSetPrHref, testSetTotals, testSetsWord,
+  unattributedTestSets,
   type CampaignCardModel, type CampaignChip,
 } from '../board/campaignStats.js';
 import { recentActivity } from '../board/homeActivity.js';
@@ -428,6 +429,7 @@ export function CampaignsPage({ runs, navigate, projectId = null, launchIntent =
   const campaigns = useCampaignsStore((s) => s.campaigns);
   const groups = useCampaignsStore((s) => s.groups);
   const testSets = useCampaignsStore((s) => s.testSets);
+  const malformedTestSets = useCampaignsStore((s) => s.malformedTestSets);
   const refresh = useCampaignsStore((s) => s.refresh);
   const byRun = useRunEventStore((s) => s.byRun);
   const logs = useRuntimeStore((s) => s.logs);
@@ -491,6 +493,15 @@ export function CampaignsPage({ runs, navigate, projectId = null, launchIntent =
     () => campaignCards(campaigns, groups, runsById, windowIds, testSets ?? []),
     [campaigns, groups, runsById, windowIds, testSets],
   );
+  // Sets no card carries (the producing run archived / its group gone) — said, never folded away.
+  const unattributed = useMemo(
+    () => (testSets === null ? [] : unattributedTestSets(cards, testSets)),
+    [cards, testSets],
+  );
+  // The tile's sets word — FIRST in the context so it survives the tile's ellipsis (#266 F-1);
+  // absent on a pre-0.36 daemon (`setTotals === null`), "no test sets registered yet" on a 0.36
+  // daemon's real zero (F-3), "· N unattributed" / "· N malformed" whenever non-zero (F-2).
+  const setsWord = setTotals === null ? null : testSetsWord(setTotals, unattributed.length, malformedTestSets);
 
   // The freshest member-run narration per card — `recentActivity` capped at 1 (the ONE
   // narrator fold the home pulse reads; a second derivation could contradict it), clocked by
@@ -643,15 +654,18 @@ export function CampaignsPage({ runs, navigate, projectId = null, launchIntent =
             testId="stat-campaigns"
             label="Tests"
             value={totals.campaigns + totals.groups}
-            context={[
-              `${totals.activeNow} active now`,
-              ...(totals.groups > 0 ? [`${totals.groups} ad-hoc group${totals.groups === 1 ? '' : 's'}`] : []),
-              // The produced sets (api-types 0.36.0) — said only when the wire carries them.
-              ...(setTotals !== null && setTotals.sets > 0
-                ? [`${setTotals.sets} test set${setTotals.sets === 1 ? '' : 's'} · ${setTotals.passed} of ${setTotals.produced} passed`]
-                : []),
-            ].join(' · ')}
-            title="Every test and ad-hoc group on this daemon — click to clear filters"
+            // The sets word leads (it is what the operator came for); "active now" follows. The
+            // "N ad-hoc group" word is gone — every 0.36 New test IS a label group, so it only crowded
+            // the line (#266 F-1 / F-8). The tile's `title` says what the value counts.
+            context={[...(setsWord !== null ? [setsWord] : []), `${totals.activeNow} active now`].join(' · ')}
+            data={{
+              'data-test-sets': setTotals === null ? 'absent' : setTotals.sets,
+              'data-test-sets-unattributed': unattributed.length,
+              'data-test-sets-malformed': malformedTestSets,
+            }}
+            title={unattributed.length > 0
+              ? `Every test on this daemon — each repository's label group and every multi-repo run — click to clear filters. ${unattributed.length} registered set${unattributed.length === 1 ? '' : 's'} belong${unattributed.length === 1 ? 's' : ''} to no test shown here (the producing run is gone from the wire): ${unattributed.map((t) => t.plan ?? t.id).join(', ')}`
+              : "Every test on this daemon — each repository's label group and every multi-repo run — click to clear filters"}
             onOpen={() => { setChip('all'); setQuery(''); }}
           />
           <StatTile

--- a/src/components/HomeBoard.tsx
+++ b/src/components/HomeBoard.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { api } from '../api/client.js';
-import { listCampaigns, type Campaign } from '../api/campaigns.js';
+import { listCampaigns, type CampaignsListing } from '../api/campaigns.js';
+import { testDoorWord } from '../board/campaignStats.js';
 import { getDiagnostics, type Diagnostics } from '../api/diagnostics.js';
 import type { SteeringRule } from '../api/steering.js';
 import type { GovernanceClaim, SessionView } from '../api/types.js';
@@ -139,7 +140,9 @@ function BandGrid({ items, columns, rowH, firstRow, lastRow, navigate, cursor }:
  *  unless) each answers; absence degrades the feature, never the page. */
 interface HomeWires {
   chats: LiveChatSnapshot[] | null;
-  campaigns: Campaign[] | null;
+  /** The ONE `GET /campaigns` answer — campaigns + label groups, plus the api-types 0.36.0 test
+   *  sets (`testSets: null` inside = a pre-0.36 daemon). */
+  campaigns: CampaignsListing | null;
   claims: GovernanceClaim[] | null;
   rules: SteeringRule[] | null;
   perRule: WikiRuleEvidenceRow[] | null;
@@ -181,7 +184,7 @@ export function HomeBoard({ runs, navigate, onOpenAsk }: Props): React.ReactElem
       if (!cancelled) setWires((w) => ({ ...w, ...part }));
     };
     void read(() => api.listChats()).then((r) => r !== null && deposit({ chats: r.chats }));
-    void read(() => listCampaigns()).then((r) => r !== null && deposit({ campaigns: r.campaigns }));
+    void read(() => listCampaigns()).then((r) => r !== null && deposit({ campaigns: r }));
     void read(() => api.listClaims()).then((r) => r !== null && deposit({ claims: r.claims }));
     void read(() => api.listConformanceRules()).then(
       (r) => r !== null && deposit({ rules: r.rules as SteeringRule[] }),
@@ -239,7 +242,8 @@ export function HomeBoard({ runs, navigate, onOpenAsk }: Props): React.ReactElem
         projectIds: projectIdByRun,
         chats: wires.chats ?? [],
         repos,
-        campaigns: wires.campaigns ?? [],
+        // The needs-you wall reads the ENGINE campaigns off the listing (a label group has no gate of its own).
+        campaigns: wires.campaigns?.campaigns ?? [],
         now,
       }),
     [runs, gates, failedAt, attachedAt, projectIdByRun, wires.chats, wires.campaigns, repos, now],
@@ -325,7 +329,9 @@ export function HomeBoard({ runs, navigate, onOpenAsk }: Props): React.ReactElem
     const plural = (n: number, w: string): string => `${n} ${w}${n === 1 ? '' : 's'}`;
     return [
       { key: 'execute', label: 'Execute', glyph: '▸', count: plural(runs.length, 'run'), href: '/execute', color: 'var(--status-run)' },
-      { key: 'test', label: 'Test', glyph: '✓', count: wires.campaigns === null ? null : plural(wires.campaigns.length, 'test'), href: '/testing/campaigns', color: 'var(--section-test)' },
+      // The same census as the landing's "Tests" tile (campaigns + label groups) — with the produced
+      // sets appended once a 0.36 daemon serves them (`testDoorWord`); a pre-0.36 answer says only "N tests".
+      { key: 'test', label: 'Test', glyph: '✓', count: wires.campaigns === null ? null : testDoorWord(wires.campaigns), href: '/testing/campaigns', color: 'var(--section-test)' },
       // F-1/F-2: the census the count covers is said — "N documents" only once the daemon-wide index
       // (or an explicit fan-out) has answered for every project; otherwise "in opened projects".
       { key: 'vibe', label: 'Vibe', glyph: '▤', count: docsCensus === 'opened' ? `${plural(docsCount, 'document')} in opened projects` : plural(docsCount, 'document'), href: '/vibe', color: 'var(--section-vibe)' },

--- a/src/components/TestingLaunchPanel.tsx
+++ b/src/components/TestingLaunchPanel.tsx
@@ -106,7 +106,6 @@ type WorkflowsState = 'loading' | 'unavailable' | WorkflowDef[];
 /** The words for the wire a launch rode — stated on the panel, never implied. */
 const ROUTE_WORD: Record<GovernedLaunchRoute, string> = {
   'testing-author': 'via POST /testing/author',
-  'testing-recon-workflow': 'via POST /testing/recon (workflow)',
   'runs-fan': 'via POST /runs per repository — repoRef scopes, projectId files',
   'testing-recon-plain': 'via POST /testing/recon — a plain free-text run',
 };

--- a/src/components/TestingLaunchPanel.tsx
+++ b/src/components/TestingLaunchPanel.tsx
@@ -157,6 +157,9 @@ interface Launched {
   ids: string[];
   campaign: string | null;
   campaignRegistered: boolean;
+  /** The `qe-tests-<repo>` label groups the daemon filed the runs under (`/testing/author`'s
+   *  `runs[].label`) — the group card already exists on the Test landing (#266 F-4). */
+  labels: string[];
   route: GovernedLaunchRoute;
   workflow: string | null;
   /** R2-1: the daemon's answer did not honour the narrowed scope — said, never hidden. */
@@ -341,6 +344,7 @@ export function TestingLaunchPanel({ intent, navigate, onClose, onLaunched, init
         ids,
         campaign: typeof result.campaign === 'string' && result.campaign !== '' ? result.campaign : null,
         campaignRegistered: result.campaignRegistered,
+        labels: result.labels,
         route: result.route,
         workflow: result.workflow,
         scopeNote: result.scopeNote,
@@ -594,6 +598,8 @@ export function TestingLaunchPanel({ intent, navigate, onClose, onLaunched, init
                   {launched.ids.length} runs launched
                   {launched.campaign !== null ? (
                     <> under <span className="font-mono" data-testid="testing-launch-fanout-label">{launched.campaign}</span></>
+                  ) : launched.labels.length > 0 ? (
+                    <> — one per attached codebase, each filed under its repository&rsquo;s label</>
                   ) : (
                     <> — one per attached codebase, under one test</>
                   )}
@@ -619,11 +625,26 @@ export function TestingLaunchPanel({ intent, navigate, onClose, onLaunched, init
               {launched.ids.length === 1 && launched.campaign !== null && (
                 <> · {launched.campaignRegistered ? 'test' : 'label'} <span className="font-mono" data-testid="testing-launch-fanout-label">{launched.campaign}</span></>
               )}
-              {launched.campaignRegistered
-                ? ' · registered on the Test landing'
-                : launched.campaign !== null
-                  ? ' · grouped under one label on the Test landing'
-                  : ' · appears on the Test landing when the run registers its test set'}
+              {launched.campaignRegistered ? (
+                ' · registered on the Test landing'
+              ) : launched.labels.length > 0 ? (
+                // 0.36.0 files each run under `qe-tests-<repo>` at launch — the group card is already
+                // on the Test landing; only the SET waits for the verify phase (#266 F-4).
+                <>
+                  {' · filed under '}
+                  {launched.labels.map((l, i) => (
+                    <span key={l}>
+                      {i > 0 ? ', ' : ''}
+                      <span className="font-mono" data-testid="testing-launch-filed-label" style={{ color: 'var(--ink-high)' }}>{l}</span>
+                    </span>
+                  ))}
+                  {' on the Test landing — the set fills in when the verify phase registers it'}
+                </>
+              ) : launched.campaign !== null ? (
+                ' · grouped under one label on the Test landing'
+              ) : (
+                ' · appears on the Test landing when the run registers its test set'
+              )}
             </p>
           </div>
 

--- a/src/components/dashboardKit.tsx
+++ b/src/components/dashboardKit.tsx
@@ -165,7 +165,11 @@ export function StatTile({
         {delta !== undefined && <DeltaMark delta={delta} sense={deltaSense} />}
       </span>
       {context !== undefined && (
+        // One nowrap line — the tail may ellipsize, so the FULL text rides on `title` (review of
+        // #266, F-1) and callers put the part that must survive first.
         <span
+          data-testid="stat-context"
+          title={context}
           style={{
             fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)', color: 'var(--ink-dim)',
             overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',

--- a/src/components/dashboardKit.tsx
+++ b/src/components/dashboardKit.tsx
@@ -86,8 +86,11 @@ export interface StatTileProps {
   delta?: StatDelta | undefined;
   /** How to color a delta: neutral (ink) or bad-up (more failed = red). */
   deltaSense?: 'neutral' | 'bad-up' | undefined;
-  /** Tiny context line (the window, honestly named). */
+  /** Tiny context line (the window, honestly named). One nowrap line — the tail may ellipsize. */
   context?: string | undefined;
+  /** The context span's hover text when the painted line is an abridgement of it (R2-1 on #266);
+   *  defaults to `context` itself so the full line is always reachable. */
+  contextTitle?: string | undefined;
   /** Inline area sparkline series (oldest first). Absent/all-zero = no chart. */
   spark?: readonly number[] | undefined;
   /** Threshold color for the number itself — only where it MEANS something. */
@@ -133,7 +136,7 @@ function DeltaMark({ delta, sense }: { delta: StatDelta; sense: 'neutral' | 'bad
 }
 
 export function StatTile({
-  testId, label, value, delta, deltaSense = 'neutral', context, spark,
+  testId, label, value, delta, deltaSense = 'neutral', context, contextTitle, spark,
   valueColor, onOpen, href, title, data,
 }: StatTileProps): React.ReactElement {
   const body = (
@@ -169,7 +172,7 @@ export function StatTile({
         // #266, F-1) and callers put the part that must survive first.
         <span
           data-testid="stat-context"
-          title={context}
+          title={contextTitle ?? context}
           style={{
             fontSize: 'var(--text-2xs)', fontFamily: 'var(--font-mono)', color: 'var(--ink-dim)',
             overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',

--- a/src/store/campaigns.ts
+++ b/src/store/campaigns.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { listCampaigns, type Campaign, type RunGroup } from '../api/campaigns.js';
 import type { CoreEvent } from '../api/types.js';
+import type { TestSet } from '../api/wave6-wire.js';
 
 /**
  * The campaign store (DES-CAMPAIGN-001 §1.5/§2.4 + TH-14): the support probe, the campaign
@@ -79,6 +80,9 @@ interface CampaignsStore {
   campaigns: Campaign[];
   /** Ad-hoc label groups (api-types 0.19.0) — `[]` on a pre-0.19 daemon (normalized). */
   groups: RunGroup[];
+  /** The registered test sets (wave 6, api-types 0.36.0), wire order (newest first); `null` on a
+   *  pre-0.36 daemon — absence, never a fabricated empty list. */
+  testSets: TestSet[] | null;
   /** Live frame fold, keyed by campaign id. */
   live: Record<string, CampaignLive>;
   /** Probe + (re)fetch the list. Sets `support` from the answer (§1.5). */
@@ -94,18 +98,19 @@ export const useCampaignsStore = create<CampaignsStore>((set) => ({
   support: 'unknown',
   campaigns: [],
   groups: [],
+  testSets: null,
   live: {},
 
   refresh: () => {
     if (inflight !== null) return inflight;
     inflight = listCampaigns()
-      .then(({ campaigns, groups }) => {
-        set({ support: 'supported', campaigns, groups });
+      .then(({ campaigns, groups, testSets }) => {
+        set({ support: 'supported', campaigns, groups, testSets: testSets ?? null });
       })
       .catch(() => {
         // 404/501 = this daemon predates campaigns (§1.5's whole discriminator);
         // anything else (network, 500) also reads as unsupported — said once, not spun on.
-        set({ support: 'unsupported', campaigns: [], groups: [] });
+        set({ support: 'unsupported', campaigns: [], groups: [], testSets: null });
       })
       .finally(() => {
         inflight = null;

--- a/src/store/campaigns.ts
+++ b/src/store/campaigns.ts
@@ -83,6 +83,8 @@ interface CampaignsStore {
   /** The registered test sets (wave 6, api-types 0.36.0), wire order (newest first); `null` on a
    *  pre-0.36 daemon — absence, never a fabricated empty list. */
   testSets: TestSet[] | null;
+  /** `test_sets` rows served without a `run_id` — counted so the landing can say "N malformed". */
+  malformedTestSets: number;
   /** Live frame fold, keyed by campaign id. */
   live: Record<string, CampaignLive>;
   /** Probe + (re)fetch the list. Sets `support` from the answer (§1.5). */
@@ -99,18 +101,19 @@ export const useCampaignsStore = create<CampaignsStore>((set) => ({
   campaigns: [],
   groups: [],
   testSets: null,
+  malformedTestSets: 0,
   live: {},
 
   refresh: () => {
     if (inflight !== null) return inflight;
     inflight = listCampaigns()
-      .then(({ campaigns, groups, testSets }) => {
-        set({ support: 'supported', campaigns, groups, testSets: testSets ?? null });
+      .then(({ campaigns, groups, testSets, malformedTestSets }) => {
+        set({ support: 'supported', campaigns, groups, testSets: testSets ?? null, malformedTestSets: malformedTestSets ?? 0 });
       })
       .catch(() => {
         // 404/501 = this daemon predates campaigns (§1.5's whole discriminator);
         // anything else (network, 500) also reads as unsupported — said once, not spun on.
-        set({ support: 'unsupported', campaigns: [], groups: [], testSets: null });
+        set({ support: 'unsupported', campaigns: [], groups: [], testSets: null, malformedTestSets: 0 });
       })
       .finally(() => {
         inflight = null;

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -11,8 +11,8 @@
   "studioVersion": "0.5.7",
   "counts": {
     "files": 146,
-    "occurrences": 1298,
-    "static": 1119,
+    "occurrences": 1300,
+    "static": 1121,
     "dynamic": 61,
     "computed": 7
   },
@@ -5165,6 +5165,12 @@
       ]
     },
     {
+      "testId": "stat-context",
+      "files": [
+        "src/components/dashboardKit.tsx"
+      ]
+    },
+    {
       "testId": "stat-delta",
       "files": [
         "src/components/dashboardKit.tsx"
@@ -6050,6 +6056,12 @@
     },
     {
       "testId": "testing-launch-fanout-run",
+      "files": [
+        "src/components/TestingLaunchPanel.tsx"
+      ]
+    },
+    {
+      "testId": "testing-launch-filed-label",
       "files": [
         "src/components/TestingLaunchPanel.tsx"
       ]

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -11,8 +11,8 @@
   "studioVersion": "0.5.7",
   "counts": {
     "files": 146,
-    "occurrences": 1295,
-    "static": 1116,
+    "occurrences": 1298,
+    "static": 1119,
     "dynamic": 61,
     "computed": 7
   },
@@ -584,13 +584,31 @@
       ]
     },
     {
+      "testId": "campaign-card-testset-more",
+      "files": [
+        "src/components/CampaignsPage.tsx"
+      ]
+    },
+    {
       "testId": "campaign-card-testset-plan",
       "files": [
         "src/components/CampaignsPage.tsx"
       ]
     },
     {
+      "testId": "campaign-card-testset-pr",
+      "files": [
+        "src/components/CampaignsPage.tsx"
+      ]
+    },
+    {
       "testId": "campaign-card-testset-unverified",
+      "files": [
+        "src/components/CampaignsPage.tsx"
+      ]
+    },
+    {
+      "testId": "campaign-card-testset-verified",
       "files": [
         "src/components/CampaignsPage.tsx"
       ]

--- a/tests/CampaignsPage.testset.test.tsx
+++ b/tests/CampaignsPage.testset.test.tsx
@@ -36,7 +36,7 @@ const { CampaignsPage } = await import('../src/components/CampaignsPage.js');
 const { useCampaignsStore } = await import('../src/store/campaigns.js');
 const { useRunEventStore } = await import('../src/store/events.js');
 const { useRuntimeStore } = await import('../src/store/runtime.js');
-const { testSetOf, testSetsOf } = await import('../src/api/wave6-wire.js');
+const { testSetOf, testSetsOf, testSetsReadOf } = await import('../src/api/wave6-wire.js');
 
 const RUNS: SessionView[] = [
   makeView({ id: W6_RUN, status: 'completed', workflow_id: 'qe-author-tests', problem: 'New test: cover the run lifecycle', repo_ref: 'wicked-studio' }),
@@ -44,7 +44,7 @@ const RUNS: SessionView[] = [
 
 function reset(): void {
   listCampaigns.mockReset();
-  useCampaignsStore.setState({ support: 'unknown', campaigns: [], groups: [], testSets: null, live: {} });
+  useCampaignsStore.setState({ support: 'unknown', campaigns: [], groups: [], testSets: null, malformedTestSets: 0, live: {} });
   useRunEventStore.setState({ byRun: {} });
   useRuntimeStore.setState({ logs: {} });
 }
@@ -74,6 +74,12 @@ describe('testSetsOf / testSetOf — the null-safe readers of CampaignsListRespo
     });
     expect(testSetOf({ id: 'no-run' })).toBeNull();
     expect(testSetOf('x')).toBeNull();
+  });
+
+  it('testSetsReadOf counts the rows it could not join instead of losing them (#266 F-2)', () => {
+    expect(testSetsReadOf({ test_sets: [W6_TEST_SET, { id: 'no-run' }, 'junk', null] })).toEqual({ sets: [W6_TEST_SET], malformed: 3 });
+    expect(testSetsReadOf({ test_sets: [] })).toEqual({ sets: [], malformed: 0 });
+    expect(testSetsReadOf({ campaigns: [] })).toBeNull();
   });
 });
 
@@ -123,10 +129,22 @@ describe('the card — the produced set off the top-level test_sets (F-7R2-014)'
     expect(within(card).getByTestId('campaign-card-testset')).toHaveAttribute('data-run-id', W6_RUN);
   });
 
-  it('a set belonging to no card renders nowhere — nothing is invented for it', async () => {
-    const stray = { ...W6_TEST_SET, id: 'testset-r-stray', run_id: 'r-stray', label: 'qe-tests-elsewhere' };
+  it('a set belonging to no card renders nowhere — and the Tests tile says "1 unattributed" instead of folding it into the total (#266 F-2)', async () => {
+    const stray = { ...W6_TEST_SET, id: 'testset-r-stray', run_id: 'r-stray', label: 'qe-tests-elsewhere', plan: 'tests/PLAN-stray.md' };
     const card = await landing(w6Listing([stray, W6_TEST_SET]));
     expect(within(card).getAllByTestId('campaign-card-testset').map((e) => e.getAttribute('data-run-id'))).toEqual([W6_RUN]);
+    const tile = screen.getByTestId('stat-campaigns');
+    expect(tile).toHaveAttribute('data-test-sets', '2');
+    expect(tile).toHaveAttribute('data-test-sets-unattributed', '1');
+    expect(within(tile).getByTestId('stat-context')).toHaveTextContent('2 test sets · 22/22 passed · 1 unattributed');
+    expect(tile).toHaveAttribute('title', expect.stringContaining('tests/PLAN-stray.md'));
+  });
+
+  it('rows the daemon served without a run_id are said as "N malformed" on the tile — never read as "nothing registered" (#266 F-2)', async () => {
+    await landing(w6Listing([W6_TEST_SET], [], [w6Group()], 2));
+    const tile = screen.getByTestId('stat-campaigns');
+    expect(tile).toHaveAttribute('data-test-sets-malformed', '2');
+    expect(within(tile).getByTestId('stat-context')).toHaveTextContent('1 test set · 11/11 passed · 2 malformed');
   });
 
   it("a set the verify phase did NOT fully run says how many were never executed and is NOT verified — shown, never hidden (F-7R2-015's lesson)", async () => {
@@ -161,9 +179,12 @@ describe('the card — the produced set off the top-level test_sets (F-7R2-014)'
     expect(within(card).getByTestId('campaign-card-workflow')).toHaveAttribute('data-workflow', 'qe-author-tests');
   });
 
-  it('a 0.36 daemon with nothing registered yet (test_sets: []) renders no counts either', async () => {
+  it('a 0.36 daemon with nothing registered yet (test_sets: []) renders no counts on the card — and the tile says its REAL zero (#266 F-3)', async () => {
     const card = await landing(w6Listing([]));
     expect(within(card).queryByTestId('campaign-card-testset')).toBeNull();
+    const tile = screen.getByTestId('stat-campaigns');
+    expect(tile).toHaveAttribute('data-test-sets', '0');
+    expect(within(tile).getByTestId('stat-context')).toHaveTextContent(/^no test sets registered yet · 0 active now$/);
   });
 
   it('with no live run known and no set, neither chip nor counts render — absence stays absent', async () => {
@@ -176,15 +197,22 @@ describe('the card — the produced set off the top-level test_sets (F-7R2-014)'
     expect(within(card).queryByTestId('campaign-card-workflow')).toBeNull();
   });
 
-  it("the Tests tile's context counts the sets once the wire carries them — and says nothing about sets on a pre-0.36 daemon", async () => {
+  it("the Tests tile's context leads with the sets word (it must survive the tile's ellipsis — #266 F-1), carries the full text as its title, and says nothing about sets on a pre-0.36 daemon", async () => {
     await landing(w6Listing());
-    expect(screen.getByTestId('stat-campaigns')).toHaveAttribute('data-value', '1');
-    expect(screen.getByTestId('stat-campaigns')).toHaveTextContent('1 test set · 11 of 11 passed');
+    const tile = screen.getByTestId('stat-campaigns');
+    expect(tile).toHaveAttribute('data-value', '1');
+    expect(tile).toHaveAttribute('data-test-sets', '1');
+    const ctx = within(tile).getByTestId('stat-context');
+    expect(ctx.textContent).toBe('1 test set · 11/11 passed · 0 active now');
+    expect(ctx).toHaveAttribute('title', '1 test set · 11/11 passed · 0 active now');
+    expect(ctx.textContent).not.toContain('ad-hoc');
     cleanup();
     reset();
     await landing(w6Listing(null));
-    expect(screen.getByTestId('stat-campaigns')).toHaveAttribute('data-value', '1');
-    expect(screen.getByTestId('stat-campaigns')).not.toHaveTextContent('test set');
+    const older = screen.getByTestId('stat-campaigns');
+    expect(older).toHaveAttribute('data-value', '1');
+    expect(older).toHaveAttribute('data-test-sets', 'absent');
+    expect(within(older).getByTestId('stat-context').textContent).toBe('0 active now');
   });
 
   it('the header copy names the governed workflow and the "Add testing rules" verb says what it authors', async () => {

--- a/tests/CampaignsPage.testset.test.tsx
+++ b/tests/CampaignsPage.testset.test.tsx
@@ -1,16 +1,20 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen, within } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import type { SessionView } from '../src/api/types.js';
+import type { CampaignsListing } from '../src/api/campaigns.js';
 import { makeView } from './factories.js';
-import { W6_RUN, W6_TEST_SET, W6_TEST_SET_UNVERIFIED, w6Campaign, w6Group } from './fixtures/wave6.js';
+import { W6_LABEL, W6_PR, W6_RUN, W6_TEST_SET, W6_TEST_SET_UNVERIFIED, w6Campaign, w6Group, w6Listing } from './fixtures/wave6.js';
 
 /**
- * The Test landing after a completed New test (wave 6 — F-7R2-014, api-types 0.36.0
- * `Campaign.test_set` / `RunGroup.test_set`): the card shows the produced set with the counts the
- * verify phase RE-DERIVED (files · tests · executed / passed / failed), flags a set that was not
- * fully executed, names the PLAN, and says "qe-author-tests" off the live runs' `workflow_id` from
- * launch — before any registration lands. A pre-0.36 row renders no counts (absence, never a
- * fabricated zero).
+ * The Test landing after a completed New test (wave 6 — F-7R2-014, api-types 0.36.0): the daemon
+ * serves the produced sets as the TOP-LEVEL `CampaignsListResponse.test_sets` (snake_case,
+ * `run_id`-keyed, tagged with the `qe-tests-<repo>` label the launch filed the run under) — there is
+ * no row-level join. The card joins them by `run_id` against its member runs (and by `label` for a
+ * group) and shows each set: the verified chip, the counts the verify phase RE-DERIVED (produced ·
+ * executed · passed · failed, "· N not executed" when some never ran), the PLAN (opens the producing
+ * run) and the engine's PR (`isPrUrl`-gated). The workflow chip says "qe-author-tests" off the live
+ * runs' `workflow_id` from launch. A pre-0.36 daemon (no `test_sets`) renders no counts — absence,
+ * never a fabricated zero — and the Tests tile says nothing about sets.
  */
 
 const listCampaigns = vi.fn();
@@ -32,80 +36,139 @@ const { CampaignsPage } = await import('../src/components/CampaignsPage.js');
 const { useCampaignsStore } = await import('../src/store/campaigns.js');
 const { useRunEventStore } = await import('../src/store/events.js');
 const { useRuntimeStore } = await import('../src/store/runtime.js');
-const { testSetOf } = await import('../src/api/wave6-wire.js');
+const { testSetOf, testSetsOf } = await import('../src/api/wave6-wire.js');
 
 const RUNS: SessionView[] = [
   makeView({ id: W6_RUN, status: 'completed', workflow_id: 'qe-author-tests', problem: 'New test: cover the run lifecycle', repo_ref: 'wicked-studio' }),
 ];
 
-beforeEach(() => {
+function reset(): void {
   listCampaigns.mockReset();
-  useCampaignsStore.setState({ support: 'unknown', campaigns: [], groups: [], live: {} });
+  useCampaignsStore.setState({ support: 'unknown', campaigns: [], groups: [], testSets: null, live: {} });
   useRunEventStore.setState({ byRun: {} });
   useRuntimeStore.setState({ logs: {} });
-});
+}
+beforeEach(reset);
 afterEach(() => cleanup());
 
-async function landing(campaigns: unknown[], groups: unknown[] = [], runs: SessionView[] = RUNS): Promise<HTMLElement> {
-  listCampaigns.mockResolvedValue({ campaigns, groups });
-  render(<CampaignsPage runs={runs} navigate={() => {}} />);
+async function landing(listing: CampaignsListing, runs: SessionView[] = RUNS, navigate: (p: string) => void = () => {}): Promise<HTMLElement> {
+  listCampaigns.mockResolvedValue(listing);
+  render(<CampaignsPage runs={runs} navigate={navigate} />);
   return await screen.findByTestId('campaign-card');
 }
 
-describe('testSetOf — the null-safe reader', () => {
-  it('narrows a well-formed registration and defaults every count it cannot read to 0', () => {
-    expect(testSetOf({ test_set: W6_TEST_SET })).toEqual(W6_TEST_SET);
-    expect(testSetOf({ test_set: { runId: 'r', counts: { tests: 3 } } })).toEqual({
-      runId: 'r', workflow: 'qe-author-tests', files: [], counts: { files: 0, tests: 3, executed: 0, passed: 0, failed: 0 }, plan: null, prUrl: null,
-    });
+describe('testSetsOf / testSetOf — the null-safe readers of CampaignsListResponse.test_sets', () => {
+  it('a body without the key is null (pre-0.36 — absence); an empty list is [] (a 0.36 daemon with nothing registered yet)', () => {
+    expect(testSetsOf({ campaigns: [], groups: [] })).toBeNull();
+    expect(testSetsOf(null)).toBeNull();
+    expect(testSetsOf({ test_sets: 'x' })).toBeNull();
+    expect(testSetsOf({ campaigns: [], groups: [], test_sets: [] })).toEqual([]);
   });
-  it('anything else is null — no key, null, a shape without runId or counts, a non-object', () => {
-    expect(testSetOf({})).toBeNull();
-    expect(testSetOf({ test_set: null })).toBeNull();
-    expect(testSetOf({ test_set: { counts: {} } })).toBeNull();
-    expect(testSetOf({ test_set: { runId: 'r' } })).toBeNull();
+
+  it('a well-formed row round-trips; a row without run_id is dropped (nothing to join); counts that are not finite numbers read as 0; verified only on an explicit true', () => {
+    expect(testSetsOf({ test_sets: [W6_TEST_SET, { id: 'no-run' }, 'junk', null] })).toEqual([W6_TEST_SET]);
+    expect(testSetOf({ run_id: 'r', produced: '3', verified: 'yes', files: [{ path: 'a.test.ts' }, { nope: 1 }], harnesses: ['vitest', 7], label: '' })).toEqual({
+      id: 'testset-r', run_id: 'r', workflow_id: 'qe-author-tests', repo_ref: null, registered_at: 0, run_status: 'unknown', verify_status: null, verified: false,
+      files: [{ path: 'a.test.ts', harness: 'unknown', status: 'not-executed' }],
+      produced: 0, executed: 0, passed: 0, failed: 0, not_executed: 0, plan: null, harnesses: ['vitest'],
+    });
+    expect(testSetOf({ id: 'no-run' })).toBeNull();
     expect(testSetOf('x')).toBeNull();
   });
 });
 
-describe('the card — the produced set with counts (F-7R2-014)', () => {
-  it('renders the workflow chip and the set: files · tests · executed / passed / failed, plus the plan', async () => {
-    const card = await landing([w6Campaign()]);
+describe('the card — the produced set off the top-level test_sets (F-7R2-014)', () => {
+  it('a label GROUP (how 0.36.0 files an authoring run) shows the set joined by run_id: the verified chip, the four counts, the PLAN, the PR', async () => {
+    const card = await landing(w6Listing());
+    expect(card).toHaveAttribute('data-kind', 'group');
+    expect(card).toHaveTextContent(W6_LABEL);
     expect(within(card).getByTestId('campaign-card-workflow')).toHaveAttribute('data-workflow', 'qe-author-tests');
     const set = within(card).getByTestId('campaign-card-testset');
-    expect(set).toHaveAttribute('data-tests', '11');
+    expect(set).toHaveAttribute('data-run-id', W6_RUN);
+    expect(set).toHaveAttribute('data-set-id', `testset-${W6_RUN}`);
+    expect(set).toHaveAttribute('data-verified', 'true');
+    expect(set).toHaveAttribute('data-produced', '11');
     expect(set).toHaveAttribute('data-executed', '11');
     expect(set).toHaveAttribute('data-passed', '11');
     expect(set).toHaveAttribute('data-failed', '0');
-    expect(set).toHaveTextContent('2 test files · 11 tests · 11 executed · 11 passed · 0 failed');
-    expect(set).toHaveAttribute('title', 'tests/run-lifecycle.test.tsx\ne2e/run_lifecycle_test.py');
-    expect(within(card).queryByTestId('campaign-card-testset-unverified')).toBeNull();
-    expect(within(card).getByTestId('campaign-card-testset-plan')).toHaveTextContent('plan: tests/PLAN-run-lifecycle.md');
+    expect(set).toHaveAttribute('data-not-executed', '0');
+    expect(within(set).getByTestId('campaign-card-testset-verified')).toHaveTextContent(/^verified$/);
+    expect(set).toHaveTextContent('11 produced · 11 executed · 11 passed · 0 failed');
+    expect(set).toHaveAttribute('title', 'tests/run-lifecycle.test.tsx — passed\ne2e/run_lifecycle_test.py — passed');
+    expect(within(set).queryByTestId('campaign-card-testset-unverified')).toBeNull();
+    expect(within(set).getByTestId('campaign-card-testset-plan')).toHaveTextContent('plan: tests/PLAN-run-lifecycle.md');
+    const pr = within(set).getByTestId('campaign-card-testset-pr');
+    expect(pr).toHaveAttribute('href', W6_PR);
+    expect(pr).toHaveTextContent('PR #999');
     // The wire's delivery rollup still rides beside it.
     expect(within(card).getByTestId('campaign-card-delivery')).toHaveTextContent('1 of 1 delivered');
   });
 
-  it('a set the verify phase did NOT fully run says how many were never executed (F-7R2-015\'s lesson)', async () => {
-    const card = await landing([w6Campaign(W6_TEST_SET_UNVERIFIED)]);
-    expect(within(card).getByTestId('campaign-card-testset-unverified')).toHaveTextContent('5 never executed');
+  it("the PLAN opens the producing run (its Files view reads the run branch) — not the card's own door", async () => {
+    const navigate = vi.fn();
+    const card = await landing(w6Listing(), RUNS, navigate);
+    fireEvent.click(within(card).getByTestId('campaign-card-testset-plan'));
+    expect(navigate).toHaveBeenCalledWith(`/runs/${W6_RUN}`);
   });
 
-  it('a group (the narrowed-project fan) carries the set too', async () => {
-    const card = await landing([], [w6Group()]);
-    expect(card).toHaveAttribute('data-kind', 'group');
-    expect(within(card).getByTestId('campaign-card-testset')).toHaveTextContent('11 executed');
-    expect(within(card).getByTestId('campaign-card-workflow')).toHaveTextContent('qe-author-tests');
+  it("joins by LABEL too: a set tagged with the group's qe-tests-<repo> label lands on the card even when its run is not on the member list", async () => {
+    const group = w6Group(W6_LABEL, [{ runId: 'r-older', status: 'completed', delivery: 'none' }]);
+    const card = await landing(w6Listing([W6_TEST_SET], [], [group]), [makeView({ id: 'r-older', status: 'completed', workflow_id: 'qe-author-tests' })]);
+    expect(within(card).getByTestId('campaign-card-testset')).toHaveAttribute('data-run-id', W6_RUN);
   });
 
-  it('a pre-0.36 row (no test_set) renders NO counts — but the workflow chip still says qe-author-tests off the live run', async () => {
-    const card = await landing([w6Campaign(null)]);
+  it('an engine CAMPAIGN whose node run produced a set joins by run_id', async () => {
+    const card = await landing(w6Listing([W6_TEST_SET], [w6Campaign()], []));
+    expect(card).toHaveAttribute('data-kind', 'campaign');
+    expect(within(card).getByTestId('campaign-card-testset')).toHaveAttribute('data-run-id', W6_RUN);
+  });
+
+  it('a set belonging to no card renders nowhere — nothing is invented for it', async () => {
+    const stray = { ...W6_TEST_SET, id: 'testset-r-stray', run_id: 'r-stray', label: 'qe-tests-elsewhere' };
+    const card = await landing(w6Listing([stray, W6_TEST_SET]));
+    expect(within(card).getAllByTestId('campaign-card-testset').map((e) => e.getAttribute('data-run-id'))).toEqual([W6_RUN]);
+  });
+
+  it("a set the verify phase did NOT fully run says how many were never executed and is NOT verified — shown, never hidden (F-7R2-015's lesson)", async () => {
+    const card = await landing(w6Listing([W6_TEST_SET_UNVERIFIED]));
+    const set = within(card).getByTestId('campaign-card-testset');
+    expect(set).toHaveAttribute('data-verified', 'false');
+    expect(set).toHaveAttribute('data-not-executed', '5');
+    expect(within(set).getByTestId('campaign-card-testset-verified')).toHaveTextContent('not verified');
+    expect(within(set).getByTestId('campaign-card-testset-unverified')).toHaveTextContent('5 not executed');
+    expect(set).toHaveTextContent('11 produced · 6 executed · 6 passed · 0 failed · 5 not executed');
+    expect(within(set).queryByTestId('campaign-card-testset-pr')).toBeNull();
+  });
+
+  it('a deliverUrl out of PR shape is not linked — the one isPrUrl gate every PR claim takes', async () => {
+    const card = await landing(w6Listing([{ ...W6_TEST_SET, deliverUrl: 'javascript:alert(1)' }]));
+    expect(within(card).getByTestId('campaign-card-testset')).toBeInTheDocument();
+    expect(within(card).queryByTestId('campaign-card-testset-pr')).toBeNull();
+  });
+
+  it('the newest three sets per card render; older ones are counted, never silently dropped', async () => {
+    const sets = [0, 1, 2, 3, 4].map((i) => ({ ...W6_TEST_SET, id: `testset-r-${i}`, run_id: `r-${i}` }));
+    const group = w6Group(W6_LABEL, sets.map((t) => ({ runId: t.run_id, status: 'completed' as const, delivery: 'none' as const })));
+    const runs = sets.map((t) => makeView({ id: t.run_id, status: 'completed', workflow_id: 'qe-author-tests' }));
+    const card = await landing(w6Listing(sets, [], [group]), runs);
+    expect(within(card).getAllByTestId('campaign-card-testset').map((e) => e.getAttribute('data-run-id'))).toEqual(['r-0', 'r-1', 'r-2']);
+    expect(within(card).getByTestId('campaign-card-testset-more')).toHaveTextContent('+2 older sets');
+  });
+
+  it('a pre-0.36 daemon (no test_sets on the wire) renders NO counts — the workflow chip still says qe-author-tests off the live run', async () => {
+    const card = await landing(w6Listing(null));
     expect(within(card).queryByTestId('campaign-card-testset')).toBeNull();
     expect(within(card).getByTestId('campaign-card-workflow')).toHaveAttribute('data-workflow', 'qe-author-tests');
   });
 
-  it('with no live run known and no registration, neither chip nor counts render — absence stays absent', async () => {
+  it('a 0.36 daemon with nothing registered yet (test_sets: []) renders no counts either', async () => {
+    const card = await landing(w6Listing([]));
+    expect(within(card).queryByTestId('campaign-card-testset')).toBeNull();
+  });
+
+  it('with no live run known and no set, neither chip nor counts render — absence stays absent', async () => {
     // No live member run ⇒ the card is outside the recency window; it is one honest chip away.
-    listCampaigns.mockResolvedValue({ campaigns: [w6Campaign(null)], groups: [] });
+    listCampaigns.mockResolvedValue(w6Listing([], [w6Campaign()], []));
     render(<CampaignsPage runs={[]} navigate={() => {}} />);
     (await screen.findByTestId('campaigns-show-older')).click();
     const card = await screen.findByTestId('campaign-card');
@@ -113,8 +176,19 @@ describe('the card — the produced set with counts (F-7R2-014)', () => {
     expect(within(card).queryByTestId('campaign-card-workflow')).toBeNull();
   });
 
+  it("the Tests tile's context counts the sets once the wire carries them — and says nothing about sets on a pre-0.36 daemon", async () => {
+    await landing(w6Listing());
+    expect(screen.getByTestId('stat-campaigns')).toHaveAttribute('data-value', '1');
+    expect(screen.getByTestId('stat-campaigns')).toHaveTextContent('1 test set · 11 of 11 passed');
+    cleanup();
+    reset();
+    await landing(w6Listing(null));
+    expect(screen.getByTestId('stat-campaigns')).toHaveAttribute('data-value', '1');
+    expect(screen.getByTestId('stat-campaigns')).not.toHaveTextContent('test set');
+  });
+
   it('the header copy names the governed workflow and the "Add testing rules" verb says what it authors', async () => {
-    await landing([w6Campaign()]);
+    await landing(w6Listing());
     expect(screen.getByTestId('campaigns-header-copy')).toHaveTextContent('New test runs the governed qe-author-tests workflow: recon → author → verify (runs what it wrote) → review (a distinct judge) → deliver (the engine opens the PR)');
     const author = screen.getByTestId('testing-author-open');
     expect(author).toHaveTextContent('Add testing rules');

--- a/tests/CampaignsPage.testset.test.tsx
+++ b/tests/CampaignsPage.testset.test.tsx
@@ -136,7 +136,8 @@ describe('the card — the produced set off the top-level test_sets (F-7R2-014)'
     const tile = screen.getByTestId('stat-campaigns');
     expect(tile).toHaveAttribute('data-test-sets', '2');
     expect(tile).toHaveAttribute('data-test-sets-unattributed', '1');
-    expect(within(tile).getByTestId('stat-context')).toHaveTextContent('2 test sets · 22/22 passed · 1 unattributed');
+    expect(within(tile).getByTestId('stat-context')).toHaveTextContent('2 sets · 22/22 passed · 1 unattributed');
+    expect(within(tile).getByTestId('stat-context')).toHaveAttribute('title', expect.stringContaining('2 test sets · 22/22 passed · 1 unattributed'));
     expect(tile).toHaveAttribute('title', expect.stringContaining('tests/PLAN-stray.md'));
   });
 
@@ -144,7 +145,7 @@ describe('the card — the produced set off the top-level test_sets (F-7R2-014)'
     await landing(w6Listing([W6_TEST_SET], [], [w6Group()], 2));
     const tile = screen.getByTestId('stat-campaigns');
     expect(tile).toHaveAttribute('data-test-sets-malformed', '2');
-    expect(within(tile).getByTestId('stat-context')).toHaveTextContent('1 test set · 11/11 passed · 2 malformed');
+    expect(within(tile).getByTestId('stat-context')).toHaveTextContent('1 set · 11/11 passed · 2 malformed');
   });
 
   it("a set the verify phase did NOT fully run says how many were never executed and is NOT verified — shown, never hidden (F-7R2-015's lesson)", async () => {
@@ -184,7 +185,8 @@ describe('the card — the produced set off the top-level test_sets (F-7R2-014)'
     expect(within(card).queryByTestId('campaign-card-testset')).toBeNull();
     const tile = screen.getByTestId('stat-campaigns');
     expect(tile).toHaveAttribute('data-test-sets', '0');
-    expect(within(tile).getByTestId('stat-context')).toHaveTextContent(/^no test sets registered yet · 0 active now$/);
+    expect(within(tile).getByTestId('stat-context')).toHaveTextContent(/^no sets registered yet · 0 active now$/);
+    expect(within(tile).getByTestId('stat-context')).toHaveAttribute('title', 'no test sets registered yet · 0 active now');
   });
 
   it('with no live run known and no set, neither chip nor counts render — absence stays absent', async () => {
@@ -197,13 +199,13 @@ describe('the card — the produced set off the top-level test_sets (F-7R2-014)'
     expect(within(card).queryByTestId('campaign-card-workflow')).toBeNull();
   });
 
-  it("the Tests tile's context leads with the sets word (it must survive the tile's ellipsis — #266 F-1), carries the full text as its title, and says nothing about sets on a pre-0.36 daemon", async () => {
+  it("the Tests tile's context leads with the short sets word (it must clear the tile's ellipsis glyph at 1440px — #266 F-1/R2-1), carries the UNABRIDGED line as its title, and says nothing about sets on a pre-0.36 daemon", async () => {
     await landing(w6Listing());
     const tile = screen.getByTestId('stat-campaigns');
     expect(tile).toHaveAttribute('data-value', '1');
     expect(tile).toHaveAttribute('data-test-sets', '1');
     const ctx = within(tile).getByTestId('stat-context');
-    expect(ctx.textContent).toBe('1 test set · 11/11 passed · 0 active now');
+    expect(ctx.textContent).toBe('1 set · 11/11 passed · 0 active now');
     expect(ctx).toHaveAttribute('title', '1 test set · 11/11 passed · 0 active now');
     expect(ctx.textContent).not.toContain('ad-hoc');
     cleanup();
@@ -213,6 +215,7 @@ describe('the card — the produced set off the top-level test_sets (F-7R2-014)'
     expect(older).toHaveAttribute('data-value', '1');
     expect(older).toHaveAttribute('data-test-sets', 'absent');
     expect(within(older).getByTestId('stat-context').textContent).toBe('0 active now');
+    expect(within(older).getByTestId('stat-context')).toHaveAttribute('title', '0 active now');
   });
 
   it('the header copy names the governed workflow and the "Add testing rules" verb says what it authors', async () => {

--- a/tests/HomeBoard.command.test.tsx
+++ b/tests/HomeBoard.command.test.tsx
@@ -5,6 +5,7 @@ import type { Diagnostics } from '../src/api/diagnostics.js';
 import { useRunEventStore } from '../src/store/events.js';
 import { useRuntimeStore } from '../src/store/runtime.js';
 import { makeView } from './factories.js';
+import { W6_RUN, W6_TEST_SET, w6Group } from './fixtures/wave6.js';
 
 /**
  * The command center's analytics column (DES-HOME-COMMAND-CENTER §4–§5): the
@@ -19,6 +20,9 @@ let chats: Array<{ chatId: string; seats: string[]; idleSecs: number | null }> |
 let claims: GovernanceClaim[] | Error = [];
 let rules: unknown[] | Error = [];
 let campaignsAnswer: unknown[] | Error = [];
+/** The listing's label groups and 0.36 test sets (`null` = a pre-0.36 daemon), beside the campaigns. */
+let groupsAnswer: unknown[] = [];
+let testSetsAnswer: unknown[] | null = null;
 let scoreboardAnswer: unknown | Error = new Error('absent');
 let diagAnswer: Diagnostics | Error = new Error('absent');
 
@@ -43,7 +47,7 @@ vi.mock('../src/api/interactive.js', () => ({
 
 vi.mock('../src/api/campaigns.js', async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
-  listCampaigns: () => answer(campaignsAnswer).then((c) => ({ campaigns: c })),
+  listCampaigns: () => answer(campaignsAnswer).then((c) => ({ campaigns: c, groups: groupsAnswer, testSets: testSetsAnswer })),
 }));
 
 vi.mock('../src/api/wiki.js', async (importOriginal) => ({
@@ -161,6 +165,8 @@ describe('HomeBoard — the section doors', () => {
       { id: 'old-001', retired: true },
     ];
     campaignsAnswer = [];
+    groupsAnswer = [];
+    testSetsAnswer = null;
     scoreboardAnswer = {
       evidence: { per_rule: [{ rule_id: 'sec-001', denial_claims: 2, governs_evidence: 1 }] },
     };
@@ -193,6 +199,17 @@ describe('HomeBoard — the section doors', () => {
       expect(bySection.get('test')).toHaveAttribute('href', '/testing/campaigns');
       expect(bySection.get('evals')).toHaveAttribute('href', '/testing/evals');
       expect(bySection.get('steering')).toHaveAttribute('href', '/steering/dashboard');
+    });
+  });
+
+  it('the Test door counts label groups as tests (how 0.36.0 files a New test) and appends the registered sets once the wire carries them', async () => {
+    groupsAnswer = [w6Group()];
+    testSetsAnswer = [W6_TEST_SET];
+    await mountBoard([makeView({ id: W6_RUN, status: 'completed' })]);
+    await vi.waitFor(() => {
+      const doors = screen.getByTestId('home-section-doors');
+      const test = within(doors).getAllByTestId('section-door').find((d) => d.getAttribute('data-section') === 'test');
+      expect(test?.textContent).toContain('1 test · 1 test set');
     });
   });
 

--- a/tests/TestingLaunch.governed.test.tsx
+++ b/tests/TestingLaunch.governed.test.tsx
@@ -207,7 +207,8 @@ describe('the workflow is read off the daemon, never assumed', () => {
 
 describe('the governed launch — the wire, the link, the waiting line (F-7R2-011)', () => {
   it('an un-narrowed project rides POST /testing/author with projectId ALONE; the panel links the run, names the workflow + wire, shows the waiting line naming the run', async () => {
-    wire({ '/testing/author': { runId: 'r-gt-1', runIds: ['r-gt-1'], campaign: 'author-1', campaignRegistered: false, workflow: 'qe-author-tests' } });
+    // The 0.36.0 `TestingAuthorResponse`: no `campaign` field — the filing rides `runs[].label`.
+    wire({ '/testing/author': { runId: 'r-gt-1', runIds: ['r-gt-1'], campaignRegistered: false, workflow: 'qe-author-tests', runs: [{ runId: 'r-gt-1', repoRef: 'wicked-studio', label: 'qe-tests-wicked-studio' }] } });
     const user = userEvent.setup();
     const navigate = vi.fn();
     const p = panel('campaign', navigate);
@@ -228,7 +229,11 @@ describe('the governed launch — the wire, the link, the waiting line (F-7R2-01
     expect(within(p).getByTestId('testing-launch-launched-workflow')).toHaveTextContent('qe-author-tests');
     expect(within(p).getByTestId('testing-launch-route')).toHaveTextContent('via POST /testing/author');
     expect(within(p).getByTestId('testing-launch-launched')).toHaveAttribute('data-route', 'testing-author');
-    expect(within(p).getByTestId('testing-launch-fanout-label')).toHaveTextContent('author-1');
+    // #266 F-4: the label group already exists on the Test landing — say "filed under", not "appears when".
+    expect(within(p).getByTestId('testing-launch-filed-label')).toHaveTextContent('qe-tests-wicked-studio');
+    expect(within(p).getByTestId('testing-launch-route')).toHaveTextContent('filed under qe-tests-wicked-studio on the Test landing — the set fills in when the verify phase registers it');
+    expect(within(p).getByTestId('testing-launch-route')).not.toHaveTextContent('appears on the Test landing when');
+    expect(within(p).queryByTestId('testing-launch-fanout-label')).toBeNull();
   });
 
   it('/testing/author absent ⇒ the per-repo POST /runs fan carries `workflow`; /testing/recon is never sent one (0.36.0 declares no such key); the route line says so', async () => {

--- a/tests/TestingLaunch.governed.test.tsx
+++ b/tests/TestingLaunch.governed.test.tsx
@@ -231,20 +231,20 @@ describe('the governed launch — the wire, the link, the waiting line (F-7R2-01
     expect(within(p).getByTestId('testing-launch-fanout-label')).toHaveTextContent('author-1');
   });
 
-  it('/testing/author absent ⇒ /testing/recon carries `workflow`; the route line says so', async () => {
-    wire({ '/testing/recon': { runId: 'r-2', runIds: ['r-2'], campaign: 'recon-2', campaignRegistered: true } });
+  it('/testing/author absent ⇒ the per-repo POST /runs fan carries `workflow`; /testing/recon is never sent one (0.36.0 declares no such key); the route line says so', async () => {
+    wire({ '/runs': { runId: 'r-2' } });
     const user = userEvent.setup();
     const p = panel();
     await within(p).findByTestId('testing-launch-workflow');
     await attach(user, p, 'wicked-studio');
     await brief(user, p, 'B');
     await screen.findByTestId('testing-launch-waiting');
-    expect(posts().map(([path, body]) => [path, body['workflow']])).toEqual([['/testing/author', undefined], ['/testing/recon', 'qe-author-tests']]);
+    // The exact sequence — a `/testing/recon` call anywhere would fail this.
+    expect(posts().map(([path, body]) => [path, body['workflow']])).toEqual([['/testing/author', undefined], ['/runs', 'qe-author-tests']]);
     const route = within(p).getByTestId('testing-launch-route');
-    expect(route).toHaveTextContent('via POST /testing/recon (workflow)');
-    expect(route).toHaveTextContent('registered on the Test landing');
-    // A single run ALSO names its test label (F-7R2-011: the single-run answer used to render nothing).
-    expect(within(route).getByTestId('testing-launch-fanout-label')).toHaveTextContent('recon-2');
+    expect(route).toHaveTextContent('via POST /runs per repository');
+    expect(within(p).getByTestId('testing-launch-launched')).toHaveAttribute('data-route', 'runs-fan');
+    expect(within(p).getByTestId('testing-launch-fanout-run')).toHaveAttribute('data-run-id', 'r-2');
   });
 });
 

--- a/tests/campaignStats.testsets.test.ts
+++ b/tests/campaignStats.testsets.test.ts
@@ -82,14 +82,17 @@ describe('unattributedTestSets / testSetsWord — the tile says what no card can
     expect(unattributedTestSets(cards, [W6_TEST_SET])).toEqual([]);
     expect(unattributedTestSets([], [])).toEqual([]);
   });
-  it('the sets word leads with the count and the pass fraction, then the honest tails; a real zero is said', () => {
+  it('the sets word leads with the count and the pass fraction, then the honest tails; a real zero is said — the painted `lead` form is short, the `full` form for the hover title is unabridged (R2-1)', () => {
     const one = testSetTotals([W6_TEST_SET]);
-    expect(testSetsWord(one, 0, 0)).toBe('1 test set · 11/11 passed');
-    expect(testSetsWord(one, 1, 0)).toBe('1 test set · 11/11 passed · 1 unattributed');
-    expect(testSetsWord(one, 0, 2)).toBe('1 test set · 11/11 passed · 2 malformed');
-    expect(testSetsWord(testSetTotals([W6_TEST_SET, W6_TEST_SET_UNVERIFIED]), 1, 1)).toBe('2 test sets · 17/22 passed · 1 unattributed · 1 malformed');
-    expect(testSetsWord(testSetTotals([]), 0, 0)).toBe('no test sets registered yet');
+    expect(testSetsWord(one, 0, 0)).toBe('1 set · 11/11 passed');
+    expect(testSetsWord(one, 0, 0, 'full')).toBe('1 test set · 11/11 passed');
+    expect(testSetsWord(one, 1, 0)).toBe('1 set · 11/11 passed · 1 unattributed');
+    expect(testSetsWord(one, 0, 2)).toBe('1 set · 11/11 passed · 2 malformed');
+    expect(testSetsWord(testSetTotals([W6_TEST_SET, W6_TEST_SET_UNVERIFIED]), 1, 1)).toBe('2 sets · 17/22 passed · 1 unattributed · 1 malformed');
+    expect(testSetsWord(testSetTotals([W6_TEST_SET, W6_TEST_SET_UNVERIFIED]), 1, 1, 'full')).toBe('2 test sets · 17/22 passed · 1 unattributed · 1 malformed');
+    expect(testSetsWord(testSetTotals([]), 0, 0)).toBe('no sets registered yet');
+    expect(testSetsWord(testSetTotals([]), 0, 0, 'full')).toBe('no test sets registered yet');
     // Zero joinable sets but a malformed row: the row is said, not "nothing registered".
-    expect(testSetsWord(testSetTotals([]), 0, 1)).toBe('0 test sets · 0/0 passed · 1 malformed');
+    expect(testSetsWord(testSetTotals([]), 0, 1)).toBe('0 sets · 0/0 passed · 1 malformed');
   });
 });

--- a/tests/campaignStats.testsets.test.ts
+++ b/tests/campaignStats.testsets.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
-  campaignCards, joinTestSets, testDoorWord, testSetCountsWord, testSetPrHref, testSetTotals,
+  campaignCards, joinTestSets, testDoorWord, testSetCountsWord, testSetPrHref, testSetTotals, testSetsWord,
+  unattributedTestSets,
 } from '../src/board/campaignStats.js';
 import { attachedRun, makeCampaign, makeGroup } from './campaignFactories.js';
 import { W6_LABEL, W6_PR, W6_RUN, W6_TEST_SET, W6_TEST_SET_UNVERIFIED, w6Group } from './fixtures/wave6.js';
@@ -65,11 +66,30 @@ describe('testSetTotals / testSetCountsWord / testSetPrHref / testDoorWord', () 
     expect(testSetPrHref({ deliverUrl: 'javascript:alert(1)' })).toBeNull();
     expect(testSetPrHref({ deliverUrl: 'https://github.com/example/x/pull/new/branch' })).toBeNull();
   });
-  it('the Home door: campaigns + groups as "tests", the sets appended only when the wire carries them', () => {
+  it('the Home door: campaigns + groups as "tests"; the sets appended whenever the wire carries the list — a real zero says "0 test sets", absence (null) says nothing (#266 F-3)', () => {
     expect(testDoorWord({ campaigns: [], groups: [], testSets: null })).toBe('0 tests');
     expect(testDoorWord({ campaigns: [{}], groups: [{}], testSets: null })).toBe('2 tests');
-    expect(testDoorWord({ campaigns: [], groups: [{}], testSets: [] })).toBe('1 test');
+    expect(testDoorWord({ campaigns: [], groups: [{}], testSets: [] })).toBe('1 test · 0 test sets');
     expect(testDoorWord({ campaigns: [], groups: [{}], testSets: [W6_TEST_SET] })).toBe('1 test · 1 test set');
     expect(testDoorWord({ campaigns: [{}], testSets: [W6_TEST_SET, W6_TEST_SET_UNVERIFIED] })).toBe('1 test · 2 test sets');
+  });
+});
+
+describe('unattributedTestSets / testSetsWord — the tile says what no card can show (#266 F-1/F-2/F-3)', () => {
+  it('a set on no card is unattributed; sets carried by any card are not', () => {
+    const cards = campaignCards([], [w6Group()], new Map(), new Set(), [W6_TEST_SET, other]);
+    expect(unattributedTestSets(cards, [W6_TEST_SET, other]).map((t) => t.id)).toEqual(['testset-r-other']);
+    expect(unattributedTestSets(cards, [W6_TEST_SET])).toEqual([]);
+    expect(unattributedTestSets([], [])).toEqual([]);
+  });
+  it('the sets word leads with the count and the pass fraction, then the honest tails; a real zero is said', () => {
+    const one = testSetTotals([W6_TEST_SET]);
+    expect(testSetsWord(one, 0, 0)).toBe('1 test set · 11/11 passed');
+    expect(testSetsWord(one, 1, 0)).toBe('1 test set · 11/11 passed · 1 unattributed');
+    expect(testSetsWord(one, 0, 2)).toBe('1 test set · 11/11 passed · 2 malformed');
+    expect(testSetsWord(testSetTotals([W6_TEST_SET, W6_TEST_SET_UNVERIFIED]), 1, 1)).toBe('2 test sets · 17/22 passed · 1 unattributed · 1 malformed');
+    expect(testSetsWord(testSetTotals([]), 0, 0)).toBe('no test sets registered yet');
+    // Zero joinable sets but a malformed row: the row is said, not "nothing registered".
+    expect(testSetsWord(testSetTotals([]), 0, 1)).toBe('0 test sets · 0/0 passed · 1 malformed');
   });
 });

--- a/tests/campaignStats.testsets.test.ts
+++ b/tests/campaignStats.testsets.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import {
+  campaignCards, joinTestSets, testDoorWord, testSetCountsWord, testSetPrHref, testSetTotals,
+} from '../src/board/campaignStats.js';
+import { attachedRun, makeCampaign, makeGroup } from './campaignFactories.js';
+import { W6_LABEL, W6_PR, W6_RUN, W6_TEST_SET, W6_TEST_SET_UNVERIFIED, w6Group } from './fixtures/wave6.js';
+
+/**
+ * The produced test sets on the campaign folds (wave 6, api-types 0.36.0 — F-7R2-014): the
+ * top-level `CampaignsListResponse.test_sets` joined onto a card by `run_id` (member runs) and, for
+ * a label group, by the `qe-tests-<repo>` `label`; the pure totals the Tests tile and the Home door
+ * speak; the one counts spelling; the `isPrUrl` gate on `deliverUrl`.
+ */
+
+const other = { ...W6_TEST_SET, id: 'testset-r-other', run_id: 'r-other', label: 'qe-tests-wicked-crew' };
+
+describe('joinTestSets — by run_id, and by label for a group', () => {
+  it('keeps the sets whose run is a member, in wire order, deduped by id', () => {
+    const dup = { ...W6_TEST_SET };
+    expect(joinTestSets([W6_RUN, 'r-x'], null, [other, W6_TEST_SET, dup]).map((t) => t.id)).toEqual([`testset-${W6_RUN}`]);
+  });
+  it('a group also claims the sets tagged with its label, even when the run is not on its member list', () => {
+    expect(joinTestSets([], W6_LABEL, [other, W6_TEST_SET]).map((t) => t.run_id)).toEqual([W6_RUN]);
+    expect(joinTestSets([], 'qe-tests-elsewhere', [other, W6_TEST_SET])).toEqual([]);
+  });
+  it('a campaign (no label) never claims by label', () => {
+    expect(joinTestSets([], null, [W6_TEST_SET])).toEqual([]);
+  });
+});
+
+describe('campaignCards — every card carries its joined sets; a pre-0.36 daemon passes none', () => {
+  it('campaign by node run id, group by member run id / label; unrelated sets land nowhere', () => {
+    const cards = campaignCards(
+      [makeCampaign('c', [{ status: 'completed', runId: 'r-other' }])],
+      [w6Group(), makeGroup('plain', [attachedRun('r-plain')])],
+      new Map(),
+      new Set(),
+      [W6_TEST_SET, other],
+    );
+    const byId = new Map(cards.map((c) => [c.id, c]));
+    expect(byId.get('c')!.testSets.map((t) => t.run_id)).toEqual(['r-other']);
+    expect(byId.get(W6_LABEL)!.testSets.map((t) => t.run_id)).toEqual([W6_RUN]);
+    expect(byId.get('plain')!.testSets).toEqual([]);
+  });
+  it('the default (no sets on the wire) is an empty list on every card — never a fabricated set', () => {
+    const cards = campaignCards([], [w6Group()], new Map(), new Set());
+    expect(cards[0]!.testSets).toEqual([]);
+  });
+});
+
+describe('testSetTotals / testSetCountsWord / testSetPrHref / testDoorWord', () => {
+  it('sums the wire counts and counts the verified sets', () => {
+    expect(testSetTotals([W6_TEST_SET, W6_TEST_SET_UNVERIFIED])).toEqual({
+      sets: 2, verified: 1, produced: 22, executed: 17, passed: 17, failed: 0, notExecuted: 5,
+    });
+    expect(testSetTotals([])).toEqual({ sets: 0, verified: 0, produced: 0, executed: 0, passed: 0, failed: 0, notExecuted: 0 });
+  });
+  it('the four counts, one spelling', () => {
+    expect(testSetCountsWord(W6_TEST_SET)).toBe('11 produced · 11 executed · 11 passed · 0 failed');
+    expect(testSetCountsWord(W6_TEST_SET_UNVERIFIED)).toBe('11 produced · 6 executed · 6 passed · 0 failed');
+  });
+  it('the PR href passes the one isPrUrl gate; absent or out of shape is null', () => {
+    expect(testSetPrHref(W6_TEST_SET)).toBe(W6_PR);
+    expect(testSetPrHref(W6_TEST_SET_UNVERIFIED)).toBeNull();
+    expect(testSetPrHref({ deliverUrl: 'javascript:alert(1)' })).toBeNull();
+    expect(testSetPrHref({ deliverUrl: 'https://github.com/example/x/pull/new/branch' })).toBeNull();
+  });
+  it('the Home door: campaigns + groups as "tests", the sets appended only when the wire carries them', () => {
+    expect(testDoorWord({ campaigns: [], groups: [], testSets: null })).toBe('0 tests');
+    expect(testDoorWord({ campaigns: [{}], groups: [{}], testSets: null })).toBe('2 tests');
+    expect(testDoorWord({ campaigns: [], groups: [{}], testSets: [] })).toBe('1 test');
+    expect(testDoorWord({ campaigns: [], groups: [{}], testSets: [W6_TEST_SET] })).toBe('1 test · 1 test set');
+    expect(testDoorWord({ campaigns: [{}], testSets: [W6_TEST_SET, W6_TEST_SET_UNVERIFIED] })).toBe('1 test · 2 test sets');
+  });
+});

--- a/tests/campaigns.store.test.ts
+++ b/tests/campaigns.store.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { CoreEvent } from '../src/api/types.js';
+import { W6_TEST_SET } from './fixtures/wave6.js';
 
 /**
  * The campaign store (TH-14): the §1.5 support probe's three states and the Campaign* frame
@@ -24,7 +25,7 @@ const frame = (type: string, fields: Record<string, unknown> = {}): CoreEvent =>
 
 beforeEach(() => {
   listCampaigns.mockReset();
-  useCampaignsStore.setState({ support: 'unknown', campaigns: [], groups: [], live: {} });
+  useCampaignsStore.setState({ support: 'unknown', campaigns: [], groups: [], testSets: null, live: {} });
 });
 afterEach(() => vi.restoreAllMocks());
 
@@ -39,6 +40,19 @@ describe('the §1.5 support probe — three states, never a boolean', () => {
     expect(useCampaignsStore.getState().support).toBe('supported');
     expect(useCampaignsStore.getState().campaigns).toEqual([]);
     expect(useCampaignsStore.getState().groups).toEqual([]);
+    expect(useCampaignsStore.getState().testSets).toBeNull();
+  });
+
+  it("holds a 0.36 daemon's test sets as served; a listing without them (an older daemon — or a partial mock) holds null, never []", async () => {
+    listCampaigns.mockResolvedValue({ campaigns: [], groups: [], testSets: [W6_TEST_SET] });
+    await useCampaignsStore.getState().refresh();
+    expect(useCampaignsStore.getState().testSets).toEqual([W6_TEST_SET]);
+    listCampaigns.mockResolvedValue({ campaigns: [], groups: [], testSets: [] });
+    await useCampaignsStore.getState().refresh();
+    expect(useCampaignsStore.getState().testSets).toEqual([]);
+    listCampaigns.mockResolvedValue({ campaigns: [], groups: [] });
+    await useCampaignsStore.getState().refresh();
+    expect(useCampaignsStore.getState().testSets).toBeNull();
   });
 
   it('404 = this daemon predates campaigns → unsupported', async () => {

--- a/tests/campaigns.store.test.ts
+++ b/tests/campaigns.store.test.ts
@@ -25,7 +25,7 @@ const frame = (type: string, fields: Record<string, unknown> = {}): CoreEvent =>
 
 beforeEach(() => {
   listCampaigns.mockReset();
-  useCampaignsStore.setState({ support: 'unknown', campaigns: [], groups: [], testSets: null, live: {} });
+  useCampaignsStore.setState({ support: 'unknown', campaigns: [], groups: [], testSets: null, malformedTestSets: 0, live: {} });
 });
 afterEach(() => vi.restoreAllMocks());
 
@@ -53,6 +53,15 @@ describe('the §1.5 support probe — three states, never a boolean', () => {
     listCampaigns.mockResolvedValue({ campaigns: [], groups: [] });
     await useCampaignsStore.getState().refresh();
     expect(useCampaignsStore.getState().testSets).toBeNull();
+  });
+
+  it('holds the malformed-row count beside the sets; a listing without it (partial mock) reads 0', async () => {
+    listCampaigns.mockResolvedValue({ campaigns: [], groups: [], testSets: [W6_TEST_SET], malformedTestSets: 2 });
+    await useCampaignsStore.getState().refresh();
+    expect(useCampaignsStore.getState().malformedTestSets).toBe(2);
+    listCampaigns.mockResolvedValue({ campaigns: [], groups: [], testSets: [] });
+    await useCampaignsStore.getState().refresh();
+    expect(useCampaignsStore.getState().malformedTestSets).toBe(0);
   });
 
   it('404 = this daemon predates campaigns → unsupported', async () => {

--- a/tests/fixtures/wave6.ts
+++ b/tests/fixtures/wave6.ts
@@ -1,16 +1,17 @@
-import type { Campaign, RunGroup } from '../../src/api/campaigns.js';
-import type { CoreEvent, GateEvaluatedEvent, UnitDistributedEvent, WorkflowDef } from '../../src/api/types.js';
-import type { TestSetRegistration, WorkerToolCallDeniedEvent } from '../../src/api/wave6-wire.js';
+import type { AttachedRunView, Campaign, CampaignsListing, RunGroup } from '../../src/api/campaigns.js';
+import type { CoreEvent, GateEvaluatedEvent, TestSet, UnitDistributedEvent, WorkflowDef } from '../../src/api/types.js';
+import type { WorkerToolCallDeniedEvent } from '../../src/api/wave6-wire.js';
 import { makeUnit } from '../factories.js';
 
 /**
  * The wave-6 wire (api-types 0.36.0 — the governed testing journey) as SYNTHETIC frames in the
  * engine's `event_to_json` spelling: camelCase, every key present, `null` never absent. Not a
  * recording — every event literal is typed `satisfies` the PUBLISHED 0.36.0 declaration (through
- * `./types.js` / the byte-pinned `wave6-wire.ts` regions) so a drift fails `tsc`. The campaign rows'
- * `test_set` is studio's provisional row-level join (wire gap 1 in `wave6-wire.ts`: 0.36.0 serves
- * `CampaignsListResponse.test_sets` instead). Privacy-scrubbed by construction: synthetic ids, no
- * host paths, no operator text.
+ * `./types.js` / the byte-pinned `wave6-wire.ts` regions) so a drift fails `tsc`. The produced set is
+ * the TOP-LEVEL `CampaignsListResponse.test_sets` row 0.36.0 declares (snake_case, `run_id`-keyed,
+ * tagged with the `qe-tests-<repo>` label the daemon files an authoring run under) — there is no
+ * row-level join on a campaign or a group. Privacy-scrubbed by construction: synthetic ids, no host
+ * paths, no operator text.
  */
 
 export const W6_RUN = 'r-gt-done';
@@ -167,25 +168,57 @@ export const W6_EVENTS: CoreEvent[] = [
   { type: 'sessionCompleted', session: W6_RUN },
 ];
 
-/** The produced test set the completed run registered on the campaigns surface. */
-export const W6_TEST_SET: TestSetRegistration = {
-  runId: W6_RUN,
-  workflow: 'qe-author-tests',
-  files: ['tests/run-lifecycle.test.tsx', 'e2e/run_lifecycle_test.py'],
-  counts: { files: 2, tests: 11, executed: 11, passed: 11, failed: 0 },
+/** The label group `POST /testing/author` files a wicked-studio run under (`TestingAuthorRun.label`). */
+export const W6_LABEL = 'qe-tests-wicked-studio';
+export const W6_PR = 'https://github.com/example/wicked-studio/pull/999';
+
+const W6_SET_BASE = {
+  id: `testset-${W6_RUN}`,
+  run_id: W6_RUN,
+  workflow_id: 'qe-author-tests',
+  label: W6_LABEL,
+  repo_ref: 'wicked-studio',
+  repo_name: 'wicked-studio',
+  registered_at: 1_757_500_000_000,
+  run_status: 'completed',
+  verify_status: 'done',
+  verified: true,
+  files: [
+    { path: 'tests/run-lifecycle.test.tsx', harness: 'vitest', status: 'passed' },
+    { path: 'e2e/run_lifecycle_test.py', harness: 'playwright-python', status: 'passed' },
+  ],
+  produced: 11,
+  executed: 11,
+  passed: 11,
+  failed: 0,
+  not_executed: 0,
   plan: 'tests/PLAN-run-lifecycle.md',
-  prUrl: 'https://github.com/example/wicked-studio/pull/999',
-};
+  harnesses: ['vitest', 'playwright-python'],
+} satisfies Omit<TestSet, 'deliverUrl'>;
 
-/** A registration whose verify phase did NOT run every test — the card must say so. */
-export const W6_TEST_SET_UNVERIFIED: TestSetRegistration = {
-  ...W6_TEST_SET,
-  counts: { files: 2, tests: 11, executed: 6, passed: 6, failed: 0 },
-  prUrl: null,
-};
+/** The produced test set the completed run registered — `CampaignsListResponse.test_sets[0]` as
+ *  0.36.0 declares it: verified, every test executed and green, the PLAN, the engine's PR. */
+export const W6_TEST_SET = { ...W6_SET_BASE, deliverUrl: W6_PR } satisfies TestSet;
 
-/** The campaign row a single-repo New test registers, as `GET /campaigns` serves it. */
-export function w6Campaign(testSet: TestSetRegistration | null = W6_TEST_SET, over: Partial<Campaign> = {}): Campaign {
+/** A set whose verify phase did NOT run every test — registered anyway (deny-dominates: a red set is
+ *  shown, never hidden), `verified: false`, no PR because the deliver phase never ran. */
+export const W6_TEST_SET_UNVERIFIED = {
+  ...W6_SET_BASE,
+  run_status: 'failed',
+  verify_status: 'rejected',
+  verified: false,
+  files: [
+    { path: 'tests/run-lifecycle.test.tsx', harness: 'vitest', status: 'passed' },
+    { path: 'e2e/run_lifecycle_test.py', harness: 'playwright-python', status: 'not-executed' },
+  ],
+  executed: 6,
+  passed: 6,
+  not_executed: 5,
+} satisfies TestSet;
+
+/** An engine campaign whose node run is the producing run — a multi-repo recon's shape; the set
+ *  joins onto it by `run_id`. Carries NO `test_set` row: 0.36.0 declares none. */
+export function w6Campaign(over: Partial<Campaign> = {}): Campaign {
   return {
     id: 'qe-tests-wicked-studio',
     def_id: 'qe-tests-wicked-studio',
@@ -194,18 +227,27 @@ export function w6Campaign(testSet: TestSetRegistration | null = W6_TEST_SET, ov
     node_status: { author: 'completed' },
     node_run_id: { author: W6_RUN },
     node_attempt: { author: 0 },
-    node_delivery: { author: { delivery: 'delivered', deliverUrl: 'https://github.com/example/wicked-studio/pull/999' } },
+    node_delivery: { author: { delivery: 'delivered', deliverUrl: W6_PR } },
     attached_runs: [],
-    test_set: testSet,
     ...over,
   };
 }
 
-/** The ad-hoc group a narrowed-project fan renders as, with the set registered by one member. */
-export function w6Group(testSet: TestSetRegistration | null = W6_TEST_SET): RunGroup {
-  return {
-    label: 'test-m1abc-xyz12345',
-    runs: [{ runId: W6_RUN, status: 'completed', delivery: 'delivered', deliverUrl: 'https://github.com/example/wicked-studio/pull/999' }],
-    test_set: testSet,
-  };
+/** The label group a New test renders as on `GET /campaigns` — how 0.36.0 files an authoring run
+ *  (`campaignRegistered: false`, one `RunGroup` per repo under `qe-tests-<repo>`). */
+export function w6Group(
+  label: string = W6_LABEL,
+  runs: AttachedRunView[] = [{ runId: W6_RUN, status: 'completed', delivery: 'delivered', deliverUrl: W6_PR }],
+): RunGroup {
+  return { label, runs };
+}
+
+/** The normalized listing `listCampaigns()` answers (what the suites mock): `testSets: null` is the
+ *  pre-0.36 daemon — the sets ABSENT, not empty. */
+export function w6Listing(
+  testSets: TestSet[] | null = [W6_TEST_SET],
+  campaigns: Campaign[] = [],
+  groups: RunGroup[] = [w6Group()],
+): CampaignsListing {
+  return { campaigns, groups, testSets };
 }

--- a/tests/fixtures/wave6.ts
+++ b/tests/fixtures/wave6.ts
@@ -248,6 +248,8 @@ export function w6Listing(
   testSets: TestSet[] | null = [W6_TEST_SET],
   campaigns: Campaign[] = [],
   groups: RunGroup[] = [w6Group()],
+  /** `test_sets` rows the daemon served without a `run_id` (#266 F-2). */
+  malformedTestSets = 0,
 ): CampaignsListing {
-  return { campaigns, groups, testSets };
+  return { campaigns, groups, testSets, malformedTestSets };
 }

--- a/tests/testingGoverned.wire.test.ts
+++ b/tests/testingGoverned.wire.test.ts
@@ -77,10 +77,11 @@ describe('the pure plan — effectiveRepos / isNarrowedProject / mintGroupLabel'
 
 describe('the ladder — each step only when the previous wire is ABSENT', () => {
   it('1. the workflow is listed ⇒ POST /testing/author with the pinned body; the answer names the route and echoes the workflow', async () => {
-    wire({ '/testing/author': { runId: 'r-1', runIds: ['r-1'], campaign: 'author-x', campaignRegistered: false, workflow: 'qe-author-tests' } });
+    wire({ '/testing/author': { runId: 'r-1', runIds: ['r-1'], campaign: 'author-x', campaignRegistered: false, workflow: 'qe-author-tests', runs: [{ runId: 'r-1', repoRef: 'wicked-studio', label: 'qe-tests-wicked-studio' }, { runId: 'r-1', repoRef: 'wicked-studio', label: 'qe-tests-wicked-studio' }, { label: '' }] } });
     const r = await launchGovernedTest({ ...base, projectId: 'proj-a', explicit: ['wicked-studio'] });
     expect(calls()).toEqual([['/testing/author', { problem: base.problem, projectId: 'proj-a', repoRefs: ['wicked-studio'] }]]);
-    expect(r).toMatchObject({ route: 'testing-author', workflow: 'qe-author-tests', runIds: ['r-1'], runId: 'r-1', campaign: 'author-x', campaignRegistered: false });
+    // `labels` = the filed `runs[].label`s, unique, empty labels dropped (#266 F-4).
+    expect(r).toMatchObject({ route: 'testing-author', workflow: 'qe-author-tests', runIds: ['r-1'], runId: 'r-1', campaign: 'author-x', campaignRegistered: false, labels: ['qe-tests-wicked-studio'] });
   });
 
   it('2. /testing/author absent ⇒ straight to the per-repo POST /runs fan — /testing/recon is never sent a `workflow` key (0.36.0 declares none)', async () => {
@@ -90,7 +91,7 @@ describe('the ladder — each step only when the previous wire is ABSENT', () =>
       ['/testing/author', { problem: base.problem, repoRefs: ['wicked-studio'] }],
       ['/runs', { problem: base.problem, humanConfirm: INTAKE_GATE, workflow: 'qe-author-tests', repoRef: 'wicked-studio' }],
     ]);
-    expect(r).toMatchObject({ route: 'runs-fan', workflow: 'qe-author-tests', runIds: ['r-2'], runId: 'r-2', campaignRegistered: false });
+    expect(r).toMatchObject({ route: 'runs-fan', workflow: 'qe-author-tests', runIds: ['r-2'], runId: 'r-2', campaignRegistered: false, labels: [] });
   });
 
   it('3. the fan: one POST /runs per resolved repo, workflow + intake gate on each, projectId filing, a shared groupLabel for ≥ 2', async () => {
@@ -103,7 +104,7 @@ describe('the ladder — each step only when the previous wire is ABSENT', () =>
       ['/runs', { problem: base.problem, humanConfirm: INTAKE_GATE, workflow: 'qe-author-tests', repoRef: 'wicked-studio', projectId: 'proj-a', groupLabel: base.groupLabel }],
       ['/runs', { problem: base.problem, humanConfirm: INTAKE_GATE, workflow: 'qe-author-tests', repoRef: 'wicked-crew', projectId: 'proj-a', groupLabel: base.groupLabel }],
     ]);
-    expect(r).toMatchObject({ route: 'runs-fan', workflow: 'qe-author-tests', runIds: ['r-1', 'r-2'], runId: 'r-1', campaign: base.groupLabel, campaignRegistered: false });
+    expect(r).toMatchObject({ route: 'runs-fan', workflow: 'qe-author-tests', runIds: ['r-1', 'r-2'], runId: 'r-1', campaign: base.groupLabel, campaignRegistered: false, labels: [] });
   });
 
   it('3b. a ONE-repo fan sends no groupLabel and answers no campaign — nothing is fabricated', async () => {
@@ -124,7 +125,7 @@ describe('the ladder — each step only when the previous wire is ABSENT', () =>
     wire({ '/testing/recon': { runId: 'r-p', runIds: ['r-p'], campaign: 'recon-z', campaignRegistered: false } });
     const r = await launchGovernedTest({ ...base, workflow: null, projectId: 'proj-a', explicit: ['wicked-studio'] });
     expect(calls()).toEqual([['/testing/recon', { problem: base.problem, projectId: 'proj-a', repoRefs: ['wicked-studio'] }]]);
-    expect(r).toMatchObject({ route: 'testing-recon-plain', workflow: null, runIds: ['r-p'] });
+    expect(r).toMatchObject({ route: 'testing-recon-plain', workflow: null, runIds: ['r-p'], labels: [] });
     expect(apiFetch.mock.calls.some(([p]) => p === '/testing/author')).toBe(false);
   });
 });

--- a/tests/testingGoverned.wire.test.ts
+++ b/tests/testingGoverned.wire.test.ts
@@ -3,10 +3,12 @@ import { ApiError } from '../src/api/errors.js';
 
 /**
  * The GOVERNED test launch chain (wave 6 — F-075 / F-7R2-003 / F-076 / F-7R2-010), below the
- * panel: `launchGovernedTest` plans the scope and walks the wire ladder — `/testing/author` →
- * `/testing/recon` + `workflow` → the per-repo `POST /runs` fan → today's plain recon — taking a
- * step ONLY when the previous wire is ABSENT (a bare unknown-route 404, or a strict schema naming
- * the additive key unrecognized). Every NAMED refusal is rethrown untouched. A NARROWED project
+ * panel: `launchGovernedTest` plans the scope and walks the wire ladder — `/testing/author` → the
+ * per-repo `POST /runs` fan → today's plain recon — taking a step ONLY when the previous wire is
+ * ABSENT (a bare unknown-route 404). There is NO `/testing/recon` + `workflow` rung: 0.36.0's
+ * `TestingReconBody` declares no such key and the workflow shipped together with the route, so
+ * `/testing/recon` only ever receives the pinned body. Every NAMED refusal is rethrown untouched.
+ * A NARROWED project
  * (members dropped) never touches the pinned recon body: its `projectId` unions the dropped members
  * back in, so the fan sends each remaining repo explicitly and keeps `projectId` for FILING.
  */
@@ -15,12 +17,13 @@ const apiFetch = vi.fn();
 vi.mock('../src/api/client.js', () => ({ apiFetch: (...a: unknown[]) => apiFetch(...a) }));
 
 const {
-  effectiveRepos, INTAKE_GATE, isNarrowedProject, isUnrecognizedKey, launchGovernedTest, mintGroupLabel,
+  effectiveRepos, INTAKE_GATE, isNarrowedProject, launchGovernedTest, mintGroupLabel,
 } = await import('../src/api/testing.js');
 const { QE_AUTHOR_TESTS_WORKFLOW_ID } = await import('../src/api/wave6-wire.js');
 
 const ROUTE_ABSENT = new ApiError(404, 'Not Found');
-const STRICT_WORKFLOW = new ApiError(400, "Invalid recon body: unrecognized key 'workflow' — the body accepts problem, projectId, repoRefs, ungated");
+/** The recon route must never be reached with a `workflow` key — the fixture makes any call loud. */
+const RECON_UNTOUCHED = new Error('must not be called');
 
 /** Every call, in order, as `[path, parsed body]`. */
 const calls = (): Array<[string, Record<string, unknown>]> =>
@@ -50,7 +53,7 @@ const base = {
 // `beforeEach` as a cleanup hook — it would call `apiFetch()` after every test.
 beforeEach(() => { apiFetch.mockReset(); });
 
-describe('the pure plan — effectiveRepos / isNarrowedProject / isUnrecognizedKey / mintGroupLabel', () => {
+describe('the pure plan — effectiveRepos / isNarrowedProject / mintGroupLabel', () => {
   it('explicit ∪ (project members − dropped), explicit first, deduped, order kept', () => {
     expect(effectiveRepos({ projectId: 'p', projectRepos: ['a', 'b', 'c'], excluded: ['b'], explicit: ['c', 'z'] })).toEqual(['c', 'z', 'a']);
     expect(effectiveRepos({ projectId: null, projectRepos: ['a', 'b'], excluded: [], explicit: ['z'] })).toEqual(['z']); // no project ⇒ members do not count
@@ -61,14 +64,6 @@ describe('the pure plan — effectiveRepos / isNarrowedProject / isUnrecognizedK
     expect(isNarrowedProject({ projectId: 'p', excluded: ['a'] })).toBe(true);
     expect(isNarrowedProject({ projectId: 'p', excluded: [] })).toBe(false);
     expect(isNarrowedProject({ projectId: null, excluded: ['a'] })).toBe(false);
-  });
-
-  it("isUnrecognizedKey: a 400 whose wire names the key as unrecognized — nothing else", () => {
-    expect(isUnrecognizedKey(STRICT_WORKFLOW, 'workflow')).toBe(true);
-    expect(isUnrecognizedKey(new ApiError(400, "unrecognized key 'projectId'"), 'workflow')).toBe(false);
-    expect(isUnrecognizedKey(new ApiError(400, 'repoRefs must name at least one registered repo'), 'workflow')).toBe(false);
-    expect(isUnrecognizedKey(new ApiError(404, "unrecognized key 'workflow'"), 'workflow')).toBe(false);
-    expect(isUnrecognizedKey(new Error("unrecognized key 'workflow'"), 'workflow')).toBe(false);
   });
 
   it('mintGroupLabel: `test-<base36 clock>-<rand>`, deterministic under injected inputs, within the wire\'s 1–200 chars', () => {
@@ -88,24 +83,23 @@ describe('the ladder — each step only when the previous wire is ABSENT', () =>
     expect(r).toMatchObject({ route: 'testing-author', workflow: 'qe-author-tests', runIds: ['r-1'], runId: 'r-1', campaign: 'author-x', campaignRegistered: false });
   });
 
-  it('2. /testing/author absent ⇒ POST /testing/recon with the additive `workflow` key', async () => {
-    wire({ '/testing/recon': { runId: 'r-2', runIds: ['r-2'], campaign: 'recon-y', campaignRegistered: true } });
+  it('2. /testing/author absent ⇒ straight to the per-repo POST /runs fan — /testing/recon is never sent a `workflow` key (0.36.0 declares none)', async () => {
+    wire({ '/runs': { runId: 'r-2' }, '/testing/recon': RECON_UNTOUCHED });
     const r = await launchGovernedTest({ ...base, explicit: ['wicked-studio'] });
     expect(calls()).toEqual([
       ['/testing/author', { problem: base.problem, repoRefs: ['wicked-studio'] }],
-      ['/testing/recon', { problem: base.problem, repoRefs: ['wicked-studio'], workflow: 'qe-author-tests' }],
+      ['/runs', { problem: base.problem, humanConfirm: INTAKE_GATE, workflow: 'qe-author-tests', repoRef: 'wicked-studio' }],
     ]);
-    expect(r).toMatchObject({ route: 'testing-recon-workflow', workflow: 'qe-author-tests', campaignRegistered: true });
+    expect(r).toMatchObject({ route: 'runs-fan', workflow: 'qe-author-tests', runIds: ['r-2'], runId: 'r-2', campaignRegistered: false });
   });
 
-  it('3. the recon schema refuses `workflow` as unrecognized ⇒ one POST /runs per resolved repo, workflow + intake gate on each, projectId filing, a shared groupLabel for ≥ 2', async () => {
+  it('3. the fan: one POST /runs per resolved repo, workflow + intake gate on each, projectId filing, a shared groupLabel for ≥ 2', async () => {
     let n = 0;
-    wire({ '/testing/recon': STRICT_WORKFLOW, '/runs': () => ({ runId: `r-${++n}` }) });
+    wire({ '/testing/recon': RECON_UNTOUCHED, '/runs': () => ({ runId: `r-${++n}` }) });
     const r = await launchGovernedTest({ ...base, projectId: 'proj-a', projectRepos: ['wicked-studio', 'wicked-crew'], explicit: [] });
     const c = calls();
     expect(c[0]![0]).toBe('/testing/author');
-    expect(c[1]![0]).toBe('/testing/recon');
-    expect(c.slice(2)).toEqual([
+    expect(c.slice(1)).toEqual([
       ['/runs', { problem: base.problem, humanConfirm: INTAKE_GATE, workflow: 'qe-author-tests', repoRef: 'wicked-studio', projectId: 'proj-a', groupLabel: base.groupLabel }],
       ['/runs', { problem: base.problem, humanConfirm: INTAKE_GATE, workflow: 'qe-author-tests', repoRef: 'wicked-crew', projectId: 'proj-a', groupLabel: base.groupLabel }],
     ]);
@@ -113,7 +107,7 @@ describe('the ladder — each step only when the previous wire is ABSENT', () =>
   });
 
   it('3b. a ONE-repo fan sends no groupLabel and answers no campaign — nothing is fabricated', async () => {
-    wire({ '/testing/recon': STRICT_WORKFLOW, '/runs': { runId: 'r-solo' } });
+    wire({ '/testing/recon': RECON_UNTOUCHED, '/runs': { runId: 'r-solo' } });
     const r = await launchGovernedTest({ ...base, explicit: ['wicked-studio'] });
     expect(calls().at(-1)).toEqual(['/runs', { problem: base.problem, humanConfirm: INTAKE_GATE, workflow: 'qe-author-tests', repoRef: 'wicked-studio' }]);
     expect(r.campaign).toBeUndefined();
@@ -121,7 +115,7 @@ describe('the ladder — each step only when the previous wire is ABSENT', () =>
   });
 
   it('3c. an UNSCOPED fan is one repo-less POST /runs — the daemon decides what that means for the workflow', async () => {
-    wire({ '/testing/recon': STRICT_WORKFLOW, '/runs': { runId: 'r-un' } });
+    wire({ '/testing/recon': RECON_UNTOUCHED, '/runs': { runId: 'r-un' } });
     await launchGovernedTest({ ...base });
     expect(calls().at(-1)).toEqual(['/runs', { problem: base.problem, humanConfirm: INTAKE_GATE, workflow: 'qe-author-tests' }]);
   });
@@ -223,11 +217,11 @@ describe('the NEGATIVE guarantee — a named refusal is an answer, never a fallb
     expect(calls().map(([p]) => p)).toEqual(['/testing/author']);
   });
 
-  it('/testing/recon (with workflow) answers a NAMED 400 that is not about `workflow` ⇒ rethrown, no fan', async () => {
+  it("the fan's POST /runs answers a NAMED 400 ⇒ rethrown untouched; /testing/recon is never a fallback for the governed launch", async () => {
     const err = new ApiError(400, "unrecognized key 'projectId'");
-    wire({ '/testing/recon': err });
+    wire({ '/runs': err, '/testing/recon': RECON_UNTOUCHED });
     await expect(launchGovernedTest({ ...base, explicit: ['wicked-studio'] })).rejects.toBe(err);
-    expect(calls().map(([p]) => p)).toEqual(['/testing/author', '/testing/recon']);
+    expect(calls().map(([p]) => p)).toEqual(['/testing/author', '/runs']);
   });
 
   it('a 201 with no run id is not disguised: runIds is empty and the panel says so', async () => {

--- a/tests/wave6Wire.test.ts
+++ b/tests/wave6Wire.test.ts
@@ -7,9 +7,11 @@
  * version, and every wave-6 declaration studio codes against lives INSIDE a region (a trivial region
  * beside a hand-written wave-6 block does not satisfy the pin — independent review of #263, F-6).
  *
- * The two WIRE GAPS the mirror keeps studio-worded (a row-level `Campaign.test_set` /
- * `RunGroup.test_set` join; `TestingReconBody.workflow`) are guarded the other way round: the
- * installed package must NOT declare them — the version that does fails here and says "re-vendor".
+ * The two shapes studio 0.5.7 coded against PROVISIONALLY (a row-level `Campaign.test_set` /
+ * `RunGroup.test_set` join; `TestingReconBody.workflow`) are gone — the produced sets ride the
+ * declared TOP-LEVEL `CampaignsListResponse.test_sets`, and the recon+workflow ladder rung was dead
+ * code. Both stay guarded the other way round: the installed package must NOT declare them, and
+ * studio must not reintroduce them — the pin (or edit) that does fails here and says "re-vendor".
  *
  * @vitest-environment node
  */
@@ -26,6 +28,7 @@ import {
   gateUngatedReason,
   QE_AUTHOR_TESTS_WORKFLOW_ID,
   testSetOf,
+  testSetsOf,
   WORKER_REMOTE_WRITE_REMEDY,
 } from '../src/api/wave6-wire.js';
 
@@ -34,6 +37,8 @@ const SKILLS_MIRROR = fileURLToPath(new URL('../src/api/skills-wire.ts', import.
 const INSTALLED = fileURLToPath(new URL('../node_modules/wicked-crew-api-types/index.d.ts', import.meta.url));
 const INSTALLED_PKG = fileURLToPath(new URL('../node_modules/wicked-crew-api-types/package.json', import.meta.url));
 const PINNED_PKG = fileURLToPath(new URL('../package.json', import.meta.url));
+const CAMPAIGNS_SRC = fileURLToPath(new URL('../src/api/campaigns.ts', import.meta.url));
+const TESTING_SRC = fileURLToPath(new URL('../src/api/testing.ts', import.meta.url));
 
 /** The version the wave-6 wire publishes under — the mirror's floor. */
 const WAVE6_VERSION = [0, 36, 0] as const;
@@ -41,7 +46,6 @@ const WAVE6_VERSION = [0, 36, 0] as const;
 const LABEL = /^wicked-crew-api-types@(\S+) index\.d\.ts:(\d+)-(\d+) /;
 const BEGIN = /^\/\/ >>> VERBATIM (.+)$/;
 const END = '// <<< VERBATIM';
-const GAPS_BANNER = '// ── WIRE GAPS — PROVISIONAL';
 
 function semver(v: string): [number, number, number] {
   const m = /^(\d+)\.(\d+)\.(\d+)/.exec(v);
@@ -85,7 +89,6 @@ const mirror = readFileSync(MIRROR, 'utf8');
 const installedDts = readFileSync(INSTALLED, 'utf8');
 const rs = regions(MIRROR);
 const regionText = rs.map((r) => r.body).join('\n');
-const gapsAt = mirror.indexOf(GAPS_BANNER);
 
 /** Studio's own spellings — the constants the surfaces speak; asserted present in the mirror. */
 const STUDIO_CONSTANTS = [
@@ -165,12 +168,11 @@ describe('src/api/wave6-wire.ts — the wave-6 mirror against the installed cont
     expect(atLeast(installed.version, WAVE6_VERSION), `${installed.version} ≥ 0.36.0`).toBe(true);
   });
 
-  it('carries the MIRROR header naming the contract and the release swap; PROVISIONAL only in the wire-gaps section', () => {
+  it('carries the MIRROR header naming the contract and the release swap; nothing PROVISIONAL remains', () => {
     const head = mirror.slice(0, 400);
     expect(head).toContain(`MIRROR of the wicked-crew-api-types ${installed.version} wave-6 additions`);
     expect(head).toContain('replace with imports from the');
-    expect(gapsAt, 'the wire-gaps section exists').toBeGreaterThan(0);
-    expect(mirror.slice(0, gapsAt)).not.toContain('PROVISIONAL');
+    expect(mirror).not.toContain('PROVISIONAL');
   });
 
   it('every VERBATIM region is byte-equal to the INSTALLED package at the labelled line range, and the label names the pinned version', () => {
@@ -202,22 +204,27 @@ describe('src/api/wave6-wire.ts — the wave-6 mirror against the installed cont
     }
   });
 
-  it('WIRE GAP 1 — a row-level `test_set` join / `TestSetRegistration` is NOT declared by the package; the mirror keeps it provisional', () => {
+  it('the produced sets ride the TOP-LEVEL `test_sets` (vendored) — no row-level `test_set` join exists in the package, and studio declares none either', () => {
     expect(installedDts).not.toMatch(/\btest_set\b/);
     expect(installedDts).not.toContain('TestSetRegistration');
-    // The package serves the sets at the list level instead — vendored, so the gap is legible.
     expect(regionText).toContain('test_sets?: TestSet[];');
-    const gaps = mirror.slice(gapsAt);
-    expect(gaps).toContain('export interface TestSetRegistration {');
-    expect(gaps).toContain('test_set?: TestSetRegistration | null;');
+    expect(regionText).toContain('export interface TestSet {');
+    // Studio reads the list, not a row: the provisional join and its reader are gone.
+    expect(mirror).not.toContain('TestSetRegistration');
+    expect(mirror).not.toContain('WithTestSet');
+    expect(readFileSync(CAMPAIGNS_SRC, 'utf8')).not.toMatch(/test_set\??:/);
+    expect(typeof testSetsOf).toBe('function');
   });
 
-  it('WIRE GAP 2 — `TestingReconBody` declares no `workflow` key; the mirror keeps the ladder rung provisional', () => {
+  it('`TestingReconBody` declares no `workflow` key — and studio sends none: the recon+workflow ladder rung is gone', () => {
     const recon = rs.find((r) => r.label.includes('TestingReconBody'));
     expect(recon, 'the TestingReconBody region').toBeDefined();
     expect(recon!.body).toContain('export interface TestingReconBody {');
     expect(recon!.body).not.toContain('workflow');
-    expect(mirror.slice(gapsAt)).toContain('export interface TestingReconWorkflowBody {');
+    expect(mirror).not.toContain('TestingReconWorkflowBody');
+    const testing = readFileSync(TESTING_SRC, 'utf8');
+    expect(testing).not.toContain('testing-recon-workflow');
+    expect(testing).not.toMatch(/\.\.\.pinned,\s*workflow/);
   });
 });
 
@@ -249,6 +256,13 @@ describe('the null-safe readers — an older daemon\'s frame changes nothing', (
   it('the constants studio speaks', () => {
     expect(QE_AUTHOR_TESTS_WORKFLOW_ID).toBe('qe-author-tests');
     expect(WORKER_REMOTE_WRITE_REMEDY).toBe("delivery is performed by the run's deliver phase");
+  });
+  it('test sets: a body without `test_sets` is null (absence), an empty list is []; a row without its run_id is null', () => {
+    expect(testSetsOf(null)).toBeNull();
+    expect(testSetsOf({ campaigns: [], groups: [] })).toBeNull();
+    expect(testSetsOf({ test_sets: [] })).toEqual([]);
     expect(testSetOf(null)).toBeNull();
+    expect(testSetOf({ id: 'x' })).toBeNull();
+    expect(testSetOf({ run_id: 'r' })?.run_id).toBe('r');
   });
 });


### PR DESCRIPTION
## Why

Studio 0.5.7 pinned `wicked-crew-api-types` **0.36.0** exactly, but the Test landing (`CampaignsPage`, the Home "Test" door, `board/campaignStats.ts`) still read a PROVISIONAL row-level `Campaign.test_set` / `RunGroup.test_set` join that 0.36.0 never declared. The daemon serves the produced sets as the top-level `CampaignsListResponse.test_sets: TestSet[]` (snake_case, `run_id`-keyed, tagged with the `qe-tests-<repo>` label an authoring run is filed under) — so against a 0.36.0 daemon no card rendered a produced set. This blocks the Phase 7 run 3 landing check (wave-6 wire gap).

## What

- **`src/api/wave6-wire.ts`** — the provisional section (`TestSetRegistration`, `TestSetCounts`, `WithTestSet`, `TestingReconWorkflowBody`, the row reader `testSetOf`) is deleted. New null-safe readers over the declared shape: `testSetsOf(body)` (`null` when the key is absent = pre-0.36 daemon, `[]` = nothing registered yet) and `testSetOf(row)` (drops a row without `run_id`; non-finite counts read as 0; `verified` only on an explicit `true`; unknown file status reads `not-executed`). The VERBATIM regions are untouched; `TestingReconBody` stays vendored as evidence of "no `workflow` key".
- **`src/api/campaigns.ts`** — `CampaignsListResponse.test_sets?: TestSet[]` mirrors the contract; `listCampaigns()` returns a normalized `CampaignsListing { campaigns, groups, testSets: TestSet[] | null }`. `test_set` is gone from `Campaign` / `RunGroup`.
- **`src/store/campaigns.ts`** — holds `testSets` (`null` on a pre-0.36 daemon or a failed probe).
- **`src/board/campaignStats.ts`** — `campaignCards(…, testSets)` joins the sets onto each card: by `run_id` against the member runs, plus by `label` for a group; deduped by set id, wire order (newest first). Pure helpers: `joinTestSets`, `testSetTotals`, `testSetCountsWord`, `testSetPrHref` (the one `isPrUrl` gate), `testDoorWord`.
- **`src/components/CampaignsPage.tsx`** — each card renders up to three sets (`campaign-card-testset`, `data-run-id/-set-id/-verified/-produced/-executed/-passed/-failed/-not-executed`): the `verified` / `not verified` chip (`campaign-card-testset-verified`), `produced · executed · passed · failed`, "· N not executed" when the verify phase left tests unrun (`campaign-card-testset-unverified`), the PLAN as a button that opens the producing run (`campaign-card-testset-plan`), the engine's PR link (`campaign-card-testset-pr`), and `+N older sets` (`campaign-card-testset-more`). The Tests tile's context appends `N test sets · P of Q passed` once the wire carries sets. Absence stays absent: a pre-0.36 daemon renders no counts and says nothing about sets.
- **`src/components/HomeBoard.tsx`** — the Test door counts campaigns + label groups as "tests" (the landing's census) and appends "· N test sets" when served; the needs-you wall keeps reading the engine campaigns off the listing.
- **`src/api/testing.ts` / `TestingLaunchPanel.tsx`** — the `POST /testing/recon` + `workflow` ladder rung (`testing-recon-workflow`) and `isUnrecognizedKey` are deleted as dead code: `qe-author-tests` and `POST /testing/author` shipped together in wave 6, so no daemon lists the workflow without the route, and 0.36.0's `TestingReconBody` declares no `workflow` key. Route absent now falls straight to the per-repo `POST /runs` fan; `/testing/recon` only ever receives the pinned body.
- **Tests** — `tests/fixtures/wave6.ts` serves the declared `TestSet` shape (`W6_TEST_SET`, `W6_TEST_SET_UNVERIFIED`, `w6Group` under `qe-tests-wicked-studio`, `w6Listing`); `CampaignsPage.testset.test.tsx` rewritten (group join by run_id, join by label, campaign join, stray set lands nowhere, unverified, `isPrUrl` refusal, cap +older, pre-0.36 absence, `[]`, KPI context); new `campaignStats.testsets.test.ts`; `wave6Wire.test.ts` now guards that neither the row join nor the recon `workflow` key returns (package AND studio source); `testingGoverned.wire.test.ts` / `TestingLaunch.governed.test.tsx` re-aimed at the fan; store + Home door tests extended. `testid-inventory.json` regenerated (+3 static ids).
- **e2e** — `uxfix_fixture.py` serves `{"campaigns": [], "groups": [GT_GROUP], "test_sets": [GT_TEST_SET]}` (the real 0.36.0 shape: an author launch is a label group, never an engine campaign); `governed_testing_test.py` asserts the group card, the verified chip, the five counts, the PLAN → run link, the PR link and the KPI context.
- **CHANGELOG** — one entry under `[Unreleased]`; no version bump (0.5.8 is cut right after).

## Gates (each `|| exit 1`)

- `npm run typecheck` — green
- `npm run lint` — green
- `npm test` — 294 files / 3178 tests green
- `npm run build` — green
- `PLAYWRIGHT_CHANNEL=chrome python3 e2e/governed_testing_test.py` (fixture updated to serve `test_sets`) — see the rig line in the PR comment thread / final report

## Notes for review

- Honesty rule preserved end to end: `testSets: null` (pre-0.36) ≠ `[]` (0.36, nothing registered); no surface fabricates a zero.
- Deny-dominates preserved: an unverified / failed set is rendered (red-ish, `not verified`), never hidden; a malformed row with a `run_id` is shown with zeroed counts rather than dropped.
- The PLAN "link" navigates to the producing run (`/runs/:id`) — studio has no file deep-link route; the run's Files view reads the run branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
