### PR TITLE
fix(runs): Archive control for terminal runs in the run header and on WorkPage rows (#219)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ npm publish dates. Every version listed here exists on
 [npm](https://www.npmjs.com/package/wicked-studio?activeTab=versions).
 
 ## [Unreleased]
+### Fixed
+- **Archive control for terminal runs in the run header and on WorkPage rows (#219, refs #211).**
+  Studio could *unarchive* a run (crew#265) but never *archive* one — `archiveRun(id, false)` was the
+  wire's only caller, so a terminal run left the active work list only through the API and the
+  seed-surfaces suite's RUN-ARC journey (#211) had to run `[SUBSTITUTE]`. The run header of every
+  terminal run (`completed` / `failed` / `cancelled`, on both `/runs/:id` and `/p/:pid/build/:runId`)
+  now carries **Archive** (`run-archive`) in the slot Cancel occupies on a live run: confirm-gated
+  (`run-archive-confirm`, Yes / Keep, Escape = Keep), refusals surfaced inline as `role="alert"`
+  (`run-archive-error`) with the confirm held open, and on success the run index refreshes and the
+  view navigates back so the run leaves the list. Every terminal Work row — the Completed / Failed /
+  Cancelled groups on the All tab and the filtered Completed / Failed / Cancelled tab views — gets
+  an inline **Archive** button (`run-archive-row`) beside the run, the shipped Unarchive-row pattern;
+  Active rows and live runs get nothing. Both paths `POST /runs/:id/archive {archived: true}`;
+  Unarchive is unchanged.
+  - *Review findings landed in-wave (independent review of #268, M-1 / L-1 / L-2):* this entry; the
+    header offers no Archive on an already-archived run (`session.archived_at` set — reachable
+    through the Archived chip), so there is nothing to re-archive; and the WorkPage tests now cover
+    the filtered tab views and the Failed / Cancelled groups, not only Completed.
 
 ## [0.5.8] — 2026-09-12
 _The published bundle is built against `wicked-crew-api-types` **0.36.0** — the exact

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -577,7 +577,7 @@ export function App(): React.ReactElement {
         <div className="flex-1 overflow-y-auto">
           {/* `search` carries §7.4's context-sensitive entry (slice Y): arriving
               from a failure context (`?filter=failed`) lands with that tab active. */}
-          <WorkPage runs={runs} selectedRunId={runId} onSelect={selectRun} navigate={navigate} search={search} />
+          <WorkPage runs={runs} selectedRunId={runId} onSelect={selectRun} navigate={navigate} search={search} onRefresh={refresh} />
         </div>
       );
     }

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -956,8 +956,11 @@ function RunChat({
         <ModePill mode={mode} onChange={onModeChange} readOnly={isTerminal} />
         <ExportEvidenceButton runId={session.id} disabled={!isTerminal} />
         {/* Archive for terminal runs (#219): write-off → navigates back so the
-            run leaves the active list; the run index refreshes on success. */}
-        {isTerminal && (
+            run leaves the active list; the run index refreshes on success. An
+            already-archived run (reached through the Archived chip) offers
+            nothing to re-archive — `archived_at` is set, guard `== null` (the
+            wire sends `null` for live, never omits the key). */}
+        {isTerminal && session.archived_at == null && (
           <RunArchiveControl
             runId={session.id}
             onArchived={() => { onRefresh(); onNavigateBack(); }}

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -319,6 +319,96 @@ function RunCancelControl({ runId, onCancelled }: {
   );
 }
 
+function RunArchiveControl({ runId, onArchived }: {
+  runId: string;
+  onArchived: () => void;
+}): React.ReactElement {
+  const [confirming, setConfirming] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function confirm(): Promise<void> {
+    if (busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await api.archiveRun(runId, true);
+      setConfirming(false);
+      onArchived();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function keep(): void {
+    if (busy) return;
+    setConfirming(false);
+    setError(null);
+  }
+
+  if (!confirming) {
+    return (
+      <button
+        type="button"
+        data-testid="run-archive"
+        onClick={() => setConfirming(true)}
+        title="Archive this run — write it off; moves it out of the active work list"
+        className="shrink-0 rounded-lg px-3 py-1.5 text-xs font-semibold font-mono transition-opacity hover:opacity-80"
+        style={{ background: 'var(--surface-raised)', color: 'var(--ink-muted)', border: '1px solid var(--surface-raised)' }}
+      >
+        Archive
+      </button>
+    );
+  }
+  return (
+    <div
+      data-testid="run-archive-confirm"
+      role="group"
+      aria-label="Confirm archiving this run"
+      className="flex items-center gap-2 shrink-0 rounded-lg px-2 py-1"
+      style={{ background: 'var(--surface-raised)', border: '1px solid var(--surface-overlay)' }}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') {
+          e.stopPropagation();
+          keep();
+        }
+      }}
+    >
+      <span className="text-[11px] font-mono" style={{ color: 'var(--ink-muted)' }}>
+        Archive this run? It moves to the Archived section.
+      </span>
+      <button
+        type="button"
+        data-testid="run-archive-yes"
+        onClick={() => void confirm()}
+        disabled={busy}
+        autoFocus
+        className="rounded-lg px-2.5 py-1 text-[11px] font-semibold font-mono disabled:opacity-50 transition-opacity"
+        style={{ background: 'var(--surface-raised)', border: '1px solid var(--surface-overlay)', color: 'var(--ink-body)' }}
+      >
+        {busy ? 'Archiving…' : 'Yes, archive'}
+      </button>
+      <button
+        type="button"
+        data-testid="run-archive-keep"
+        onClick={keep}
+        disabled={busy}
+        className="rounded-lg px-2.5 py-1 text-[11px] font-semibold font-mono disabled:opacity-50 transition-opacity"
+        style={{ background: 'var(--surface-card)', border: '1px solid var(--surface-raised)', color: 'var(--ink-body)' }}
+      >
+        Keep
+      </button>
+      {error !== null && (
+        <span role="alert" data-testid="run-archive-error" className="text-[11px] font-mono" style={{ color: 'var(--status-fail)' }}>
+          {error}
+        </span>
+      )}
+    </div>
+  );
+}
+
 function DownloadIcon(): React.ReactElement {
   return (
     <svg width="13" height="13" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
@@ -865,6 +955,14 @@ function RunChat({
         {isTerminal && <InspectMenu lens={runTab} onSelect={setRunTab} />}
         <ModePill mode={mode} onChange={onModeChange} readOnly={isTerminal} />
         <ExportEvidenceButton runId={session.id} disabled={!isTerminal} />
+        {/* Archive for terminal runs (#219): write-off → navigates back so the
+            run leaves the active list; the run index refreshes on success. */}
+        {isTerminal && (
+          <RunArchiveControl
+            runId={session.id}
+            onArchived={() => { onRefresh(); onNavigateBack(); }}
+          />
+        )}
         {/* F-029: Cancel for every non-terminal status — planning, distributing,
             executing AND awaiting_human — outside any gate card, confirmed, on
             the wire's `POST /runs/:id/cancel`; the run index refreshes on success. */}

--- a/src/components/WorkPage.tsx
+++ b/src/components/WorkPage.tsx
@@ -17,6 +17,8 @@ interface Props {
    *  `?filter=failed` (an all-runs affordance in a failure context) lands with
    *  the Failed tab active. Anything not a tab id is ignored. */
   search?: string;
+  /** Called after a successful archive so the parent can refresh the run list. */
+  onRefresh?: () => void;
 }
 
 /** The routed status filter, or null when the search carries none/garbage. */
@@ -44,7 +46,7 @@ const TABS: { id: StatusTab; label: string }[] = [
   { id: 'cancelled', label: 'Cancelled' },
 ];
 
-export function WorkPage({ runs, selectedRunId, onSelect, navigate, search = '' }: Props): React.ReactElement {
+export function WorkPage({ runs, selectedRunId, onSelect, navigate, search = '', onRefresh }: Props): React.ReactElement {
   const [query, setQuery] = useState('');
   const entryFilter = routedFilter(search);
   const [tab, setTab] = useState<StatusTab>(entryFilter ?? 'all');
@@ -81,6 +83,15 @@ export function WorkPage({ runs, selectedRunId, onSelect, navigate, search = '' 
     try {
       await api.archiveRun(id, false);
       setArchivedRuns((prev) => (prev ? prev.filter((v) => v.session.id !== id) : prev));
+    } catch {
+      /* surfaced on next fetch; the row simply stays */
+    }
+  }
+
+  async function archive(id: string): Promise<void> {
+    try {
+      await api.archiveRun(id, true);
+      onRefresh?.();
     } catch {
       /* surfaced on next fetch; the row simply stays */
     }
@@ -370,7 +381,20 @@ export function WorkPage({ runs, selectedRunId, onSelect, navigate, search = '' 
               <>
                 <GroupLabel>Completed</GroupLabel>
                 {completedGroup.map(v => (
-                  <RunLink key={v.session.id} view={v} selectedRunId={selectedRunId} onSelect={onSelect} />
+                  <div key={v.session.id} className="flex items-center gap-2">
+                    <div className="flex-1 min-w-0">
+                      <RunLink view={v} selectedRunId={selectedRunId} onSelect={onSelect} />
+                    </div>
+                    <button
+                      type="button"
+                      data-testid="run-archive-row"
+                      onClick={() => void archive(v.session.id)}
+                      className="rounded-lg px-2 py-1 text-[11px] font-mono shrink-0"
+                      style={{ color: 'var(--ink-muted)', border: '1px solid var(--surface-raised)' }}
+                    >
+                      Archive
+                    </button>
+                  </div>
                 ))}
               </>
             )}
@@ -378,7 +402,20 @@ export function WorkPage({ runs, selectedRunId, onSelect, navigate, search = '' 
               <>
                 <GroupLabel>Failed</GroupLabel>
                 {failedGroup.map(v => (
-                  <RunLink key={v.session.id} view={v} selectedRunId={selectedRunId} onSelect={onSelect} />
+                  <div key={v.session.id} className="flex items-center gap-2">
+                    <div className="flex-1 min-w-0">
+                      <RunLink view={v} selectedRunId={selectedRunId} onSelect={onSelect} />
+                    </div>
+                    <button
+                      type="button"
+                      data-testid="run-archive-row"
+                      onClick={() => void archive(v.session.id)}
+                      className="rounded-lg px-2 py-1 text-[11px] font-mono shrink-0"
+                      style={{ color: 'var(--ink-muted)', border: '1px solid var(--surface-raised)' }}
+                    >
+                      Archive
+                    </button>
+                  </div>
                 ))}
               </>
             )}
@@ -386,7 +423,20 @@ export function WorkPage({ runs, selectedRunId, onSelect, navigate, search = '' 
               <>
                 <GroupLabel>Cancelled</GroupLabel>
                 {cancelledGroup.map(v => (
-                  <RunLink key={v.session.id} view={v} selectedRunId={selectedRunId} onSelect={onSelect} />
+                  <div key={v.session.id} className="flex items-center gap-2">
+                    <div className="flex-1 min-w-0">
+                      <RunLink view={v} selectedRunId={selectedRunId} onSelect={onSelect} />
+                    </div>
+                    <button
+                      type="button"
+                      data-testid="run-archive-row"
+                      onClick={() => void archive(v.session.id)}
+                      className="rounded-lg px-2 py-1 text-[11px] font-mono shrink-0"
+                      style={{ color: 'var(--ink-muted)', border: '1px solid var(--surface-raised)' }}
+                    >
+                      Archive
+                    </button>
+                  </div>
                 ))}
               </>
             )}
@@ -397,9 +447,26 @@ export function WorkPage({ runs, selectedRunId, onSelect, navigate, search = '' 
             {filtered.length === 0 ? (
               <EmptyState query={query} tab={tab} hidden={hiddenByRange} />
             ) : (
-              filtered.map(v => (
-                <RunLink key={v.session.id} view={v} selectedRunId={selectedRunId} onSelect={onSelect} />
-              ))
+              filtered.map(v =>
+                tab === 'active' ? (
+                  <RunLink key={v.session.id} view={v} selectedRunId={selectedRunId} onSelect={onSelect} />
+                ) : (
+                  <div key={v.session.id} className="flex items-center gap-2">
+                    <div className="flex-1 min-w-0">
+                      <RunLink view={v} selectedRunId={selectedRunId} onSelect={onSelect} />
+                    </div>
+                    <button
+                      type="button"
+                      data-testid="run-archive-row"
+                      onClick={() => void archive(v.session.id)}
+                      className="rounded-lg px-2 py-1 text-[11px] font-mono shrink-0"
+                      style={{ color: 'var(--ink-muted)', border: '1px solid var(--surface-raised)' }}
+                    >
+                      Archive
+                    </button>
+                  </div>
+                )
+              )
             )}
           </>
         )}

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -11,8 +11,8 @@
   "studioVersion": "0.5.8",
   "counts": {
     "files": 146,
-    "occurrences": 1300,
-    "static": 1121,
+    "occurrences": 1309,
+    "static": 1127,
     "dynamic": 61,
     "computed": 7
   },
@@ -4203,6 +4203,42 @@
       "testId": "routing-provenance",
       "files": [
         "src/components/RoutingProvenance.tsx"
+      ]
+    },
+    {
+      "testId": "run-archive",
+      "files": [
+        "src/components/ChatPanel.tsx"
+      ]
+    },
+    {
+      "testId": "run-archive-confirm",
+      "files": [
+        "src/components/ChatPanel.tsx"
+      ]
+    },
+    {
+      "testId": "run-archive-error",
+      "files": [
+        "src/components/ChatPanel.tsx"
+      ]
+    },
+    {
+      "testId": "run-archive-keep",
+      "files": [
+        "src/components/ChatPanel.tsx"
+      ]
+    },
+    {
+      "testId": "run-archive-row",
+      "files": [
+        "src/components/WorkPage.tsx"
+      ]
+    },
+    {
+      "testId": "run-archive-yes",
+      "files": [
+        "src/components/ChatPanel.tsx"
       ]
     },
     {

--- a/tests/ChatPanel.archive.test.tsx
+++ b/tests/ChatPanel.archive.test.tsx
@@ -1,0 +1,109 @@
+// Issue #219 — run header Archive control for terminal runs.
+//
+// Terminal runs can be archived (written off) from the run header. The control
+// asks first, then calls api.archiveRun(id, true), then navigates back and
+// refreshes the run index. Errors surface as role="alert"; live runs offer no
+// Archive — only terminal ones can be written off.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ChatPanel } from '../src/components/ChatPanel.js';
+import * as client from '../src/api/client.js';
+import { useGateStore } from '../src/store/gates.js';
+import { useRunEventStore } from '../src/store/events.js';
+import { makeView, makeUnit } from './factories.js';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  useGateStore.setState({ gates: {}, approaching: {} });
+  useRunEventStore.setState({ byRun: {} });
+  vi.spyOn(client.api, 'getRoster').mockResolvedValue({ roster: [] });
+  vi.spyOn(client.api, 'listRepos').mockResolvedValue({ repos: [] });
+  vi.spyOn(client.api, 'listWorkflows').mockResolvedValue({ workflows: [] });
+  vi.spyOn(client.api, 'getUnitOutput').mockResolvedValue({ output: 'out' });
+  vi.spyOn(client.api, 'archiveRun').mockResolvedValue({ runId: 'run-9', archived: true });
+});
+
+function terminalView(status: 'completed' | 'cancelled' | 'failed') {
+  return makeView({ id: 'run-9', status, unit_ix: 0 }, [
+    makeUnit({ id: 'run-9:u0', session_id: 'run-9', ord: 0, stage: 'recon', status: 'done', assigned_cli: 'claude' }),
+  ]);
+}
+
+function renderPanel(view: ReturnType<typeof makeView>) {
+  const onRefresh = vi.fn();
+  const onNavigateBack = vi.fn();
+  render(
+    <ChatPanel view={view} onLaunched={vi.fn()} onNavigateBack={onNavigateBack} onRefresh={onRefresh} />,
+  );
+  return { onRefresh, onNavigateBack };
+}
+
+describe('run header Archive (#219)', () => {
+  it.each(['completed', 'cancelled', 'failed'] as const)(
+    'a %s run renders Archive in the header',
+    (status) => {
+      renderPanel(terminalView(status));
+      const header = screen.getByTestId('run-header');
+      const archive = screen.getByTestId('run-archive');
+      expect(header.contains(archive)).toBe(true);
+      expect(archive).toHaveTextContent('Archive');
+      expect(client.api.archiveRun).not.toHaveBeenCalled();
+    },
+  );
+
+  it('a live run offers no Archive — only terminal runs can be written off', () => {
+    renderPanel(makeView({ id: 'run-9', status: 'executing', unit_ix: 0 }, []));
+    expect(screen.queryByTestId('run-archive')).toBeNull();
+    expect(screen.queryByTestId('run-archive-confirm')).toBeNull();
+  });
+
+  it('asks first — Keep closes the confirm and fires nothing', async () => {
+    const user = userEvent.setup();
+    const { onRefresh } = renderPanel(terminalView('completed'));
+    await user.click(screen.getByTestId('run-archive'));
+    const confirm = screen.getByTestId('run-archive-confirm');
+    expect(confirm).toHaveTextContent(/Archive this run\?/);
+    expect(screen.queryByTestId('run-archive')).toBeNull();
+    await user.click(screen.getByTestId('run-archive-keep'));
+    expect(screen.queryByTestId('run-archive-confirm')).toBeNull();
+    expect(screen.getByTestId('run-archive')).toBeInTheDocument();
+    expect(client.api.archiveRun).not.toHaveBeenCalled();
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it('Escape inside the confirm is Keep', async () => {
+    const user = userEvent.setup();
+    renderPanel(terminalView('failed'));
+    await user.click(screen.getByTestId('run-archive'));
+    await user.keyboard('{Escape}');
+    expect(screen.queryByTestId('run-archive-confirm')).toBeNull();
+    expect(client.api.archiveRun).not.toHaveBeenCalled();
+  });
+
+  it('confirming POSTs archive=true, then refreshes and navigates back', async () => {
+    const user = userEvent.setup();
+    const { onRefresh, onNavigateBack } = renderPanel(terminalView('completed'));
+    await user.click(screen.getByTestId('run-archive'));
+    await user.click(screen.getByTestId('run-archive-yes'));
+    await waitFor(() => expect(client.api.archiveRun).toHaveBeenCalledWith('run-9', true));
+    await waitFor(() => expect(onRefresh).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(onNavigateBack).toHaveBeenCalledTimes(1));
+    expect(screen.queryByTestId('run-archive-error')).toBeNull();
+  });
+
+  it('a refused archive surfaces the error with role=alert and keeps the confirm open', async () => {
+    vi.mocked(client.api.archiveRun).mockRejectedValue(new Error('run is not terminal'));
+    const user = userEvent.setup();
+    const { onRefresh, onNavigateBack } = renderPanel(terminalView('completed'));
+    await user.click(screen.getByTestId('run-archive'));
+    await user.click(screen.getByTestId('run-archive-yes'));
+    const err = await screen.findByTestId('run-archive-error');
+    expect(err).toHaveTextContent('run is not terminal');
+    expect(err).toHaveAttribute('role', 'alert');
+    expect(screen.getByTestId('run-archive-confirm')).toBeInTheDocument();
+    expect(onRefresh).not.toHaveBeenCalled();
+    expect(onNavigateBack).not.toHaveBeenCalled();
+  });
+});

--- a/tests/ChatPanel.archive.test.tsx
+++ b/tests/ChatPanel.archive.test.tsx
@@ -59,6 +59,17 @@ describe('run header Archive (#219)', () => {
     expect(screen.queryByTestId('run-archive-confirm')).toBeNull();
   });
 
+  it.each(['completed', 'cancelled', 'failed'] as const)(
+    'an already-archived %s run offers no Archive — archived_at is set, nothing to re-archive',
+    (status) => {
+      renderPanel(makeView({ id: 'run-9', status, unit_ix: 0, archived_at: 1786700000000 }, []));
+      expect(screen.getByTestId('run-header')).toBeInTheDocument();
+      expect(screen.queryByTestId('run-archive')).toBeNull();
+      expect(screen.queryByTestId('run-archive-confirm')).toBeNull();
+      expect(client.api.archiveRun).not.toHaveBeenCalled();
+    },
+  );
+
   it('asks first — Keep closes the confirm and fires nothing', async () => {
     const user = userEvent.setup();
     const { onRefresh } = renderPanel(terminalView('completed'));

--- a/tests/WorkPage.archived.test.tsx
+++ b/tests/WorkPage.archived.test.tsx
@@ -21,6 +21,9 @@ vi.mock('../src/api/client.js', () => ({
 }));
 
 const live = makeView({ id: 'live-1', workflow_id: 'feature', problem: 'live work', status: 'completed' });
+const failed = makeView({ id: 'fail-1', workflow_id: 'feature', problem: 'broken work', status: 'failed' });
+const cancelled = makeView({ id: 'canc-1', workflow_id: 'feature', problem: 'stopped work', status: 'cancelled' });
+const active = makeView({ id: 'act-1', workflow_id: 'feature', problem: 'active work', status: 'executing' });
 const archived = makeView({
   id: 'old-1',
   workflow_id: 'feature',
@@ -116,5 +119,94 @@ describe('WorkPage — Archive from terminal row (#219)', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Archive' }));
     expect(archiveRun).toHaveBeenCalledWith('live-1', true);
     await waitFor(() => expect(onRefresh).toHaveBeenCalledTimes(1));
+  });
+
+  // The All tab partitions rows into Active / Completed / Failed / Cancelled groups
+  // (`outcomeOf`); every TERMINAL group carries the button, the Active group none.
+  // Each group is exercised on its own so a group that drops the button fails on
+  // its own name — the review's surviving mutation M5.
+  it.each([
+    ['Completed', live],
+    ['Failed', failed],
+    ['Cancelled', cancelled],
+  ] as const)('the %s group on the All tab archives its row', async (label, view) => {
+    archiveRun.mockResolvedValue({ runId: view.session.id, archived: true });
+    const onRefresh = vi.fn();
+    render(
+      <WorkPage
+        runs={[active, view]}
+        selectedRunId={null}
+        onSelect={() => {}}
+        navigate={() => {}}
+        onRefresh={onRefresh}
+      />,
+    );
+    expect(screen.getByRole('tablist', { name: 'Filter by status' })).toHaveAttribute('data-filter', 'all');
+    expect(screen.getByText(label)).toBeInTheDocument();
+    // The Active row has no button, so the single Archive belongs to this group's row.
+    const buttons = screen.getAllByRole('button', { name: 'Archive' });
+    expect(buttons).toHaveLength(1);
+    await userEvent.click(buttons[0]!);
+    expect(archiveRun).toHaveBeenCalledWith(view.session.id, true);
+    await waitFor(() => expect(onRefresh).toHaveBeenCalledTimes(1));
+  });
+
+  it('the All tab shows one Archive per terminal row across all three groups, none for Active', () => {
+    render(
+      <WorkPage
+        runs={[active, live, failed, cancelled]}
+        selectedRunId={null}
+        onSelect={() => {}}
+        navigate={() => {}}
+        onRefresh={() => {}}
+      />,
+    );
+    expect(screen.getAllByRole('button', { name: 'Archive' })).toHaveLength(3);
+    expect(screen.getByText(/active work · act-1/)).toBeInTheDocument();
+  });
+
+  // The filtered tab views render their own row wrapper (not the All-tab groups), so
+  // they are covered separately — the review's surviving mutation M4.
+  it.each([
+    ['completed', live],
+    ['failed', failed],
+    ['cancelled', cancelled],
+  ] as const)('the ?filter=%s tab view archives its row', async (tab, view) => {
+    archiveRun.mockResolvedValue({ runId: view.session.id, archived: true });
+    const onRefresh = vi.fn();
+    render(
+      <WorkPage
+        runs={[active, live, failed, cancelled]}
+        selectedRunId={null}
+        onSelect={() => {}}
+        navigate={() => {}}
+        search={`?filter=${tab}`}
+        onRefresh={onRefresh}
+      />,
+    );
+    expect(screen.getByRole('tablist', { name: 'Filter by status' })).toHaveAttribute('data-filter', tab);
+    // Exactly the one run of this status is listed, with exactly one Archive.
+    expect(screen.getByText(new RegExp(`${view.session.problem} · ${view.session.id}`))).toBeInTheDocument();
+    const buttons = screen.getAllByRole('button', { name: 'Archive' });
+    expect(buttons).toHaveLength(1);
+    await userEvent.click(buttons[0]!);
+    expect(archiveRun).toHaveBeenCalledWith(view.session.id, true);
+    await waitFor(() => expect(onRefresh).toHaveBeenCalledTimes(1));
+  });
+
+  it('the ?filter=active tab view lists live runs with no Archive', () => {
+    render(
+      <WorkPage
+        runs={[active, live, failed, cancelled]}
+        selectedRunId={null}
+        onSelect={() => {}}
+        navigate={() => {}}
+        search="?filter=active"
+        onRefresh={() => {}}
+      />,
+    );
+    expect(screen.getByRole('tablist', { name: 'Filter by status' })).toHaveAttribute('data-filter', 'active');
+    expect(screen.getByText(/active work · act-1/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Archive' })).toBeNull();
   });
 });

--- a/tests/WorkPage.archived.test.tsx
+++ b/tests/WorkPage.archived.test.tsx
@@ -1,4 +1,4 @@
-// crew#265 — the Archived chip: a write-off view, off by default.
+// crew#265 + issue #219 — Archived chip and Archive-from-row.
 //
 // Default: archived runs are simply absent (the daemon excludes them; WorkPage adds nothing).
 // Chip ON: fetches the complete list, shows ONLY the archived remainder under an "Archived"
@@ -70,5 +70,51 @@ describe('WorkPage — Archived chip (crew#265)', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Unarchive' }));
     expect(archiveRun).toHaveBeenCalledWith('old-1', false);
     await waitFor(() => expect(screen.queryByText(/campaign leftover/)).toBeNull());
+  });
+});
+
+describe('WorkPage — Archive from terminal row (#219)', () => {
+  it('terminal rows show an Archive button', () => {
+    render(
+      <WorkPage
+        runs={[live]}
+        selectedRunId={null}
+        onSelect={() => {}}
+        navigate={() => {}}
+        onRefresh={() => {}}
+      />,
+    );
+    expect(screen.getAllByRole('button', { name: 'Archive' })).toHaveLength(1);
+  });
+
+  it('active runs do not show an Archive button', () => {
+    const activeRun = makeView({ id: 'act-1', workflow_id: 'feature', problem: 'active work', status: 'executing' });
+    render(
+      <WorkPage
+        runs={[activeRun]}
+        selectedRunId={null}
+        onSelect={() => {}}
+        navigate={() => {}}
+        onRefresh={() => {}}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: 'Archive' })).toBeNull();
+  });
+
+  it('Archive calls archiveRun(id, true) and invokes onRefresh', async () => {
+    archiveRun.mockResolvedValue({ runId: 'live-1', archived: true });
+    const onRefresh = vi.fn();
+    render(
+      <WorkPage
+        runs={[live]}
+        selectedRunId={null}
+        onSelect={() => {}}
+        navigate={() => {}}
+        onRefresh={onRefresh}
+      />,
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Archive' }));
+    expect(archiveRun).toHaveBeenCalledWith('live-1', true);
+    await waitFor(() => expect(onRefresh).toHaveBeenCalledTimes(1));
   });
 });


### PR DESCRIPTION
## Intent

Runs: no Archive control in the UI — only Unarchive exists (WorkPage.tsx:82 archiveRun(id, false))

## What

Studio can **unarchive** a run but cannot **archive** one. `src/api/client.ts:142` exposes `archiveRun(id, archived, note?)`, yet the only caller is `src/components/WorkPage.tsx:82` — `api.archiveRun(id, false)` behind the Archived section's Unarchive control. No run card, run header or WorkPage row offers "Archive".

## Why it matters

Archiving is how a terminal run leaves the active dashboard/work list; today it has to be done through the API. The seed-surfaces suite (#211, RUN-ARC) had to mark its archive journey `[SUBSTITUTE]` (API call, UI-verified) while RUN-UNARC ran as a real UI journey — the asymmetry is the gap.

## Suggested fix

An Archive action on terminal runs (run header on `/runs/:id` and the WorkPage row menu) calling `archiveRun(id, true, note?)`, with the run moving to the Archived section; keep the existing Unarchive. Then #211's RUN-ARC drops its substitute marker.

## Evidence

- `grep -rn "archiveRun(" src` → one caller, `WorkPage.tsx:82`, `archived=false`.
- #211 run 10: RUN-ARC `[SUBSTITUTE] archive via API — studio mounts no archive control`; RUN-UNARC real control.

fix issue #219

Fixes #219
Refs: #211

## Run

- Run: `0ab5ccb8-7da3-4c04-8025-cdd20a024500`
- workflow `bug` · repo `wicked-studio`

## Phases

| phase | stage | role | seat | gate | outcome |
|---|---|---|---|---|---|
| `triage` | recon | neutral | claude | auto | approved |
| `reproduce` | test | neutral | opencode | auto | approved |
| `fix` | build | creator | claude | auto | approved |
| `verify` | test | evaluator | opencode | human if verdict not pass | approved |
| `deliver` | build | neutral | tool | auto | this PR |

## Repo checks

| check | command | exit | duration |
|---|---|---|---|
| typecheck | `npm run typecheck` | 0 | 18.1s |
| lint | `npm run lint` | 0 | 15.2s |
| test | `npm run test` | 0 | 328.3s |

## Evaluator verdict

- `verify` (opencode): **approved**

---

Delivered by [wicked-crew](https://wc.wickedagile.com) run `0ab5ccb8-7da3-4c04-8025-cdd20a024500`. Merge stays human: the phase opens the PR, never merges it.

## Follow-up commit (independent review)

An independent review of this PR approved it and asked for three items in-wave, landed as one
plain-agent commit on top of the harness commit:

- **M-1** — `CHANGELOG.md` `[Unreleased]` entry for #219 (every fix/feat PR on this repo carries one).
- **L-1** — the run header no longer offers **Archive** on an already-archived run
  (`session.archived_at` set — reachable through the Archived chip → row → run page); +3 tests.
- **L-2** — WorkPage tests now cover the filtered Completed / Failed / Cancelled tab views and the
  Failed / Cancelled groups on the All tab, not only Completed (the review's surviving mutations
  M4 / M5 are killed); +8 tests.

No version bump; the testid inventory is unchanged (no new ids).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
