### PR TITLE
chore(wire): pin wicked-crew-api-types 0.37.0 and re-vendor the skills + wave-6 mirrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,18 @@ npm publish dates. Every version listed here exists on
   never sends `deliverGate` (the older launch schema rejects it). "No gates" is labelled
   auto-deliver only where the select is honoured (not in Ask mode, where every unit is gated).
 
+### Changed
+- **Pin `wicked-crew-api-types` 0.37.0** (the deliver-gate wire, crew#543) and re-vendor both wire
+  mirrors from the installed `index.d.ts`. Built against api-types 0.37.0: `HealthResponse`
+  (`GET /health`, previously undeclared) with `capabilities.deliverGate`, `LaunchRunBody.deliverGate:
+  'human' | 'auto'`, and `AgentSession.auto_deliver` — the three shapes #269 hand-declared as
+  "≥ 0.37" in `src/api/client.ts` (`getHealth`) and `src/api/types.ts` (`LaunchBodyWithDeliver`) now
+  come from the package, and `tests/deliverGateWire.test.ts` pins them to the installed `index.d.ts`
+  (compile-time `satisfies` + the declaration lines) so a pin that loses them fails the suite. 0.37.0
+  is ADDITIVE and touches neither the skills block nor the wave-6 shapes: all 16 VERBATIM regions of
+  `src/api/skills-wire.ts` (+ its fixture, now `tests/fixtures/api-types-0.37.0-skills.d.ts`;
+  `index.d.ts:1995-2445` / `4720-4779`) and `src/api/wave6-wire.ts` are byte-identical to 0.36.0 and
+  relabelled by line range only (+26 above the `LaunchRunBody` addition, +38 below it).
 
 ## [0.5.8] — 2026-09-12
 _The published bundle is built against `wicked-crew-api-types` **0.36.0** — the exact

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "typescript-eslint": "^8.63.0",
         "vite": "^6.4.3",
         "vitest": "^3.2.6",
-        "wicked-crew-api-types": "0.36.0"
+        "wicked-crew-api-types": "0.37.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -7146,9 +7146,9 @@
       }
     },
     "node_modules/wicked-crew-api-types": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/wicked-crew-api-types/-/wicked-crew-api-types-0.36.0.tgz",
-      "integrity": "sha512-Up3DT3A95w3VeFiG3vPzz7jjrwiZS4VtiAJq5QZ4nUagpROh5zjA782o7vhxUyMDqBO0hZGPSZzDngfdI7LgPw==",
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/wicked-crew-api-types/-/wicked-crew-api-types-0.37.0.tgz",
+      "integrity": "sha512-TaJ9NbNsdUoGy6ZQEDFyA/Ogqp+soAVxLF0uW/UwjvAo1ClwXD++V54+tnI7qQ0U63nsPRyoNq2HhHyKxmDE0Q==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "typescript-eslint": "^8.63.0",
     "vite": "^6.4.3",
     "vitest": "^3.2.6",
