### PR TITLE
fix(composer): deliver gate by default, "No gates · auto-deliver" is the explicit opt-out; intake plan names the deliver gate (F-E2E-030)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,12 @@ npm publish dates. Every version listed here exists on
   says "with NO deliver gate — this posture is auto-deliver". The intake plan's deliver row names
   the gate from `session.auto_deliver` ("human gate before it pushes its branch + opens the PR" /
   "auto-deliver — … no gate"; `intake-plan-deliver-gate`) and stays silent on an engine that
-  predates the gate, so no promise is made that the engine cannot keep.
+  predates the gate, so no promise is made that the engine cannot keep. The composer makes the
+  same promise only when the DAEMON can keep it: it reads `GET /health.capabilities.deliverGate`
+  (crew ≥ 0.7.33) and, against a daemon without it, says "this daemon delivers WITHOUT a deliver
+  gate (upgrade crew to 0.7.33+ to confirm the push first)", offers no auto-deliver option and
+  never sends `deliverGate` (the older launch schema rejects it). "No gates" is labelled
+  auto-deliver only where the select is honoured (not in Ask mode, where every unit is gated).
 
 
 ## [0.5.8] — 2026-09-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,22 @@ npm publish dates. Every version listed here exists on
     through the Archived chip), so there is nothing to re-archive; and the WorkPage tests now cover
     the filtered tab views and the Failed / Cancelled groups, not only Completed.
 
