### PR TITLE
chore(release): studio 0.5.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ npm publish dates. Every version listed here exists on
 [npm](https://www.npmjs.com/package/wicked-studio?activeTab=versions).
 
 ## [Unreleased]
+
+## [0.5.9] — 2026-09-13
+_The published bundle is built against `wicked-crew-api-types` **0.37.0** — the exact
+devDependency pin bumped from 0.36.0 in #270 (the deliver-gate wire: `HealthResponse.capabilities.deliverGate`,
+`LaunchRunBody.deliverGate`, `AgentSession.auto_deliver`); this cut lands the Archive control (#268, the
+harness-delivered fix for #219) and the composer's deliver-gate posture (#269, F-E2E-030)._
 ### Fixed
 - **Archive control for terminal runs in the run header and on WorkPage rows (#219, refs #211).**
   Studio could *unarchive* a run (crew#265) but never *archive* one — `archiveRun(id, false)` was the
@@ -29,8 +35,6 @@ npm publish dates. Every version listed here exists on
     header offers no Archive on an already-archived run (`session.archived_at` set — reachable
     through the Archived chip), so there is nothing to re-archive; and the WorkPage tests now cover
     the filtered tab views and the Failed / Cancelled groups, not only Completed.
-
-### Fixed
 - **The composer promised a push with no gate (acceptance finding F-E2E-030).** Under the default
   "First gate" posture the deliver notice read "When this finishes it pushes its branch → opens a
   PR" — and that is exactly what run `0ab5ccb8` did, unattended. The engine now gates the deliver
@@ -1110,7 +1114,8 @@ The merged interactive layer: wicked-interactive's UI moved into this skin (DES-
   `git subtree split` (92 commits).
 - The SPA as a pure HTTP/WS client of the wicked-crew daemon: runs, gates, live CoreEvents.
 
-[Unreleased]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.8...HEAD
+[Unreleased]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.9...HEAD
+[0.5.9]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.8...v0.5.9
 [0.5.8]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.7...v0.5.8
 [0.5.7]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.6...v0.5.7
 [0.5.6]: https://github.com/mikeparcewski/wicked-studio/compare/v0.5.5...v0.5.6

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wicked-studio",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wicked-studio",
-      "version": "0.5.8",
+      "version": "0.5.9",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "^5.56.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-studio",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "The coder-facing skin of the wicked experience plane — a pure HTTP/WS client of the wicked-crew daemon's /api/v1",
   "type": "module",
   "repository": {

--- a/testid-inventory.json
+++ b/testid-inventory.json
@@ -8,7 +8,7 @@
     "Entry kinds: `static` values appear verbatim in the DOM; `dynamic` are template-literal testids with each ${expr} normalised to '*'; `computed` carry the raw JSX expression — dynamic/computed resolve only against a live DOM."
   ],
   "version": 1,
-  "studioVersion": "0.5.8",
+  "studioVersion": "0.5.9",
   "counts": {
     "files": 146,
     "occurrences": 1311,


### PR DESCRIPTION
## Summary

Release cut for **wicked-studio 0.5.9** — the same four-file bump as #267 (0.5.8), one commit, no code changes. Step 2 of the two-step cut; step 1 was the api-types 0.37.0 pin (#270).

- `package.json` → `0.5.9`
- `package-lock.json` root `version` fields (both) → `0.5.9`
- `testid-inventory.json` `studioVersion` → `0.5.9` (`npm run manifest:testids` is a no-op beyond this field)
- `CHANGELOG.md`: `[Unreleased]` cut to `## [0.5.9] — 2026-09-13` keeping every bullet — **#268** Archive control for terminal runs (#219, harness-delivered; the M-1 / L-1 / L-2 review follow-ups), **#269** the composer's deliver-gate posture ("First gate" pauses at the deliver gate, "No gates · auto-deliver" is the only auto posture, the intake plan names the gate from `auto_deliver`, the copy is capability-gated on `GET /health.capabilities.deliverGate`; F-E2E-030), **#270** the `wicked-crew-api-types` 0.37.0 pin + mirror re-vendor — plus a "built against `wicked-crew-api-types` **0.37.0**" note, the `[0.5.9]` compare link-ref, and the `[Unreleased]` compare base retargeted to `v0.5.9`. The two `### Fixed` headings #268 and #269 each opened are folded into one (bullets unchanged).

The `wicked-crew-api-types` devDependency pin is exactly `0.37.0` (from #270).

## Base

Cut from main `92fdef6` (#270 squash) with main CI green on that SHA (run 34708607069).

## Local gates (clean clone, `npm ci`)

- `npm run manifest:testids` — no-op (only `studioVersion` changed)
- `npm run typecheck` — pass
- `npm run lint` — pass
- `npm test` — see the PR comment / CI
- `npm run build` — pass; the bundle carries the `"0.5.9"` marker ×1 (`SettingsRailSection` reads `version` from `package.json` at build time), `dist/testid-inventory.json` says `studioVersion: 0.5.9`, no `0.5.8` remnant.
- Privacy scrub of the diff — 0 hits.

## After merge

Annotated tag `v0.5.9` on the squash commit → `release.yml` (tag/manifest agreement guard → OIDC `npm publish --provenance` → registry probe → GitHub Release from the CHANGELOG section). crew 0.7.33 then pins `wicked-studio ^0.5.9` (bundle marker 0.5.9) + api-types 0.37.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