-    "wicked-crew-api-types": "0.36.0"
+    "wicked-crew-api-types": "0.37.0"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -11,6 +11,7 @@ import type {
   DeliverRunResult,
   GateDecision,
   GateInfo,
+  HealthResponse,
   LaunchBodyWithDeliver,
   OnboardRef,
   OpenTerminalBody,
@@ -331,12 +332,10 @@ export const api = {
   rerunOnboarding: (repoId: string) =>
     apiFetch<{ runId: string }>(`/repos/${encodeURIComponent(repoId)}/onboard`, { method: 'POST' }),
 
-  /** Liveness (also proves the actor + event pump are up). */
-  // `capabilities` is hand-declared until the api-types 0.37.0 pin lands (`HealthResponse` there):
-  // `deliverGate` — the daemon's engine pauses before the deliver phase pushes (F-E2E-030). Absent
-  // on a daemon before crew 0.7.33 ⇒ delivery follows verify unattended.
-  getHealth: () =>
-    apiFetch<{ status: string; version: string; ping: string; capabilities?: { deliverGate?: boolean } }>('/health'),
+  /** Liveness (also proves the actor + event pump are up). `HealthResponse` (api-types 0.37.0):
+   *  `capabilities.deliverGate` — the daemon's engine pauses before the deliver phase pushes
+   *  (F-E2E-030); absent on a daemon before crew 0.7.33 ⇒ delivery follows verify unattended. */
+  getHealth: () => apiFetch<HealthResponse>('/health'),
 
   /**
    * Open a PTY terminal session → its id. Drive it over the terminal WS

--- a/src/api/skills-wire.ts
+++ b/src/api/skills-wire.ts
@@ -1,5 +1,5 @@
 /**
- * MIRROR of wicked-crew-api-types 0.36.0 skills block (crew#531, crew#535) — replace with imports from the
+ * MIRROR of wicked-crew-api-types 0.37.0 skills block (crew#531, crew#535) — replace with imports from the
  * published package at release.
  *
  * Studio pins `wicked-crew-api-types` exactly; the skills contract lives in the package's skills
@@ -7,9 +7,12 @@
  * two regions copied VERBATIM from the package's `index.d.ts` between the `>>> VERBATIM` /
  * `<<< VERBATIM` markers. Nothing inside a marked region is studio's wording, and nothing may be
  * edited there: `tests/skillsWire.test.ts` pins each region byte-for-byte against the vendored
- * fixture `tests/fixtures/api-types-0.36.0-skills.d.ts`, so any drift — a hand edit here, or a
+ * fixture `tests/fixtures/api-types-0.37.0-skills.d.ts`, so any drift — a hand edit here, or a
  * re-vendored fixture from a re-minted contract — fails the suite until both sides agree again.
  *
+ * 0.37.0 (crew#543 — the deliver-gate wire: `HealthResponse`, `AgentSession.auto_deliver`,
+ * `LaunchRunBody.deliverGate`) carries the 0.36.0 skills block UNCHANGED — byte-identical, shifted by
+ * those additions above it — so this mirror is re-vendored by label only (line ranges).
  * 0.36.0 (F-083, crew#535, published by crew#536) is ADDITIVE over the 0.35.0 block:
  * `SkillsManifestResponse.current` grows the optional `rules` (`PortabilityRulesIdentity` recorded vs
  * running, `stale`) and `drift` (`SnapshotRowDrift[]` — the rows the RUNNING rules derive
@@ -31,7 +34,7 @@
  * is EXCLUSIVELY a stale `expectedRevision`.
  */
 
-// >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:1969-2419 (crew#535 via crew#536) — the skills block
+// >>> VERBATIM wicked-crew-api-types@0.37.0 index.d.ts:1995-2445 (crew#535 via crew#536) — the skills block
 // ── Skills — the daemon-owned garden plugin root, published as immutable snapshots (api-types 0.28.0) ──
 //
 // api-types 0.29.0 (design amendment v3.6, crew #490): the installer-managed copy
@@ -485,7 +488,7 @@ export interface ReplaceSkillBody {
 }
 // <<< VERBATIM
 
-// >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:4682-4741 (crew#535 via crew#536) — the diagnostics skills block
+// >>> VERBATIM wicked-crew-api-types@0.37.0 index.d.ts:4720-4779 (crew#535 via crew#536) — the diagnostics skills block
 /** The skills seam's state as `GET /diagnostics` reports it (skills keystone, api-types 0.28.0). */
 export type DiagnosticsSkillsState = 'published' | 'fallback' | 'blocked' | 'config-error' | 'disabled';
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -87,16 +87,11 @@ export interface DeliverRunResult {
  * `'pr'` (flippable by the daemon's `deliverDefault` setting), everything else
  * to `'none'`. `'none'` is additive at 0.18.0: older daemons 400 on it, so the
  * composer only sends the key where it would have been licensed to send `'pr'`.
+ * `deliverGate: 'human' | 'auto'` (F-E2E-030; api-types 0.37.0) needs no hand-declaration: it rides
+ * `LaunchRunBody` itself and survives the `Omit` — `tests/deliverGateWire.test.ts` pins it.
  */
 export type LaunchBodyWithDeliver = Omit<LaunchRunBody, 'deliver'> & {
   deliver?: 'pr' | 'none';
-  /**
-   * Who confirms the deliver phase (F-E2E-030; crew ≥ 0.7.33 / api-types ≥ 0.37): the ENGINE
-   * gates the push + PR by default (`'human'`, or omitted); `'auto'` is the operator's EXPLICIT
-   * opt-out, sent only for the postures the composer names "auto-deliver" (No gates,
-   * Autonomous). Hand-declared here like `deliver` — delete on the ≥0.37 api-types bump.
-   */
-  deliverGate?: 'human' | 'auto';
   /**
    * Ad-hoc campaign attach (wicked-studio#27; api-types 0.19.0): file this run onto an
    * EXISTING campaign's surface. Provenance only — the run executes byte-identically, never

--- a/src/api/wave6-wire.ts
+++ b/src/api/wave6-wire.ts
@@ -1,9 +1,11 @@
 /**
- * MIRROR of the wicked-crew-api-types 0.36.0 wave-6 additions (the governed testing journey —
+ * MIRROR of the wicked-crew-api-types 0.37.0 wave-6 additions (the governed testing journey —
  * crew#536, the wave-6 crew PR; `skills.stale-rules` from crew#535) — replace with imports from the
  * published package at release.
  *
- * Studio pins `wicked-crew-api-types` exactly (0.36.0). Every declaration below that is a contract
+ * Studio pins `wicked-crew-api-types` exactly (0.37.0 — crew#543's deliver-gate additions leave every
+ * wave-6 shape byte-identical to 0.36.0; the regions below are relabelled by line range only). Every
+ * declaration below that is a contract
  * shape is a region copied VERBATIM from the package's `index.d.ts` between `>>> VERBATIM` /
  * `<<< VERBATIM` markers, labelled with the version and the 1-based line range it was cut from.
  * Nothing inside a marked region is studio's wording, and nothing may be edited there:
@@ -68,7 +70,7 @@ import type {
 
 // ── The QE authoring workflow — `POST /testing/author`, the plan, the registered test set ──────
 
-// >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:2801-2941 (crew#536) — the governed test-authoring launch: QeAuthorTestsWorkflowId, TestingAuthorBody, WorkflowPlanPhase, WorkflowPlan, TestingAuthorRun, TestingAuthorResponse, TestSetFile, TestSet
+// >>> VERBATIM wicked-crew-api-types@0.37.0 index.d.ts:2827-2967 (crew#536) — the governed test-authoring launch: QeAuthorTestsWorkflowId, TestingAuthorBody, WorkflowPlanPhase, WorkflowPlan, TestingAuthorRun, TestingAuthorResponse, TestSetFile, TestSet
 // ── The governed test-authoring launch (wave 6; api-types 0.36.0) ──────────────────────────────
 
 /**
@@ -213,7 +215,7 @@ export interface TestSet {
 // <<< VERBATIM
 
 /** The recon body, vendored as EVIDENCE: no `workflow` key — studio's launch ladder sends none. */
-// >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:2745-2778 (crew#536) — TestingReconBody (no `workflow` key)
+// >>> VERBATIM wicked-crew-api-types@0.37.0 index.d.ts:2771-2804 (crew#536) — TestingReconBody (no `workflow` key)
 /**
  * The `POST /testing/recon` request body (api-types 0.15.0) — the Testing page's campaign-recon
  * trigger. `problem` is the recon brief, passed to every launched run VERBATIM (the client owns
@@ -256,7 +258,7 @@ export const QE_AUTHOR_TESTS_WORKFLOW_ID = 'qe-author-tests' satisfies QeAuthorT
 
 // ── The campaigns surface — where the registered sets are served ──────────────────────────────
 
-// >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:4396-4407 (crew#536) — CampaignsListResponse incl. test_sets
+// >>> VERBATIM wicked-crew-api-types@0.37.0 index.d.ts:4434-4445 (crew#536) — CampaignsListResponse incl. test_sets
 /**
  * `GET /campaigns` 200 body (api-types 0.19.0 — `groups` is ADDITIVE: a pre-0.19 daemon sends
  * only `campaigns`). One fetch answers the whole grouping surface: engine campaigns (each
@@ -273,7 +275,7 @@ export interface CampaignsListResponse {
 
 // ── The diff route once the worktree is gone ──────────────────────────────────────────────────
 
-// >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:553-580 (crew#536) — RunDiff incl. source / branch / base
+// >>> VERBATIM wicked-crew-api-types@0.37.0 index.d.ts:579-606 (crew#536) — RunDiff incl. source / branch / base
 /**
  * Response of `GET /runs/:id/diff` / `GET /runs/:id/diff?path=<abs>` (DES-FEEDBACK-002 CREW-1) —
  * the run worktree's unified diff against HEAD (staged + unstaged), with untracked files appended
@@ -309,7 +311,7 @@ export type RunDiffSource = NonNullable<RunDiff['source']>;
 
 // ── Gate / floor / routing / fence / carrier / base events ────────────────────────────────────
 
-// >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:1008-1059 (crew#536) — GateEvaluatedEvent incl. ungated / ungatedReason / floorNote / judgeSkippedReason
+// >>> VERBATIM wicked-crew-api-types@0.37.0 index.d.ts:1034-1085 (crew#536) — GateEvaluatedEvent incl. ungated / ungatedReason / floorNote / judgeSkippedReason
 /** §3 B1 — the gate's decision depth, emitted alongside `gateDecided`. `denial` is the structured
  *  twin of `denialReason`: `null` when the gate approved, else the winning layer (deny-dominates) —
  *  `worktree_guard` and `repo_checks` are the two wicked-core F-036/F-039 layers. `judgeCli` /
@@ -364,7 +366,7 @@ export interface GateEvaluatedEvent {
 }
 // <<< VERBATIM
 
-// >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:1328-1385 (crew#536) — RepoChecksEvaluatedEvent incl. sandboxLevel / sandboxError / detectError
+// >>> VERBATIM wicked-crew-api-types@0.37.0 index.d.ts:1354-1411 (crew#536) — RepoChecksEvaluatedEvent incl. sandboxLevel / sandboxError / detectError
 /** wicked-core F-039 — the engine ran the repository's OWN checks in the worktree for the def's
  *  code-verifying unit (`verified_evidence` with an `executes_code` creator upstream: `bug/verify`,
  *  `feature/test`, `migration/verify`) and folded them into the gate as a deterministic floor. Fires
@@ -425,7 +427,7 @@ export type RepoChecksEvaluatedEvent = {
 };
 // <<< VERBATIM
 
-// >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:1645-1703 (crew#536) — UnitDistributedEvent (camelCase) + BenchedSeat
+// >>> VERBATIM wicked-crew-api-types@0.37.0 index.d.ts:1671-1729 (crew#536) — UnitDistributedEvent (camelCase) + BenchedSeat
 /**
  * Foundation wave: a unit was distributed with full routing detail.
  *
@@ -487,7 +489,7 @@ export interface BenchedSeat {
 }
 // <<< VERBATIM
 
-// >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:1535-1565 (crew#536) — WorkerToolCallDeniedEvent
+// >>> VERBATIM wicked-crew-api-types@0.37.0 index.d.ts:1561-1591 (crew#536) — WorkerToolCallDeniedEvent
 /**
  * Wave 6 (F-7R2-012, api-types 0.36.0) — a WORKER seat asked to run a REMOTE-WRITING command
  * (`git push`, `gh pr create|merge|edit|comment`, a `gh api` mutation, `gh release`, …) and the
@@ -521,7 +523,7 @@ export type WorkerToolCallDeniedEvent = {
 };
 // <<< VERBATIM
 
-// >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:1108-1144 (crew#536) — AcpFallbackKind incl. the auth kinds + AcpFallbackEvent
+// >>> VERBATIM wicked-crew-api-types@0.37.0 index.d.ts:1134-1170 (crew#536) — AcpFallbackKind incl. the auth kinds + AcpFallbackEvent
 /**
  * `acpFallback.fallbackKind` — WHY a unit left the ACP carrier for the wrapped (single-shot) one:
  * - `binary_unavailable` / `session_died` / `auth_required` — the ACP session could not be had; the
@@ -561,7 +563,7 @@ export interface AcpFallbackEvent {
 }
 // <<< VERBATIM
 
-// >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:1500-1528 (crew#536) — RunBaseResolvedEvent incl. runBranch
+// >>> VERBATIM wicked-crew-api-types@0.37.0 index.d.ts:1526-1554 (crew#536) — RunBaseResolvedEvent incl. runBranch
 /** wicked-core#431 / F-3R2-013 — how the run's BASE commit was chosen when its worktree was minted:
  *  the engine fetches `origin` and, when the registered clone's `HEAD` is strictly behind the remote
  *  default branch's tip, bases the run on that tip — so the worker starts from the current code and
@@ -595,7 +597,7 @@ export type RunBaseResolvedEvent = {
 
 // ── The roster — auth, free tier, council eligibility, the bench ──────────────────────────────
 
-// >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:424-521 (crew#536) — RosterSeat incl. auth / auth_source / free_tier_source / council_eligible / council_bench + RosterSeatCouncilBench + SeatAuth
+// >>> VERBATIM wicked-crew-api-types@0.37.0 index.d.ts:450-547 (crew#536) — RosterSeat incl. auth / auth_source / free_tier_source / council_eligible / council_bench + RosterSeatCouncilBench + SeatAuth
 /**
  * A council seat (`AgenticCli`) as returned by `GET /roster`. Only the fields
  * the launch form uses are named; the index signature keeps the (large) rest of
@@ -698,7 +700,7 @@ export type SeatAuth = 'signed_in' | 'signed_out' | 'not_required' | 'unknown';
 
 // ── Chat admission — the refused seats and why ────────────────────────────────────────────────
 
-// >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:3917-3978 (crew#536) — ChatSeatOutcome, ChatRefusalSource, ChatSeatRefusal, ChatOpenResponse incl. refused[], ChatSeatRefusedFrame
+// >>> VERBATIM wicked-crew-api-types@0.37.0 index.d.ts:3955-4016 (crew#536) — ChatSeatOutcome, ChatRefusalSource, ChatSeatRefusal, ChatOpenResponse incl. refused[], ChatSeatRefusedFrame
 /** One seat's warm-up outcome on `POST /chats`. */
 export interface ChatSeatOutcome {
   cliKey: string;
@@ -763,7 +765,7 @@ export type ChatSeatRefusedFrame = {
 };
 // <<< VERBATIM
 
-// >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:4000-4010 (crew#536) — ChatDetailResponse incl. refused[]
+// >>> VERBATIM wicked-crew-api-types@0.37.0 index.d.ts:4038-4048 (crew#536) — ChatDetailResponse incl. refused[]
 /** `GET /chats/:id` → 200. */
 export interface ChatDetailResponse {
   chatId: string;
@@ -779,7 +781,7 @@ export interface ChatDetailResponse {
 
 // ── The daemon-wide docs listing (no bridge spawn) ────────────────────────────────────────────
 
-// >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:3741-3795 (crew#536) — GET /interactive/docs: InteractiveDocsListing, InteractiveSeamKind, InteractiveDocIndexRow, InteractiveDocsUnreachable
+// >>> VERBATIM wicked-crew-api-types@0.37.0 index.d.ts:3779-3833 (crew#536) — GET /interactive/docs: InteractiveDocsListing, InteractiveSeamKind, InteractiveDocIndexRow, InteractiveDocsUnreachable
 /**
  * `GET /api/v1/interactive/docs` (api-types 0.36.0, studio #263) — every interactive document across
  * projects, listed by the DAEMON from disk WITHOUT spawning a bridge: each project's docs root

--- a/src/components/IntakePlan.tsx
+++ b/src/components/IntakePlan.tsx
@@ -32,8 +32,9 @@ export interface IntakePlanProps {
   autoDeliver?: boolean | null | undefined;
 }
 
-/** The run's deliver posture off the session DTO (`auto_deliver`, additive since wicked-core-ts
- *  0.7.24): a boolean when the engine knows the deliver gate, `null` when it predates it. */
+/** The run's deliver posture off the session DTO (`AgentSession.auto_deliver`, additive since
+ *  wicked-core-ts 0.7.24 / api-types 0.37.0): a boolean when the engine knows the deliver gate,
+ *  `null` when it predates it. Null-safe on ANY frame — an older daemon's DTO has no key. */
 export function autoDeliverOf(session: unknown): boolean | null {
   if (typeof session !== 'object' || session === null) return null;
   const v = (session as { auto_deliver?: unknown }).auto_deliver;

--- a/tests/ChatPanel.dock.test.tsx
+++ b/tests/ChatPanel.dock.test.tsx
@@ -49,9 +49,8 @@ describe('ApprovalDock → SteeringGate → IntakePlan deliver-gate pass-through
 
   it('a session with auto_deliver: false reaches the intake plan as "human gate before it pushes"', () => {
     openIntakeGate();
-    const v = makeView({ status: 'awaiting_human', unit_ix: 0 }, intakeUnits());
-    (v.session as unknown as { auto_deliver: boolean }).auto_deliver = false;
-    renderPanel(v);
+    // `auto_deliver` is declared on `AgentSession` since api-types 0.37.0 — no cast.
+    renderPanel(makeView({ status: 'awaiting_human', unit_ix: 0, auto_deliver: false }, intakeUnits()));
     const row = screen.getByTestId('intake-plan-deliver-gate');
     expect(row.dataset.deliverGate).toBe('human');
     expect(screen.getByTestId('approval-dock').contains(row)).toBe(true);

--- a/tests/deliverGateWire.test.ts
+++ b/tests/deliverGateWire.test.ts
@@ -1,0 +1,112 @@
+/**
+ * The deliver-gate wire (api-types 0.37.0 — crew#543 / wicked-core#456, acceptance finding F-E2E-030)
+ * against the INSTALLED `wicked-crew-api-types`.
+ *
+ * Studio 0.5.9-pre (#269) hand-declared three "≥ 0.37" shapes while 0.37.0 was unpublished:
+ * `GET /health`'s `capabilities.deliverGate` (in `src/api/client.ts`), `LaunchRunBody.deliverGate`
+ * (on `LaunchBodyWithDeliver` in `src/api/types.ts`) and the `session.auto_deliver` read. At the pin
+ * they come from the package — so, the `wire433.shapes` pattern, two pins, one per compiler.
+ * COMPILE-TIME: the literals below are declared `satisfies` the package's own types (a lost or
+ * re-spelled key is a red `npm run typecheck`). RUN-TIME: the installed `index.d.ts` must declare
+ * each shape at its 0.37.0 spelling, the pin must be exact and ≥ 0.37.0, and the hand-declared
+ * copies must be GONE — a pin bump that regresses below the deliver-gate wire, or a re-mint that
+ * drops a key, fails here and says which.
+ *
+ * @vitest-environment node
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import type { AgentSession, HealthResponse, LaunchBodyWithDeliver, LaunchRunBody } from '../src/api/types.js';
+
+const INSTALLED = fileURLToPath(new URL('../node_modules/wicked-crew-api-types/index.d.ts', import.meta.url));
+const INSTALLED_PKG = fileURLToPath(new URL('../node_modules/wicked-crew-api-types/package.json', import.meta.url));
+const PINNED_PKG = fileURLToPath(new URL('../package.json', import.meta.url));
+const CLIENT_SRC = fileURLToPath(new URL('../src/api/client.ts', import.meta.url));
+const TYPES_SRC = fileURLToPath(new URL('../src/api/types.ts', import.meta.url));
+
+/** The version that published the deliver-gate wire — this suite's floor. */
+const DELIVER_GATE_VERSION = [0, 37, 0] as const;
+
+function semver(v: string): [number, number, number] {
+  const m = /^(\d+)\.(\d+)\.(\d+)/.exec(v);
+  if (m === null) throw new Error(`not a semver: ${v}`);
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+function atLeast(v: string, floor: readonly [number, number, number]): boolean {
+  const [a, b, c] = semver(v);
+  if (a !== floor[0]) return a > floor[0];
+  if (b !== floor[1]) return b > floor[1];
+  return c >= floor[2];
+}
+
+// ── COMPILE-TIME pins — spelled as 0.37.0 publishes them ──────────────────────────────────────
+
+/** A crew ≥ 0.7.33 daemon whose engine (core-ts ≥ 0.7.24) knows the deliver gate. */
+const HEALTH_GATED = { status: 'ok', version: '0.7.33', ping: 'pong', capabilities: { deliverGate: true } } satisfies HealthResponse;
+/** A daemon before the capability — `capabilities` absent; delivery follows verify unattended. */
+const HEALTH_OLDER = { status: 'ok', version: '0.7.32', ping: 'pong' } satisfies HealthResponse;
+/** The composer's explicit opt-out (the "No gates · auto-deliver" / Autonomous postures). */
+const LAUNCH_AUTO = { problem: 'fix the flaky test', repoRef: 'r', deliver: 'pr', deliverGate: 'auto' } satisfies LaunchRunBody;
+/** The default posture spelled out — the engine gates the push whatever `humanConfirm` says. */
+const LAUNCH_HUMAN = { problem: 'fix the flaky test', humanConfirm: 'none', deliverGate: 'human' } satisfies LaunchRunBody;
+/** Studio's launch body keeps the key through the `Omit<LaunchRunBody, 'deliver'>` — no hand-declaration. */
+const STUDIO_BODY: LaunchBodyWithDeliver = { problem: 'fix the flaky test', deliver: 'none', deliverGate: 'auto' };
+/** The run DTO's posture (`false` = the engine pauses before the deliver Tool unit). */
+const SESSION_GATED: Pick<AgentSession, 'auto_deliver'> = { auto_deliver: false };
+const SESSION_PREDATES: Pick<AgentSession, 'auto_deliver'> = {};
+
+/** 0.37.0's declaration lines, verbatim — each must be in the installed `index.d.ts`. */
+const DECLS = [
+  'export interface HealthResponse {',
+  '  capabilities?: { deliverGate: boolean };',
+  '  auto_deliver?: boolean;',
+  "  deliverGate?: 'human' | 'auto';",
+];
+
+const installed = JSON.parse(readFileSync(INSTALLED_PKG, 'utf8')) as { version: string };
+const pinned = (JSON.parse(readFileSync(PINNED_PKG, 'utf8')) as { devDependencies: Record<string, string> }).devDependencies['wicked-crew-api-types']!;
+const installedDts = readFileSync(INSTALLED, 'utf8');
+
+describe('the deliver-gate wire (api-types 0.37.0) — declared by the installed package, not by studio', () => {
+  it('the devDependency is an exact pin equal to the installed version, at or above the deliver-gate floor', () => {
+    expect(pinned).toBe(installed.version);
+    expect(atLeast(installed.version, DELIVER_GATE_VERSION), `${installed.version} ≥ 0.37.0`).toBe(true);
+  });
+
+  it('declares HealthResponse.capabilities.deliverGate, AgentSession.auto_deliver and LaunchRunBody.deliverGate at their 0.37.0 spelling', () => {
+    for (const line of DECLS) expect(installedDts, line).toContain(line);
+    // Each lives in the interface it belongs to.
+    const between = (from: string, to: RegExp): string => {
+      const start = installedDts.indexOf(from);
+      expect(start, from).toBeGreaterThanOrEqual(0);
+      const rest = installedDts.slice(start);
+      return rest.slice(0, rest.search(to));
+    };
+    expect(between('export interface HealthResponse {', /\n}\n/)).toContain('capabilities?: { deliverGate: boolean };');
+    expect(between('export interface AgentSession {', /\n}\n/)).toContain('auto_deliver?: boolean;');
+    expect(between('export interface LaunchRunBody {', /\n}\n/)).toContain("deliverGate?: 'human' | 'auto';");
+  });
+
+  it('the hand-declared "≥ 0.37" copies are gone: client.ts reads HealthResponse, types.ts declares no deliverGate', () => {
+    const client = readFileSync(CLIENT_SRC, 'utf8');
+    expect(client).toContain("getHealth: () => apiFetch<HealthResponse>('/health'),");
+    expect(client).not.toContain('capabilities?: { deliverGate?: boolean }');
+    const types = readFileSync(TYPES_SRC, 'utf8');
+    const launchBody = types.slice(types.indexOf('export type LaunchBodyWithDeliver ='));
+    expect(launchBody.slice(0, launchBody.indexOf('\n};\n'))).not.toMatch(/^\s*deliverGate\??:/m);
+  });
+
+  it('the compile-time pins read back as the wire spells them', () => {
+    expect(HEALTH_GATED.capabilities.deliverGate).toBe(true);
+    expect('capabilities' in HEALTH_OLDER).toBe(false);
+    expect(LAUNCH_AUTO.deliverGate).toBe('auto');
+    expect(LAUNCH_HUMAN.deliverGate).toBe('human');
+    expect(STUDIO_BODY.deliverGate).toBe('auto');
+    expect(SESSION_GATED.auto_deliver).toBe(false);
+    expect(SESSION_PREDATES.auto_deliver).toBeUndefined();
+  });
+});

--- a/tests/fixtures/api-types-0.37.0-skills.d.ts
+++ b/tests/fixtures/api-types-0.37.0-skills.d.ts
@@ -1,4 +1,4 @@
-// >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:1969-2419 (crew#535 via crew#536) — the skills block
+// >>> VERBATIM wicked-crew-api-types@0.37.0 index.d.ts:1995-2445 (crew#535 via crew#536) — the skills block
 // ── Skills — the daemon-owned garden plugin root, published as immutable snapshots (api-types 0.28.0) ──
 //
 // api-types 0.29.0 (design amendment v3.6, crew #490): the installer-managed copy
@@ -452,7 +452,7 @@ export interface ReplaceSkillBody {
 }
 // <<< VERBATIM
 
-// >>> VERBATIM wicked-crew-api-types@0.36.0 index.d.ts:4682-4741 (crew#535 via crew#536) — the diagnostics skills block
+// >>> VERBATIM wicked-crew-api-types@0.37.0 index.d.ts:4720-4779 (crew#535 via crew#536) — the diagnostics skills block
 /** The skills seam's state as `GET /diagnostics` reports it (skills keystone, api-types 0.28.0). */
 export type DiagnosticsSkillsState = 'published' | 'fallback' | 'blocked' | 'config-error' | 'disabled';
 

--- a/tests/skillsWire.test.ts
+++ b/tests/skillsWire.test.ts
@@ -1,9 +1,9 @@
 /**
- * The skills wire MIRROR is pinned byte-for-byte to the vendored 0.36.0 contract (the 0.35.0 skills block + the F-083 stale-rules additions).
+ * The skills wire MIRROR is pinned byte-for-byte to the vendored 0.37.0 contract (the 0.36.0 skills block, byte-identical, relabelled).
  *
  * `src/api/skills-wire.ts` carries the skills block and the `diagnostics.skills` block of
- * `wicked-crew-api-types@0.36.0` (crew#535 via crew#536; the 0.34.0/crew#531 block plus F-083) copied VERBATIM between `>>> VERBATIM` / `<<< VERBATIM`
- * markers, and `tests/fixtures/api-types-0.36.0-skills.d.ts` is a byte copy of the same regions
+ * `wicked-crew-api-types@0.37.0` (crew#543; the skills block is 0.36.0/crew#535 — the 0.34.0/crew#531 block plus F-083 — unchanged) copied VERBATIM between `>>> VERBATIM` / `<<< VERBATIM`
+ * markers, and `tests/fixtures/api-types-0.37.0-skills.d.ts` is a byte copy of the same regions
  * taken from the package's `index.d.ts`. This test compares every marked region of the two files:
  * a hand edit to the mirror, or a re-vendored fixture from a re-minted contract, fails here until
  * both agree again — the mirror can never quietly drift from the wire crew serves.
@@ -19,7 +19,7 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 const MIRROR = fileURLToPath(new URL('../src/api/skills-wire.ts', import.meta.url));
-const FIXTURE = fileURLToPath(new URL('./fixtures/api-types-0.36.0-skills.d.ts', import.meta.url));
+const FIXTURE = fileURLToPath(new URL('./fixtures/api-types-0.37.0-skills.d.ts', import.meta.url));
 const INSTALLED = fileURLToPath(new URL('../node_modules/wicked-crew-api-types/index.d.ts', import.meta.url));
 const INSTALLED_PKG = fileURLToPath(new URL('../node_modules/wicked-crew-api-types/package.json', import.meta.url));
 const PINNED_PKG = fileURLToPath(new URL('../package.json', import.meta.url));
@@ -53,10 +53,10 @@ function regions(path: string): Array<{ label: string; body: string }> {
   return out;
 }
 
-describe('src/api/skills-wire.ts — a byte-for-byte mirror of the 0.36.0 skills contract', () => {
+describe('src/api/skills-wire.ts — a byte-for-byte mirror of the 0.37.0 skills contract', () => {
   it('carries the MIRROR header naming the contract, the PR, and the release swap', () => {
     const head = readFileSync(MIRROR, 'utf8').slice(0, 400);
-    expect(head).toContain('MIRROR of wicked-crew-api-types 0.36.0 skills block (crew#531, crew#535) — replace with imports from the');
+    expect(head).toContain('MIRROR of wicked-crew-api-types 0.37.0 skills block (crew#531, crew#535) — replace with imports from the');
     expect(head).toContain('published package at release.');
   });
 
@@ -71,10 +71,10 @@ describe('src/api/skills-wire.ts — a byte-for-byte mirror of the 0.36.0 skills
     }
   });
 
-  it('the two regions are the skills block and the diagnostics.skills block of 0.36.0', () => {
+  it('the two regions are the skills block and the diagnostics.skills block of 0.37.0', () => {
     const labels = regions(FIXTURE).map((r) => r.label);
-    expect(labels[0]).toMatch(/^wicked-crew-api-types@0\.36\.0 index\.d\.ts.* — the skills block$/);
-    expect(labels[1]).toMatch(/^wicked-crew-api-types@0\.36\.0 index\.d\.ts.* — the diagnostics skills block$/);
+    expect(labels[0]).toMatch(/^wicked-crew-api-types@0\.37\.0 index\.d\.ts.* — the skills block$/);
+    expect(labels[1]).toMatch(/^wicked-crew-api-types@0\.37\.0 index\.d\.ts.* — the diagnostics skills block$/);
     const [skills, diagnostics] = regions(FIXTURE).map((r) => r.body);
     // The declarations studio consumes are all in the block — a re-mint that drops one fails here.
     for (const name of [


### PR DESCRIPTION
## Summary

Step 1 of the studio 0.5.9 cut (the #264 two-step pattern): pin `wicked-crew-api-types` **0.37.0** exactly and re-vendor both wire mirrors from the installed `index.d.ts`. No behaviour change — the surfaces already speak this wire since #269; this PR makes the package, not studio, declare it.

**Built against api-types 0.37.0** (crew#543 — the deliver-gate wire, F-E2E-030): `HealthResponse.capabilities.deliverGate`, `LaunchRunBody.deliverGate: 'human' | 'auto'`, `AgentSession.auto_deliver`.

- `package.json` devDependency `0.36.0` → `0.37.0`; `package-lock.json` regenerated (`npm install`: only the pin + the resolved package moved).
- **The #269 provisional "≥ 0.37" shapes are replaced by the real declarations:** `api.getHealth` reads the package's `HealthResponse` (the hand-declared `capabilities?: { deliverGate?: boolean }` is gone); `LaunchBodyWithDeliver` drops its own `deliverGate` — it rides `LaunchRunBody` itself and survives the `Omit<…, 'deliver'>`; the dock test sets `auto_deliver` through the `makeView` factory instead of an `as unknown as` cast. `autoDeliverOf` stays a null-safe reader (an older daemon's DTO has no key) — doc updated.
- **Guard:** new `tests/deliverGateWire.test.ts` — the `wire433.shapes` pattern, two pins one per compiler: literals declared `satisfies HealthResponse` / `LaunchRunBody` / `Pick<AgentSession,'auto_deliver'>` (compile-time), and at run-time the installed `index.d.ts` must declare each shape at its 0.37.0 spelling inside its interface, the pin must be exact and ≥ 0.37.0, and the hand-declared copies must be absent from `client.ts` / `types.ts`. A pin that regresses below the deliver-gate wire or a re-mint that drops a key fails here and says which.
- **Mirrors:** 0.37.0 is ADDITIVE (+38 lines: `HealthResponse` at 140–157, `auto_deliver` at 168–175, `deliverGate` at 3029–3040) and touches neither the skills block nor the wave-6 shapes. All **16 VERBATIM regions** — 2 in `src/api/skills-wire.ts` (+ the fixture, renamed `tests/fixtures/api-types-0.37.0-skills.d.ts`; `index.d.ts:1995-2445` / `4720-4779`) and 14 in `src/api/wave6-wire.ts` — were relocated by exact, unique byte match in the new d.ts and are **byte-identical to 0.36.0**, relabelled by line range only (+26 above the `LaunchRunBody` addition, +38 below it). Headers updated (skills-wire: "carries the 0.36.0 skills block UNCHANGED … re-vendored by label only", the 0.35.0-style note; wave6-wire: names 0.37.0). `tests/skillsWire.test.ts` follows the fixture rename / version strings; `tests/wave6Wire.test.ts` needed no change (its floor is ≥ 0.36.0 and every check is against the installed version).
- CHANGELOG: `### Changed` bullet under `[Unreleased]`.

## Base

Branched from main `6d77153` (#269 squash) with main CI green on that SHA (run 34706887093).

## Local gates (clean clone, `npm install`)

- `npm run typecheck` — pass
- `npm run lint` — pass
- `npm test` — 297 files / 3220 tests pass; one unhandled teardown error from `tests/MemoriesPanel.test.tsx` (a `FacetAutocomplete` blur timer after environment teardown) under a 409 s heavy-load run — untouched by this branch, passes 2/2 in isolation, absent from main's CI log → host-load flake; CI authoritative.
- Wire suites (`skillsWire`, `wave6Wire`, `deliverGateWire`, `wire433.shapes`, `ChatPanel.dock`, `ChatInput.deliver`, `IntakePlan.deliverGate`) — 62/62.
- `npm run build` — pass; dist marker `"0.5.8"` ×1 (the version is untouched here — step 2 cuts 0.5.9).
- `npm run manifest:testids` — no-op.
- Privacy scrub of the diff — 0 hits.

## Next

Step 2 (`release/0.5.9`, the #267 file set) follows once this is on main with CI green; crew 0.7.33 then pins `wicked-studio ^0.5.9` + api-types 0.37.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