+### Fixed
+- **The composer promised a push with no gate (acceptance finding F-E2E-030).** Under the default
+  "First gate" posture the deliver notice read "When this finishes it pushes its branch → opens a
+  PR" — and that is exactly what run `0ab5ccb8` did, unattended. The engine now gates the deliver
+  phase by default (wicked-core#456) and crew accepts `deliverGate: 'human' | 'auto'`
+  (wicked-crew#543). The composer says WHEN the push happens: the default postures read "pauses
+  at the deliver gate; approve it and the run pushes its branch → opens a PR on <repo>", the
+  confirm line gains `deliver: after you approve the deliver gate` (`launch-confirm-deliver`), and
+  the body sends NO opt-out. Only the explicitly unattended postures — Autonomous, or the gate
+  option now labelled **"No gates · auto-deliver"** — send `deliverGate: 'auto'`, and their notice
+  says "with NO deliver gate — this posture is auto-deliver". The intake plan's deliver row names
+  the gate from `session.auto_deliver` ("human gate before it pushes its branch + opens the PR" /
+  "auto-deliver — … no gate"; `intake-plan-deliver-gate`) and stays silent on an engine that
+  predates the gate, so no promise is made that the engine cannot keep.
+
+
 ## [0.5.8] — 2026-09-12
 _The published bundle is built against `wicked-crew-api-types` **0.36.0** — the exact
 devDependency pin, unchanged from 0.5.7 (#264); this cut lands the fix that reads the `test_sets`

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -332,7 +332,11 @@ export const api = {
     apiFetch<{ runId: string }>(`/repos/${encodeURIComponent(repoId)}/onboard`, { method: 'POST' }),
 
   /** Liveness (also proves the actor + event pump are up). */
-  getHealth: () => apiFetch<{ status: string; version: string; ping: string }>('/health'),
+  // `capabilities` is hand-declared until the api-types 0.37.0 pin lands (`HealthResponse` there):
+  // `deliverGate` — the daemon's engine pauses before the deliver phase pushes (F-E2E-030). Absent
+  // on a daemon before crew 0.7.33 ⇒ delivery follows verify unattended.
+  getHealth: () =>
+    apiFetch<{ status: string; version: string; ping: string; capabilities?: { deliverGate?: boolean } }>('/health'),
 
   /**
    * Open a PTY terminal session → its id. Drive it over the terminal WS

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -91,6 +91,13 @@ export interface DeliverRunResult {
 export type LaunchBodyWithDeliver = Omit<LaunchRunBody, 'deliver'> & {
   deliver?: 'pr' | 'none';
   /**
+   * Who confirms the deliver phase (F-E2E-030; crew ≥ 0.7.33 / api-types ≥ 0.37): the ENGINE
+   * gates the push + PR by default (`'human'`, or omitted); `'auto'` is the operator's EXPLICIT
+   * opt-out, sent only for the postures the composer names "auto-deliver" (No gates,
+   * Autonomous). Hand-declared here like `deliver` — delete on the ≥0.37 api-types bump.
+   */
+  deliverGate?: 'human' | 'auto';
+  /**
    * Ad-hoc campaign attach (wicked-studio#27; api-types 0.19.0): file this run onto an
    * EXISTING campaign's surface. Provenance only — the run executes byte-identically, never
    * becomes a DAG node. Validated at launch, loudly: unknown campaign = 404 (nothing

--- a/src/components/ApprovalDock.tsx
+++ b/src/components/ApprovalDock.tsx
@@ -3,6 +3,7 @@ import type { SessionView } from '../api/types.js';
 import { useElicitationStore } from '../store/elicitations.js';
 import { useGateStore } from '../store/gates.js';
 import { ElicitationPrompt } from './ElicitationPrompt.js';
+import { autoDeliverOf } from './IntakePlan.js';
 import { SteeringGate } from './SteeringGate.js';
 
 /**
@@ -77,7 +78,9 @@ export function ApprovalDock({
           guidance={guidance}
           {...(ord !== undefined ? { ord } : {})}
           {...(gate ? { prompt: gate.prompt } : {})}
-          {...(view !== undefined ? { units: view.units, clis: view.session.clis } : {})}
+          {...(view !== undefined
+            ? { units: view.units, clis: view.session.clis, autoDeliver: autoDeliverOf(view.session) }
+            : {})}
           onResolved={onResolved}
         />
       )}

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -240,6 +240,20 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
   // — and the composer names that posture "auto-deliver" wherever it shows it, so the operator
   // reads the consequence before Send. "First gate" / "Every unit" keep the gate.
   const autoDeliver = mode === 'autonomous' || (mode !== 'ask' && confirmMode === 'none');
+  // …and whether THIS daemon can keep the gate at all (review F-2 on studio#269): the engine gate
+  // exists from crew 0.7.33 / core-ts 0.7.24 (`GET /health.capabilities.deliverGate`). Against an
+  // older daemon the push follows verify unattended — the composer must SAY that, not promise a
+  // gate, and must not send `deliverGate` (the older launch schema rejects it). `null` = not yet
+  // known (loading, or the read failed) — no promise either way.
+  const [daemonDeliverGate, setDaemonDeliverGate] = useState<boolean | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    Promise.resolve()
+      .then(() => api.getHealth())
+      .then((h) => { if (!cancelled) setDaemonDeliverGate(h.capabilities?.deliverGate === true); })
+      .catch(() => { if (!cancelled) setDaemonDeliverGate(null); });
+    return () => { cancelled = true; };
+  }, []);
 
   // ── Preflight (DES-UX-001 §7.8, EC43, slice AC) ────────────────────────────
   // A code-shaped intent with no repo attached warns-and-blocks: zero POST
@@ -578,7 +592,7 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
     if (deliverKind(wf) === 'build' && targetRepoRef !== null) body.deliver = deliverOn ? 'pr' : 'none';
     // F-E2E-030: the deliver gate is the engine's default; the body says nothing to be gated.
     // Only the explicitly unattended postures send the opt-out — and only with a delivery.
-    if (body.deliver === 'pr' && autoDeliver) body.deliverGate = 'auto';
+    if (body.deliver === 'pr' && autoDeliver && daemonDeliverGate === true) body.deliverGate = 'auto';
     // §5.1: Unfiled = NO projectId key at all (the backend default); a selected
     // or pre-bound project files the run atomically with the launch.
     const boundProject = lockedProjectId ?? selectedProjectId;
@@ -915,9 +929,14 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
               // F-E2E-030: say WHEN the push happens — after the deliver gate the operator
               // approves, or, under an explicitly unattended posture, with no gate at all —
               // named "auto-deliver", never implied.
-              text: autoDeliver
-                ? `When this finishes it pushes its branch → opens a PR on ${targetLabel} with NO deliver gate — this posture is auto-deliver. Merging stays yours.`
-                : `When this finishes it pauses at the deliver gate; approve it and the run pushes its branch → opens a PR on ${targetLabel}. Merging stays yours.`,
+              text:
+                daemonDeliverGate === false
+                  ? `When this finishes it pushes its branch → opens a PR on ${targetLabel} — this daemon delivers WITHOUT a deliver gate (upgrade crew to 0.7.33+ to confirm the push first). Merging stays yours.`
+                  : daemonDeliverGate === null
+                    ? `When this finishes it pushes its branch → opens a PR on ${targetLabel}. Merging stays yours.`
+                    : autoDeliver
+                      ? `When this finishes it pushes its branch → opens a PR on ${targetLabel} with NO deliver gate — this posture is auto-deliver. Merging stays yours.`
+                      : `When this finishes it pauses at the deliver gate; approve it and the run pushes its branch → opens a PR on ${targetLabel}. Merging stays yours.`,
             }
           : {
               // The consequence of OFF, said before the send (crew#393): the
@@ -928,6 +947,11 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
             };
     }
   })();
+
+  // The deliver-gate word the notice and the confirm line share (F-E2E-030): what the daemon can
+  // keep, then what the posture asks for. `unknown` while the health read is pending/failed.
+  const deliverGateWord: 'human' | 'auto' | 'unsupported' | 'unknown' =
+    daemonDeliverGate === false ? 'unsupported' : daemonDeliverGate === null ? 'unknown' : autoDeliver ? 'auto' : 'human';
 
   // Determine whether CLIs differ from the defaults that loaded from the roster
   const defaultCliSet = new Set(
@@ -1131,7 +1155,7 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
           <option value="all">Every unit</option>
           {/* F-E2E-030: when this launch delivers, "No gates" is also the auto-deliver opt-out —
               the option says so where it is chosen. */}
-          <option value="none">{deliverNotice?.state === 'on' ? 'No gates · auto-deliver' : 'No gates'}</option>
+          <option value="none">{deliverNotice?.state === 'on' && mode !== 'ask' && daemonDeliverGate === true ? 'No gates · auto-deliver' : 'No gates'}</option>
         </select>
       </div>
 
@@ -1297,7 +1321,7 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
           data-testid="deliver-notice"
           data-deliver-state={deliverNotice.state}
           data-deliver-repo={targetRepoRef ?? ''}
-          data-deliver-gate={deliverNotice.state === 'on' ? (autoDeliver ? 'auto' : 'human') : ''}
+          data-deliver-gate={deliverNotice.state === 'on' ? deliverGateWord : ''}
           className="text-xs px-1 font-mono"
           style={{
             color:
@@ -1388,10 +1412,16 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
               {' · deliver: '}
               <span
                 data-testid="launch-confirm-deliver"
-                data-deliver-gate={autoDeliver ? 'auto' : 'human'}
-                style={{ color: autoDeliver ? 'var(--status-gate)' : 'var(--ink-high)' }}
+                data-deliver-gate={deliverGateWord}
+                style={{ color: deliverGateWord === 'human' ? 'var(--ink-high)' : 'var(--status-gate)' }}
               >
-                {autoDeliver ? 'auto — no gate before the push' : 'after you approve the deliver gate'}
+                {deliverGateWord === 'unsupported'
+                  ? 'no gate on this daemon (upgrade crew to 0.7.33+)'
+                  : deliverGateWord === 'unknown'
+                    ? 'after verify'
+                    : deliverGateWord === 'auto'
+                      ? 'auto — no gate before the push'
+                      : 'after you approve the deliver gate'}
               </span>
             </>
           )}

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -234,6 +234,12 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
   /** Per-launch override; `null` = follow the preference. */
   const [deliverOverride, setDeliverOverride] = useState<boolean | null>(null);
   const deliverOn = deliverOverride ?? deliverPr;
+  // Who confirms the push (F-E2E-030). The ENGINE gates the deliver phase by default — the
+  // run pauses before it pushes its branch and opens the PR, whatever the gate posture. Only an
+  // EXPLICITLY unattended posture opts out: the Autonomous run mode, or the "No gates" selection
+  // — and the composer names that posture "auto-deliver" wherever it shows it, so the operator
+  // reads the consequence before Send. "First gate" / "Every unit" keep the gate.
+  const autoDeliver = mode === 'autonomous' || (mode !== 'ask' && confirmMode === 'none');
 
   // ── Preflight (DES-UX-001 §7.8, EC43, slice AC) ────────────────────────────
   // A code-shaped intent with no repo attached warns-and-blocks: zero POST
@@ -570,6 +576,9 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
     // older daemons also 400 on `'none'`, so unlicensed bodies never carry it).
     // The same verdict is on screen before the operator sends (`deliverNotice`).
     if (deliverKind(wf) === 'build' && targetRepoRef !== null) body.deliver = deliverOn ? 'pr' : 'none';
+    // F-E2E-030: the deliver gate is the engine's default; the body says nothing to be gated.
+    // Only the explicitly unattended postures send the opt-out — and only with a delivery.
+    if (body.deliver === 'pr' && autoDeliver) body.deliverGate = 'auto';
     // §5.1: Unfiled = NO projectId key at all (the backend default); a selected
     // or pre-bound project files the run atomically with the launch.
     const boundProject = lockedProjectId ?? selectedProjectId;
@@ -903,7 +912,12 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
               // F-028: the notice NAMES the repo the PR lands on — `owner/repo`
               // off its registered git URL, its registered name otherwise.
               state: 'on',
-              text: `When this finishes it pushes its branch → opens a PR on ${targetLabel}. Merging stays yours.`,
+              // F-E2E-030: say WHEN the push happens — after the deliver gate the operator
+              // approves, or, under an explicitly unattended posture, with no gate at all —
+              // named "auto-deliver", never implied.
+              text: autoDeliver
+                ? `When this finishes it pushes its branch → opens a PR on ${targetLabel} with NO deliver gate — this posture is auto-deliver. Merging stays yours.`
+                : `When this finishes it pauses at the deliver gate; approve it and the run pushes its branch → opens a PR on ${targetLabel}. Merging stays yours.`,
             }
           : {
               // The consequence of OFF, said before the send (crew#393): the
@@ -1115,7 +1129,9 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
         >
           <option value="before">{beforeOrd === 1 ? 'First gate' : `Before unit #${beforeOrd}`}</option>
           <option value="all">Every unit</option>
-          <option value="none">No gates</option>
+          {/* F-E2E-030: when this launch delivers, "No gates" is also the auto-deliver opt-out —
+              the option says so where it is chosen. */}
+          <option value="none">{deliverNotice?.state === 'on' ? 'No gates · auto-deliver' : 'No gates'}</option>
         </select>
       </div>
 
@@ -1281,6 +1297,7 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
           data-testid="deliver-notice"
           data-deliver-state={deliverNotice.state}
           data-deliver-repo={targetRepoRef ?? ''}
+          data-deliver-gate={deliverNotice.state === 'on' ? (autoDeliver ? 'auto' : 'human') : ''}
           className="text-xs px-1 font-mono"
           style={{
             color:
@@ -1365,6 +1382,19 @@ export function ChatInput({ runId, runStatus, onLaunched, embedded, workflowOver
           </span>
           {' · gate: '}
           <span data-testid="launch-confirm-gate" style={{ color: 'var(--ink-high)' }}>{describeGate(mode, confirmMode, beforeOrd)}</span>
+          {/* F-E2E-030: the deliver gate is part of what is being sent — read it here too. */}
+          {deliverNotice?.state === 'on' && (
+            <>
+              {' · deliver: '}
+              <span
+                data-testid="launch-confirm-deliver"
+                data-deliver-gate={autoDeliver ? 'auto' : 'human'}
+                style={{ color: autoDeliver ? 'var(--status-gate)' : 'var(--ink-high)' }}
+              >
+                {autoDeliver ? 'auto — no gate before the push' : 'after you approve the deliver gate'}
+              </span>
+            </>
+          )}
         </p>
       )}
 

--- a/src/components/IntakePlan.tsx
+++ b/src/components/IntakePlan.tsx
@@ -24,6 +24,20 @@ export interface IntakePlanProps {
   clis?: readonly string[] | undefined;
   /** The workflow def the run was planned from, when the host knows it. */
   workflow?: WorkflowDef | null | undefined;
+  /**
+   * The run's deliver posture (F-E2E-030, `session.auto_deliver`): `false` — the engine pauses
+   * for a human before the `deliver` phase pushes and opens the PR; `true` — the launch opted out
+   * (auto-deliver). `null`/absent — the engine predates the deliver gate, so NO promise is made.
+   */
+  autoDeliver?: boolean | null | undefined;
+}
+
+/** The run's deliver posture off the session DTO (`auto_deliver`, additive since wicked-core-ts
+ *  0.7.24): a boolean when the engine knows the deliver gate, `null` when it predates it. */
+export function autoDeliverOf(session: unknown): boolean | null {
+  if (typeof session !== 'object' || session === null) return null;
+  const v = (session as { auto_deliver?: unknown }).auto_deliver;
+  return typeof v === 'boolean' ? v : null;
 }
 
 /** Whether `prompt` is the engine's PRE-RUN gate on the run's first unit — the intake gate. */
@@ -41,7 +55,7 @@ function executorOf(unit: WorkUnit, phase: WorkflowDef['phases'][number] | undef
   return 'agent';
 }
 
-export function IntakePlan({ runId, units, clis, workflow }: IntakePlanProps): React.ReactElement | null {
+export function IntakePlan({ runId, units, clis, workflow, autoDeliver }: IntakePlanProps): React.ReactElement | null {
   if (units.length === 0) return null;
   const ordered = [...units].sort((a, b) => a.ord - b.ord);
   const pool = (clis ?? []).filter((c) => c !== '');
@@ -86,6 +100,20 @@ export function IntakePlan({ runId, units, clis, workflow }: IntakePlanProps): R
               )}
               {(u.role === 'evaluator' || phase?.role === 'evaluator') && (
                 <span style={{ color: 'var(--status-gate)' }}>evaluator ≠ creator</span>
+              )}
+              {/* F-E2E-030: the deliver phase is the step that leaves the machine — say, on the
+                  plan the operator approves, whether a human confirms it first. Silent when the
+                  engine predates the gate (no false promise). */}
+              {executor === 'tool' && name === 'deliver' && typeof autoDeliver === 'boolean' && (
+                <span
+                  data-testid="intake-plan-deliver-gate"
+                  data-deliver-gate={autoDeliver ? 'auto' : 'human'}
+                  style={{ color: autoDeliver ? 'var(--status-run)' : 'var(--status-gate)' }}
+                >
+                  {autoDeliver
+                    ? 'auto-deliver — pushes its branch + opens the PR with no gate'
+                    : 'human gate before it pushes its branch + opens the PR'}
+                </span>
               )}
               <span data-testid="intake-plan-seat" style={{ color: seat ? 'var(--ink-high)' : 'var(--ink-dim)' }}>
                 {seat

--- a/src/components/SteeringGate.tsx
+++ b/src/components/SteeringGate.tsx
@@ -34,6 +34,9 @@ interface Props {
   /** The workflow def the run was planned from, when the host knows it (`GET /workflows`) — the
    *  intake plan (F-7R2-008) reads executor / skill / role vocabulary off it. */
   workflow?: WorkflowDef | null;
+  /** The run's deliver posture (`session.auto_deliver`, F-E2E-030) for the intake plan's deliver
+   *  row; `null`/absent = the engine predates the deliver gate. */
+  autoDeliver?: boolean | null;
   onResolved?: () => void;
 }
 
@@ -57,7 +60,7 @@ function coverageLabel(r: CoverageReport): string {
   return `Coverage: ${pct} · ${r.behavior_bearing.toLocaleString()} nodes · ${r.unaccounted} unaccounted${resolvedPct}`;
 }
 
-export function SteeringGate({ runId, ord, prompt, guidance, repoRef, units, clis, workflow, onResolved }: Props): React.ReactElement {
+export function SteeringGate({ runId, ord, prompt, guidance, repoRef, units, clis, workflow, onResolved, autoDeliver }: Props): React.ReactElement {
   const clearGate = useGateStore((s) => s.clearGate);
   const recordSteering = useSteeringStore((s) => s.record);
   // F-7R2-008: the intake gate — the engine's pre-run gate on the run's FIRST unit — renders the
@@ -324,7 +327,7 @@ export function SteeringGate({ runId, ord, prompt, guidance, repoRef, units, cli
           planned phase with its executor, skill and seat — what "approve" launches — instead of the
           brief echoed back. Read off the run's units snapshot (+ the def when the host knows it). */}
       {intake && (
-        <IntakePlan runId={runId} units={units ?? EMPTY_UNITS} clis={pool ?? undefined} workflow={workflow ?? null} />
+        <IntakePlan runId={runId} units={units ?? EMPTY_UNITS} clis={pool ?? undefined} workflow={workflow ?? null} autoDeliver={autoDeliver ?? null} />
       )}
 
       {/* The evaluator verdict this gate is about (F-3R2-006): pass/deny, criterion, the judge's

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -11,8 +11,8 @@
   "studioVersion": "0.5.8",
   "counts": {
     "files": 146,
-    "occurrences": 1309,
-    "static": 1127,
+    "occurrences": 1311,
+    "static": 1129,
     "dynamic": 61,
     "computed": 7
   },
@@ -2718,6 +2718,12 @@
       ]
     },
     {
+      "testId": "intake-plan-deliver-gate",
+      "files": [
+        "src/components/IntakePlan.tsx"
+      ]
+    },
+    {
       "testId": "intake-plan-seat",
       "files": [
         "src/components/IntakePlan.tsx"
@@ -2767,6 +2773,12 @@
     },
     {
       "testId": "launch-confirm",
+      "files": [
+        "src/components/ChatInput.tsx"
+      ]
+    },
+    {
+      "testId": "launch-confirm-deliver",
       "files": [
         "src/components/ChatInput.tsx"
       ]

--- a/tests/ChatInput.deliver.test.tsx
+++ b/tests/ChatInput.deliver.test.tsx
@@ -94,6 +94,51 @@ describe('ChatInput delivery (#123)', () => {
     expect(body.repoRef).toBe('studio-api');
   });
 
+  // F-E2E-030 — the deliver gate: the default posture promises the gate and sends no opt-out;
+  // only the explicitly unattended "No gates" posture sends `deliverGate: 'auto'`, and it is
+  // named auto-deliver wherever the composer shows it.
+  it('the default posture keeps the deliver gate: the notice says so, the confirm line says so, the body sends no opt-out', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
+    await bind(user, { workflow: 'feature', repo: 'studio-api' });
+
+    const notice = screen.getByTestId('deliver-notice');
+    expect(notice.dataset.deliverGate).toBe('human');
+    expect(notice.textContent).toMatch(/pauses at the deliver gate/i);
+    expect(notice.textContent).not.toMatch(/auto-deliver/i);
+    expect(screen.getByTestId('launch-confirm-deliver').textContent).toMatch(/after you approve the deliver gate/i);
+    expect(screen.getByTestId('launch-confirm-deliver').dataset.deliverGate).toBe('human');
+    // The "No gates" option is labelled as the auto-deliver opt-out while this launch delivers.
+    expect(screen.getByRole('option', { name: /No gates · auto-deliver/ })).toBeInTheDocument();
+
+    await send(user, 'ship the archive control');
+    await waitFor(() => expect(client.api.launchRun).toHaveBeenCalledTimes(1));
+    const body = sentBody();
+    expect(body.deliver).toBe('pr');
+    expect(body.deliverGate).toBeUndefined();
+    expect(body.humanConfirm).toBe('before:1');
+  });
+
+  it('"No gates" is the explicit opt-out: named auto-deliver before Send, and the body carries deliverGate: auto', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
+    await bind(user, { workflow: 'feature', repo: 'studio-api' });
+    await user.selectOptions(screen.getByTestId('gate-posture'), 'none');
+
+    const notice = screen.getByTestId('deliver-notice');
+    expect(notice.dataset.deliverGate).toBe('auto');
+    expect(notice.textContent).toMatch(/NO deliver gate/);
+    expect(notice.textContent).toMatch(/auto-deliver/i);
+    expect(screen.getByTestId('launch-confirm-deliver').dataset.deliverGate).toBe('auto');
+
+    await send(user, 'ship the archive control');
+    await waitFor(() => expect(client.api.launchRun).toHaveBeenCalledTimes(1));
+    const body = sentBody();
+    expect(body.deliver).toBe('pr');
+    expect(body.deliverGate).toBe('auto');
+    expect(body.humanConfirm).toBeUndefined();
+  });
+
   it('GUARD — no workflow: launches WITHOUT deliver (crew would 400), and names the guard', async () => {
     const user = userEvent.setup();
     render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);

--- a/tests/ChatInput.deliver.test.tsx
+++ b/tests/ChatInput.deliver.test.tsx
@@ -37,6 +37,11 @@ beforeEach(() => {
   });
   vi.spyOn(client.api, 'listProjects').mockResolvedValue({ projects: [] });
   vi.spyOn(client.api, 'launchRun').mockResolvedValue({ runId: 'r-new' });
+  // A daemon that KEEPS the deliver gate (crew ≥ 0.7.33 on core-ts ≥ 0.7.24) — the F-E2E-030
+  // cases below assume it; the capability-absent case overrides this mock.
+  vi.spyOn(client.api, 'getHealth').mockResolvedValue({
+    status: 'ok', version: '0.7.33', ping: 'ok', capabilities: { deliverGate: true },
+  });
   // The default-ON preference, as a fresh install loads it (no stored key).
   useComposerPrefsStore.setState({
     prefs: DEFAULT_COMPOSER_PREFS, loaded: true, persist: 'unknown',
@@ -103,7 +108,7 @@ describe('ChatInput delivery (#123)', () => {
     await bind(user, { workflow: 'feature', repo: 'studio-api' });
 
     const notice = screen.getByTestId('deliver-notice');
-    expect(notice.dataset.deliverGate).toBe('human');
+    await waitFor(() => expect(notice.dataset.deliverGate).toBe('human'));
     expect(notice.textContent).toMatch(/pauses at the deliver gate/i);
     expect(notice.textContent).not.toMatch(/auto-deliver/i);
     expect(screen.getByTestId('launch-confirm-deliver').textContent).toMatch(/after you approve the deliver gate/i);
@@ -126,7 +131,7 @@ describe('ChatInput delivery (#123)', () => {
     await user.selectOptions(screen.getByTestId('gate-posture'), 'none');
 
     const notice = screen.getByTestId('deliver-notice');
-    expect(notice.dataset.deliverGate).toBe('auto');
+    await waitFor(() => expect(notice.dataset.deliverGate).toBe('auto'));
     expect(notice.textContent).toMatch(/NO deliver gate/);
     expect(notice.textContent).toMatch(/auto-deliver/i);
     expect(screen.getByTestId('launch-confirm-deliver').dataset.deliverGate).toBe('auto');
@@ -137,6 +142,66 @@ describe('ChatInput delivery (#123)', () => {
     expect(body.deliver).toBe('pr');
     expect(body.deliverGate).toBe('auto');
     expect(body.humanConfirm).toBeUndefined();
+  });
+
+  it('Autonomous mode is the other explicit opt-out: deliverGate: auto, no humanConfirm (review F-4)', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} mode="autonomous" />);
+    await bind(user, { workflow: 'feature', repo: 'studio-api' });
+    const notice = screen.getByTestId('deliver-notice');
+    await waitFor(() => expect(notice.dataset.deliverGate).toBe('auto'));
+    expect(notice.textContent).toMatch(/auto-deliver/i);
+
+    await send(user, 'ship it unattended');
+    await waitFor(() => expect(client.api.launchRun).toHaveBeenCalledTimes(1));
+    const body = sentBody();
+    expect(body.deliver).toBe('pr');
+    expect(body.deliverGate).toBe('auto');
+    expect(body.humanConfirm).toBeUndefined();
+  });
+
+  it('a daemon WITHOUT the deliver gate gets a truthful notice, and the body never sends deliverGate (review F-2)', async () => {
+    // crew ≤ 0.7.32: `/health` has no `capabilities` — the push follows verify unattended, and the
+    // older launch schema rejects `deliverGate`, so "No gates" must not send it either.
+    vi.mocked(client.api.getHealth).mockResolvedValue({ status: 'ok', version: '0.7.32', ping: 'ok' });
+    const user = userEvent.setup();
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} />);
+    await bind(user, { workflow: 'feature', repo: 'studio-api' });
+    const notice = screen.getByTestId('deliver-notice');
+    await waitFor(() => expect(notice.dataset.deliverGate).toBe('unsupported'));
+    expect(notice.textContent).toMatch(/delivers WITHOUT a deliver gate/);
+    expect(notice.textContent).toMatch(/upgrade crew to 0\.7\.33\+/);
+    expect(notice.textContent).not.toMatch(/pauses at the deliver gate/i);
+    expect(screen.getByTestId('launch-confirm-deliver').dataset.deliverGate).toBe('unsupported');
+    expect(screen.getByTestId('launch-confirm-deliver').textContent).toMatch(/no gate on this daemon/i);
+    // The opt-out label is not offered — there is nothing to opt out of.
+    expect(screen.queryByRole('option', { name: /auto-deliver/ })).toBeNull();
+    expect(screen.getByRole('option', { name: /^No gates$/ })).toBeInTheDocument();
+
+    await user.selectOptions(screen.getByTestId('gate-posture'), 'none');
+    await send(user, 'ship the archive control');
+    await waitFor(() => expect(client.api.launchRun).toHaveBeenCalledTimes(1));
+    const body = sentBody();
+    expect(body.deliver).toBe('pr');
+    expect(body.deliverGate).toBeUndefined();
+  });
+
+  it('Ask mode ignores the gate select, so "No gates" is not labelled auto-deliver there (review F-3)', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput runId={null} runStatus={null} onLaunched={vi.fn()} mode="ask" />);
+    await bind(user, { workflow: 'feature', repo: 'studio-api' });
+    const notice = screen.getByTestId('deliver-notice');
+    await waitFor(() => expect(notice.dataset.deliverGate).toBe('human'));
+    expect(screen.queryByRole('option', { name: /auto-deliver/ })).toBeNull();
+    expect(screen.getByRole('option', { name: /^No gates$/ })).toBeInTheDocument();
+    // Selecting it changes nothing: Ask gates every unit, the deliver gate included.
+    await user.selectOptions(screen.getByTestId('gate-posture'), 'none');
+    expect(notice.dataset.deliverGate).toBe('human');
+    await send(user, 'ship it, asking first');
+    await waitFor(() => expect(client.api.launchRun).toHaveBeenCalledTimes(1));
+    const body = sentBody();
+    expect(body.humanConfirm).toBe('all');
+    expect(body.deliverGate).toBeUndefined();
   });
 
   it('GUARD — no workflow: launches WITHOUT deliver (crew would 400), and names the guard', async () => {

--- a/tests/ChatPanel.dock.test.tsx
+++ b/tests/ChatPanel.dock.test.tsx
@@ -33,6 +33,38 @@ function renderPanel(v = gatedView()): void {
   render(<ChatPanel view={v} onLaunched={vi.fn()} onNavigateBack={vi.fn()} onRefresh={vi.fn()} />);
 }
 
+describe('ApprovalDock → SteeringGate → IntakePlan deliver-gate pass-through (F-E2E-030, review F-4)', () => {
+  const intakeUnits = () => [
+    makeUnit({ id: 'run-1:fix', ord: 1, stage: 'build', status: 'pending', assigned_cli: 'claude' }),
+    makeUnit({ id: 'run-1:deliver', ord: 2, stage: 'build', status: 'pending', assigned_cli: null, tool_cmd: ['bash', '-lc', 'echo deliver'] }),
+  ];
+  const openIntakeGate = (): void => {
+    act(() => {
+      useGateStore.setState({
+        gates: { 'run-1': { runId: 'run-1', ord: 1, prompt: 'Approve unit 1 before it runs: fix', lifecycle: 'open', receivedAt: 0 } },
+        approaching: {},
+      });
+    });
+  };
+
+  it('a session with auto_deliver: false reaches the intake plan as "human gate before it pushes"', () => {
+    openIntakeGate();
+    const v = makeView({ status: 'awaiting_human', unit_ix: 0 }, intakeUnits());
+    (v.session as unknown as { auto_deliver: boolean }).auto_deliver = false;
+    renderPanel(v);
+    const row = screen.getByTestId('intake-plan-deliver-gate');
+    expect(row.dataset.deliverGate).toBe('human');
+    expect(screen.getByTestId('approval-dock').contains(row)).toBe(true);
+  });
+
+  it('a session from an engine that predates the gate (no auto_deliver) promises nothing', () => {
+    openIntakeGate();
+    renderPanel(makeView({ status: 'awaiting_human', unit_ix: 0 }, intakeUnits()));
+    expect(screen.getByTestId('intake-plan')).toBeInTheDocument();
+    expect(screen.queryByTestId('intake-plan-deliver-gate')).toBeNull();
+  });
+});
+
 describe('ApprovalDock — pinned, never scrolls away', () => {
   it('renders the gate card in the dock, as a SIBLING of the scroll region (never inside it)', () => {
     act(() => {

--- a/tests/IntakePlan.deliverGate.test.tsx
+++ b/tests/IntakePlan.deliverGate.test.tsx
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { IntakePlan, autoDeliverOf } from '../src/components/IntakePlan.js';
+import type { WorkUnit } from '../src/api/types.js';
+
+/**
+ * F-E2E-030 — the plan the operator approves at the intake gate names whether a HUMAN confirms
+ * the deliver phase (the push + PR) before it runs: `session.auto_deliver === false` ⇒ "human gate
+ * before it pushes"; `true` ⇒ "auto-deliver … no gate"; absent (an engine that predates the gate)
+ * ⇒ nothing — no false promise.
+ */
+
+const RUN = 'run-1';
+
+function unit(ord: number, phase: string, tool: boolean): WorkUnit {
+  return {
+    id: `${RUN}:${phase}`,
+    session_id: RUN,
+    ord,
+    description: phase,
+    stage: tool ? 'build' : 'recon',
+    assigned_cli: tool ? null : 'claude',
+    status: 'pending',
+    ...(tool ? { tool_cmd: ['bash', '-lc', 'echo deliver'] } : {}),
+  } as unknown as WorkUnit;
+}
+
+const UNITS = [unit(1, 'triage', false), unit(2, 'fix', false), unit(3, 'deliver', true)];
+
+describe('IntakePlan — the deliver phase names its gate (F-E2E-030)', () => {
+  it('auto_deliver: false ⇒ "human gate before it pushes"', () => {
+    render(<IntakePlan runId={RUN} units={UNITS} autoDeliver={false} />);
+    const row = screen.getByTestId('intake-plan-deliver-gate');
+    expect(row.dataset.deliverGate).toBe('human');
+    expect(row.textContent).toMatch(/human gate before it pushes/i);
+    // Only the deliver row carries it.
+    expect(screen.getAllByTestId('intake-plan-deliver-gate')).toHaveLength(1);
+  });
+
+  it('auto_deliver: true ⇒ "auto-deliver … no gate"', () => {
+    render(<IntakePlan runId={RUN} units={UNITS} autoDeliver />);
+    const row = screen.getByTestId('intake-plan-deliver-gate');
+    expect(row.dataset.deliverGate).toBe('auto');
+    expect(row.textContent).toMatch(/auto-deliver/i);
+    expect(row.textContent).toMatch(/no gate/i);
+  });
+
+  it('an engine that predates the gate (no auto_deliver on the session) promises nothing', () => {
+    render(<IntakePlan runId={RUN} units={UNITS} autoDeliver={null} />);
+    expect(screen.queryByTestId('intake-plan-deliver-gate')).toBeNull();
+    render(<IntakePlan runId={RUN} units={UNITS} />);
+    expect(screen.queryByTestId('intake-plan-deliver-gate')).toBeNull();
+  });
+
+  it('autoDeliverOf reads the additive session field and nothing else', () => {
+    expect(autoDeliverOf({ auto_deliver: false })).toBe(false);
+    expect(autoDeliverOf({ auto_deliver: true })).toBe(true);
+    expect(autoDeliverOf({})).toBeNull();
+    expect(autoDeliverOf({ auto_deliver: 'yes' })).toBeNull();
+    expect(autoDeliverOf(null)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Why

**F-E2E-030 (HIGH, governance).** In the clean end-to-end acceptance run, `0ab5ccb8` was launched from this composer under its default posture ("gate: first gate" → `humanConfirm: 'before:1'`). The deliver notice read *"When this finishes it pushes its branch → opens a PR on wicked-studio. Merging stays yours."* — and that is exactly what happened: the intake gate was the only human gate, verify passed, and the run pushed and opened #268 **with no human confirmation**, under whatever `gh` account the daemon held. The notice disclosed the push; nothing let the operator confirm it.

## Root cause

The posture select maps to the engine's run-level `human_confirm` (`before:1` gates unit 1 only); the deliver phase crew composes is `gate: 'auto'`; the engine had no notion of the deliver unit needing its own confirmation. Fixed at the engine (wicked-core#456: the deliver unit pauses unless the launch says `autoDeliver: true`) and on the crew wire (wicked-crew#543: `deliverGate: 'human' | 'auto'` on `POST /runs`). This PR is the composer/run-page half: say WHEN the push happens, and make the opt-out explicit and named.

## What changed

- **Composer (`ChatInput.tsx`).** `autoDeliver = mode === 'autonomous' || (mode !== 'ask' && confirmMode === 'none')`. Default postures ("First gate" / "Every unit"): the notice reads *"When this finishes it pauses at the deliver gate; approve it and the run pushes its branch → opens a PR on <repo>. Merging stays yours."*, the confirm line gains `· deliver: after you approve the deliver gate` (`launch-confirm-deliver`, `data-deliver-gate="human"`), and the body carries **no** `deliverGate` (the engine's default is the gate). Explicitly unattended postures: the gate option is relabelled **"No gates · auto-deliver"** while the launch delivers, the notice reads *"… with NO deliver gate — this posture is auto-deliver"*, the confirm line reads `deliver: auto — no gate before the push`, and the body sends `deliverGate: 'auto'` (only together with `deliver: 'pr'`). `deliver-notice` gains `data-deliver-gate`.
- **Intake plan (`IntakePlan.tsx`, `SteeringGate.tsx`, `ApprovalDock.tsx`).** The deliver row (Tool executor, phase `deliver`) names its gate from `session.auto_deliver` (`autoDeliverOf(session)`): *"human gate before it pushes its branch + opens the PR"* / *"auto-deliver — pushes its branch + opens the PR with no gate"* (`intake-plan-deliver-gate`). Absent field (an engine that predates the gate) ⇒ nothing rendered — no promise the engine cannot keep.
- `LaunchBodyWithDeliver` hand-declares `deliverGate` (like `deliver`; delete on the ≥0.37 api-types bump). `testid-inventory.json` regenerated for the two new testids.

## Review follow-up (verdict on #269, landed as one commit)

- **F-2 (MEDIUM)** — the pre-launch promise is now gated on daemon capability: the composer reads `GET /health.capabilities.deliverGate` (crew #543, ≥ 0.7.33) once on mount. `true` ⇒ the gate copy; `false`/absent ⇒ *"this daemon delivers WITHOUT a deliver gate (upgrade crew to 0.7.33+ to confirm the push first)"* on the notice, `no gate on this daemon (upgrade crew to 0.7.33+)` on the confirm line, NO auto-deliver option, and the body never sends `deliverGate` (the older launch schema is `.strict()`); unknown (read pending/failed) ⇒ the neutral pre-fix wording. `data-deliver-gate` ∈ `human | auto | unsupported | unknown`. `capabilities` is hand-declared on the health client type (provisional, like `deliver`/`deliverGate` on the launch body) until the api-types 0.37.0 pin lands in the release train.
- **F-3 (LOW)** — "No gates · auto-deliver" is shown only where the select is honoured (`mode !== 'ask'`, and only with a capable daemon); Ask mode shows plain "No gates".
- **F-4 (LOW)** — tests: Autonomous ⇒ `deliverGate: 'auto'`, no `humanConfirm`; `ChatPanel.dock`: a view with `session.auto_deliver: false` at the intake gate renders the human deliver row inside the dock, a session without the field renders no row.

## Tests

- `tests/ChatInput.deliver.test.tsx`: the default posture keeps the gate (notice, confirm line, option label, body without `deliverGate`, `humanConfirm: before:1`); "No gates" sends `deliverGate: 'auto'` and is named auto-deliver; Autonomous sends `deliverGate: 'auto'`; a daemon without the capability gets the truthful notice and never `deliverGate`; Ask mode shows plain "No gates" and sends `humanConfirm: all`.
- `tests/IntakePlan.deliverGate.test.tsx` (new): `false` ⇒ human gate row, `true` ⇒ auto-deliver row, `null`/absent ⇒ no row; `autoDeliverOf` reads only a boolean `auto_deliver`.
- `tests/ChatPanel.dock.test.tsx`: ApprovalDock → SteeringGate → IntakePlan `auto_deliver` pass-through (+2).
- `tests/testidInventory.test.ts` green (no new ids in the follow-up; zero drift). Local: `vitest run` on the deliver / dock / target / SteeringGate / IntakePlan suites (49 passed), `tsc --noEmit` (0), `eslint` on touched files (clean).

## CI note

Independent of the crew/core PRs at build time (the wire field is hand-declared on the studio type; the run-page read is a narrowing helper). Behaviourally the gate exists once crew 0.7.33 ships on core-ts 0.7.24; against an older daemon the composer's `deliverGate` is rejected with a 400 only when `'auto'` is sent (the default body is unchanged), and the run page renders no gate row. No version bump (coordinator cuts 0.5.9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
