### PR TITLE
chore(release): studio 0.5.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ npm publish dates. Every version listed here exists on
 [npm](https://www.npmjs.com/package/wicked-studio?activeTab=versions).
 
 ## [Unreleased]
+
+## [0.5.8] — 2026-09-12
+_The published bundle is built against `wicked-crew-api-types` **0.36.0** — the exact
+devDependency pin, unchanged from 0.5.7 (#264); this cut lands the fix that reads the `test_sets`
+that wire actually declares (#266)._
 ### Fixed
 - **The Test landing reads the daemon's top-level `test_sets` (api-types 0.36.0) — counts, PLAN and
   PR per produced set.** The 0.5.7 landing (`CampaignsPage`, the Home "Test" door, `campaignStats`)
@@ -1054,7 +1059,8 @@ The merged interactive layer: wicked-interactive's UI moved into this skin (DES-
   `git subtree split` (92 commits).
 - The SPA as a pure HTTP/WS client of the wicked-crew daemon: runs, gates, live CoreEvents.
 
-[Unreleased]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.7...HEAD
+[Unreleased]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.8...HEAD
+[0.5.8]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.7...v0.5.8
 [0.5.7]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.6...v0.5.7
 [0.5.6]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.5...v0.5.6
 [0.5.5]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.4...v0.5.5

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-studio",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-studio",
-      "version": "0.5.7",
+      "version": "0.5.8",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "^5.56.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-studio",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "The coder-facing skin of the wicked experience plane — a pure HTTP/WS client of the wicked-crew daemon's /api/v1",
   "type": "module",
   "repository": {

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -8,7 +8,7 @@
     "Entry kinds: `static` values appear verbatim in the DOM; `dynamic` are template-literal testids with each ${expr} normalised to '*'; `computed` carry the raw JSX expression — dynamic/computed resolve only against a live DOM."
   ],
   "version": 1,
-  "studioVersion": "0.5.7",
+  "studioVersion": "0.5.8",
   "counts": {
     "files": 146,
     "occurrences": 1300,


### PR DESCRIPTION
## Summary

Release cut for **wicked-studio 0.5.8** — the same four-file bump as #265 (0.5.7), one commit, no code changes.

- `package.json` → `0.5.8`
- `package-lock.json` root `version` fields (both) → `0.5.8`
- `testid-inventory.json` `studioVersion` → `0.5.8` (`npm run manifest:testids` is a no-op beyond this field)
- `CHANGELOG.md`: `[Unreleased]` cut to `## [0.5.8] — 2026-09-12` keeping every bullet (the #266 landing: top-level `test_sets` join by `run_id` + `qe-tests-<repo>` label groups, per-set verified / produced / executed / passed / failed, PLAN + PR links, unattributed / malformed counts, empty state, filed-under label, the dead recon + `workflow` ladder rung removed, the Tests tile lead / ellipsis fix; F-1..F-4 + R2-1 review fixes), a "built against `wicked-crew-api-types` 0.36.0" note, the `[0.5.8]` compare link-ref, and the `[Unreleased]` compare base retargeted to `v0.5.8`.

The `wicked-crew-api-types` devDependency pin stays exactly `0.36.0` (unchanged from #264 / 0.5.7).

## Base

Cut from main `639071a` (#266 squash) with main CI green on that SHA (run 34666587585).

## Local gates (clean clone, `npm ci`)

- `npm run manifest:testids` — no-op (only `studioVersion` changed)
- `npm run typecheck` — pass
- `npm run lint` — pass
- `npm test` — see the PR comment / CI
- `npm run build` — pass; the bundle carries the `"0.5.8"` marker (`SettingsRailSection` reads `version` from `package.json` at build time), `dist/testid-inventory.json` says `studioVersion: 0.5.8`, no `0.5.7` remnant.

## After merge

Annotated tag `v0.5.8` on the squash commit → `release.yml` (tag/manifest agreement guard → OIDC `npm publish --provenance` → registry probe → GitHub Release from the CHANGELOG section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
